### PR TITLE
Support user defined `ParquetAccessPlan` in `ParquetExec`, validation to `ParquetAccessPlan::select` (#10813)

### DIFF
--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -134,6 +134,17 @@ impl PartitionedFile {
         self.range = Some(FileRange { start, end });
         self
     }
+
+    /// Update the user defined extensions for this file.
+    ///
+    /// This can be used to pass reader specific information.
+    pub fn with_extensions(
+        mut self,
+        extensions: Arc<dyn std::any::Any + Send + Sync>,
+    ) -> Self {
+        self.extensions = Some(extensions);
+        self
+    }
 }
 
 impl From<ObjectMeta> for PartitionedFile {

--- a/datafusion/core/tests/parquet/external_access_plan.rs
+++ b/datafusion/core/tests/parquet/external_access_plan.rs
@@ -1,0 +1,418 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Tests for passing user provided [`ParquetAccessPlan`]` to `ParquetExec`]`
+use crate::parquet::utils::MetricsFinder;
+use crate::parquet::{create_data_batch, Scenario};
+use arrow::util::pretty::pretty_format_batches;
+use arrow_schema::SchemaRef;
+use datafusion::common::Result;
+use datafusion::datasource::listing::PartitionedFile;
+use datafusion::datasource::physical_plan::parquet::{ParquetAccessPlan, RowGroupAccess};
+use datafusion::datasource::physical_plan::{FileScanConfig, ParquetExec};
+use datafusion::prelude::SessionContext;
+use datafusion_common::{assert_contains, DFSchema};
+use datafusion_execution::object_store::ObjectStoreUrl;
+use datafusion_expr::{col, lit, Expr};
+use datafusion_physical_plan::metrics::MetricsSet;
+use datafusion_physical_plan::ExecutionPlan;
+use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use std::sync::{Arc, OnceLock};
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn none() {
+    // no user defined plan
+    Test {
+        access_plan: None,
+        expected_rows: 10,
+    }
+    .run_success()
+    .await;
+}
+
+#[tokio::test]
+async fn scan_all() {
+    let parquet_metrics = Test {
+        access_plan: Some(ParquetAccessPlan::new(vec![
+            RowGroupAccess::Scan,
+            RowGroupAccess::Scan,
+        ])),
+        expected_rows: 10,
+    }
+    .run_success()
+    .await;
+
+    // Verify that some bytes were read
+    let bytes_scanned = metric_value(&parquet_metrics, "bytes_scanned").unwrap();
+    assert_ne!(bytes_scanned, 0, "metrics : {parquet_metrics:#?}",);
+}
+
+#[tokio::test]
+async fn skip_all() {
+    let parquet_metrics = Test {
+        access_plan: Some(ParquetAccessPlan::new(vec![
+            RowGroupAccess::Skip,
+            RowGroupAccess::Skip,
+        ])),
+        expected_rows: 0,
+    }
+    .run_success()
+    .await;
+
+    // Verify that skipping all row groups skips reading any data at all
+    let bytes_scanned = metric_value(&parquet_metrics, "bytes_scanned").unwrap();
+    assert_eq!(bytes_scanned, 0, "metrics : {parquet_metrics:#?}",);
+}
+
+#[tokio::test]
+async fn skip_one_row_group() {
+    let plans = vec![
+        ParquetAccessPlan::new(vec![RowGroupAccess::Scan, RowGroupAccess::Skip]),
+        ParquetAccessPlan::new(vec![RowGroupAccess::Skip, RowGroupAccess::Scan]),
+    ];
+
+    for access_plan in plans {
+        Test {
+            access_plan: Some(access_plan),
+            expected_rows: 5,
+        }
+        .run_success()
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn selection_scan() {
+    let plans = vec![
+        ParquetAccessPlan::new(vec![
+            RowGroupAccess::Scan,
+            RowGroupAccess::Selection(select_one_row()),
+        ]),
+        ParquetAccessPlan::new(vec![
+            RowGroupAccess::Selection(select_one_row()),
+            RowGroupAccess::Scan,
+        ]),
+    ];
+
+    for access_plan in plans {
+        Test {
+            access_plan: Some(access_plan),
+            expected_rows: 6,
+        }
+        .run_success()
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn skip_scan() {
+    let plans = vec![
+        // skip one row group, scan the toehr
+        ParquetAccessPlan::new(vec![
+            RowGroupAccess::Skip,
+            RowGroupAccess::Selection(select_one_row()),
+        ]),
+        ParquetAccessPlan::new(vec![
+            RowGroupAccess::Selection(select_one_row()),
+            RowGroupAccess::Skip,
+        ]),
+    ];
+
+    for access_plan in plans {
+        Test {
+            access_plan: Some(access_plan),
+            expected_rows: 1,
+        }
+        .run_success()
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn plan_and_filter() {
+    // show that row group pruning is applied even when an initial plan is supplied
+
+    // No rows match this predicate
+    let predicate = col("utf8").eq(lit("z"));
+
+    // user supplied access plan specifies to still read a row group
+    let access_plan = Some(ParquetAccessPlan::new(vec![
+        // Row group 0 has values a-d
+        RowGroupAccess::Skip,
+        // Row group 1 has values e-i
+        RowGroupAccess::Scan,
+    ]));
+
+    // initia
+    let parquet_metrics = TestFull {
+        access_plan,
+        expected_rows: 0,
+        predicate: Some(predicate),
+    }
+    .run()
+    .await
+    .unwrap();
+
+    // Verify that row group pruning still happens for just that group
+    let row_groups_pruned_statistics =
+        metric_value(&parquet_metrics, "row_groups_pruned_statistics").unwrap();
+    assert_eq!(
+        row_groups_pruned_statistics, 1,
+        "metrics : {parquet_metrics:#?}",
+    );
+}
+
+#[tokio::test]
+async fn two_selections() {
+    let plans = vec![
+        ParquetAccessPlan::new(vec![
+            RowGroupAccess::Selection(select_one_row()),
+            RowGroupAccess::Selection(select_two_rows()),
+        ]),
+        ParquetAccessPlan::new(vec![
+            RowGroupAccess::Selection(select_two_rows()),
+            RowGroupAccess::Selection(select_one_row()),
+        ]),
+    ];
+
+    for access_plan in plans {
+        Test {
+            access_plan: Some(access_plan),
+            expected_rows: 3,
+        }
+        .run_success()
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn bad_row_groups() {
+    let err = TestFull {
+        access_plan: Some(ParquetAccessPlan::new(vec![
+            // file has only 2 row groups, but specify 3
+            RowGroupAccess::Scan,
+            RowGroupAccess::Skip,
+            RowGroupAccess::Scan,
+        ])),
+        expected_rows: 0,
+        predicate: None,
+    }
+    .run()
+    .await
+    .unwrap_err();
+    let err_string = err.to_string();
+    assert_contains!(&err_string, "Invalid ParquetAccessPlan");
+    assert_contains!(&err_string, "Specified 3 row groups, but file has 2");
+}
+
+#[tokio::test]
+async fn bad_selection() {
+    let err = TestFull {
+        access_plan: Some(ParquetAccessPlan::new(vec![
+            // specify fewer rows than are actually in the row group
+            RowGroupAccess::Selection(RowSelection::from(vec![
+                RowSelector::skip(1),
+                RowSelector::select(3),
+            ])),
+            RowGroupAccess::Skip,
+        ])),
+        // expects that we hit an error, this should not be run
+        expected_rows: 10000,
+        predicate: None,
+    }
+    .run()
+    .await
+    .unwrap_err();
+    let err_string = err.to_string();
+    assert_contains!(&err_string, "Internal error: Invalid ParquetAccessPlan Selection. Row group 0 has 5 rows but selection only specifies 4 rows");
+}
+
+/// Return a RowSelection of 1 rows from a row group of 5 rows
+fn select_one_row() -> RowSelection {
+    RowSelection::from(vec![
+        RowSelector::skip(2),
+        RowSelector::select(1),
+        RowSelector::skip(2),
+    ])
+}
+/// Return a RowSelection of 2 rows from a row group of 5 rows
+fn select_two_rows() -> RowSelection {
+    RowSelection::from(vec![
+        RowSelector::skip(1),
+        RowSelector::select(1),
+        RowSelector::skip(1),
+        RowSelector::select(1),
+        RowSelector::skip(1),
+    ])
+}
+
+/// Test for passing user defined ParquetAccessPlans. See [`TestFull`] for details.
+#[derive(Debug)]
+struct Test {
+    access_plan: Option<ParquetAccessPlan>,
+    expected_rows: usize,
+}
+
+impl Test {
+    /// Runs the test case, panic'ing on error.
+    ///
+    /// Returns the `MetricsSet` from the ParqeutExec
+    async fn run_success(self) -> MetricsSet {
+        let Self {
+            access_plan,
+            expected_rows,
+        } = self;
+        TestFull {
+            access_plan,
+            expected_rows,
+            predicate: None,
+        }
+        .run()
+        .await
+        .unwrap()
+    }
+}
+
+/// Test for passing user defined ParquetAccessPlans:
+///
+/// 1. Creates a parquet file with 2 row groups, each with 5 rows
+/// 2. Reads the parquet file with an optional user provided access plan
+/// 3. Verifies that the expected number of rows is read
+/// 4. Returns the statistics from running the plan
+struct TestFull {
+    access_plan: Option<ParquetAccessPlan>,
+    expected_rows: usize,
+    predicate: Option<Expr>,
+}
+
+impl TestFull {
+    async fn run(self) -> Result<MetricsSet> {
+        let ctx = SessionContext::new();
+
+        let Self {
+            access_plan,
+            expected_rows,
+            predicate,
+        } = self;
+
+        let TestData {
+            temp_file: _,
+            schema,
+            file_name,
+            file_size,
+        } = get_test_data();
+
+        let mut partitioned_file = PartitionedFile::new(file_name, *file_size);
+
+        // add the access plan, if any, as an extension
+        if let Some(access_plan) = access_plan {
+            partitioned_file = partitioned_file.with_extensions(Arc::new(access_plan));
+        }
+
+        // Create a ParquetExec to read the file
+        let object_store_url = ObjectStoreUrl::local_filesystem();
+        let config = FileScanConfig::new(object_store_url, schema.clone())
+            .with_file(partitioned_file);
+
+        let mut builder = ParquetExec::builder(config);
+
+        // add the predicate, if requested
+        if let Some(predicate) = predicate {
+            let df_schema = DFSchema::try_from(schema.clone())?;
+            let predicate = ctx.create_physical_expr(predicate, &df_schema)?;
+            builder = builder.with_predicate(predicate);
+        }
+
+        let plan: Arc<dyn ExecutionPlan> = builder.build_arc();
+
+        // run the ParquetExec and collect the results
+        let results =
+            datafusion::physical_plan::collect(Arc::clone(&plan), ctx.task_ctx()).await?;
+
+        // calculate the total number of rows that came out
+        let total_rows = results.iter().map(|b| b.num_rows()).sum::<usize>();
+        assert_eq!(
+            total_rows,
+            expected_rows,
+            "results: \n{}",
+            pretty_format_batches(&results).unwrap()
+        );
+
+        Ok(MetricsFinder::find_metrics(plan.as_ref()).unwrap())
+    }
+}
+
+// Holds necessary data for these tests to reuse the same parquet file
+struct TestData {
+    // field is present as on drop the file is deleted
+    #[allow(dead_code)]
+    temp_file: NamedTempFile,
+    schema: SchemaRef,
+    file_name: String,
+    file_size: u64,
+}
+
+static TEST_DATA: OnceLock<TestData> = OnceLock::new();
+
+/// Return a parquet file with 2 row groups each with 5 rows
+fn get_test_data() -> &'static TestData {
+    TEST_DATA.get_or_init(|| {
+        let scenario = Scenario::UTF8;
+        let row_per_group = 5;
+
+        let mut temp_file = tempfile::Builder::new()
+            .prefix("user_access_plan")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("tempfile creation");
+
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(row_per_group)
+            .build();
+
+        let batches = create_data_batch(scenario);
+        let schema = batches[0].schema();
+
+        let mut writer =
+            ArrowWriter::try_new(&mut temp_file, schema.clone(), Some(props)).unwrap();
+
+        for batch in batches {
+            writer.write(&batch).expect("writing batch");
+        }
+        writer.close().unwrap();
+
+        let file_name = temp_file.path().to_string_lossy().to_string();
+        let file_size = temp_file.path().metadata().unwrap().len();
+
+        TestData {
+            temp_file,
+            schema,
+            file_name,
+            file_size,
+        }
+    })
+}
+
+/// Return the total value of the specified metric name
+fn metric_value(parquet_metrics: &MetricsSet, metric_name: &str) -> Option<usize> {
+    parquet_metrics
+        .sum(|metric| metric.value().name() == metric_name)
+        .map(|v| v.as_usize())
+}

--- a/datafusion/core/tests/parquet/utils.rs
+++ b/datafusion/core/tests/parquet/utils.rs
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Utilities for parquet tests
+
+use datafusion::datasource::physical_plan::ParquetExec;
+use datafusion_physical_plan::metrics::MetricsSet;
+use datafusion_physical_plan::{accept, ExecutionPlan, ExecutionPlanVisitor};
+
+/// Find the metrics from the first ParquetExec encountered in the plan
+#[derive(Debug)]
+pub struct MetricsFinder {
+    metrics: Option<MetricsSet>,
+}
+impl MetricsFinder {
+    pub fn new() -> Self {
+        Self { metrics: None }
+    }
+
+    /// Return the metrics if found
+    pub fn into_metrics(self) -> Option<MetricsSet> {
+        self.metrics
+    }
+
+    pub fn find_metrics(plan: &dyn ExecutionPlan) -> Option<MetricsSet> {
+        let mut finder = Self::new();
+        accept(plan, &mut finder).unwrap();
+        finder.into_metrics()
+    }
+}
+
+impl ExecutionPlanVisitor for MetricsFinder {
+    type Error = std::convert::Infallible;
+    fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
+        if plan.as_any().downcast_ref::<ParquetExec>().is_some() {
+            self.metrics = plan.metrics();
+        }
+        // stop searching once we have found the metrics
+        Ok(self.metrics.is_none())
+    }
+}

--- a/datafusion/core/tests/parquet_exec.rs
+++ b/datafusion/core/tests/parquet_exec.rs
@@ -15,5 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! End to end test for `ParquetExec` and related components
+
 /// Run all tests that are found in the `parquet` directory
 mod parquet;


### PR DESCRIPTION
… to `ParquetAccessPlan::select` (#10813)

* Allow `ParquetAccessPlan` to be passed in to `ParquetExec`, add validation to ParquetAccessPlan::select

* Add test for filtering and user supplied access plan

* fix on windows

* Apply suggestions from code review



---------

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
