### PR TITLE
Unparser rule for datatime cast

### DIFF
--- a/datafusion-examples/examples/plan_to_sql.rs
+++ b/datafusion-examples/examples/plan_to_sql.rs
@@ -19,7 +19,7 @@ use datafusion::error::Result;
 
 use datafusion::prelude::*;
 use datafusion::sql::unparser::expr_to_sql;
-use datafusion_sql::unparser::dialect::CustomDialect;
+use datafusion_sql::unparser::dialect::CustomDialectBuilder;
 use datafusion_sql::unparser::{plan_to_sql, Unparser};
 
 /// This example demonstrates the programmatic construction of SQL strings using
@@ -68,7 +68,9 @@ fn simple_expr_to_sql_demo() -> Result<()> {
 /// using a custom dialect and an explicit unparser
 fn simple_expr_to_sql_demo_escape_mysql_style() -> Result<()> {
     let expr = col("a").lt(lit(5)).or(col("a").eq(lit(8)));
-    let dialect = CustomDialect::new(Some('`'), true, false);
+    let dialect = CustomDialectBuilder::new()
+        .with_identifier_quote_style('`')
+        .build();
     let unparser = Unparser::new(&dialect);
     let sql = unparser.expr_to_sql(&expr)?.to_string();
     assert_eq!(sql, r#"((`a` < 5) OR (`a` = 8))"#);

--- a/datafusion-examples/examples/plan_to_sql.rs
+++ b/datafusion-examples/examples/plan_to_sql.rs
@@ -68,7 +68,7 @@ fn simple_expr_to_sql_demo() -> Result<()> {
 /// using a custom dialect and an explicit unparser
 fn simple_expr_to_sql_demo_escape_mysql_style() -> Result<()> {
     let expr = col("a").lt(lit(5)).or(col("a").eq(lit(8)));
-    let dialect = CustomDialect::new(Some('`'));
+    let dialect = CustomDialect::new(Some('`'), true, false);
     let unparser = Unparser::new(&dialect);
     let sql = unparser.expr_to_sql(&expr)?.to_string();
     assert_eq!(sql, r#"((`a` < 5) OR (`a` = 8))"#);

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -35,6 +35,12 @@ pub trait Dialect {
     fn supports_nulls_first_in_sort(&self) -> bool {
         true
     }
+
+    // Does the dialect use TIMESTAMP to represent Date64 rather than DATETIME?
+    // E.g. Trino, Athena and Dremio does not have DATETIME data type
+    fn use_timestamp_for_date64(&self) -> bool {
+        false
+    }
 }
 pub struct DefaultDialect {}
 
@@ -81,12 +87,20 @@ impl Dialect for SqliteDialect {
 
 pub struct CustomDialect {
     identifier_quote_style: Option<char>,
+    supports_nulls_first_in_sort: bool,
+    use_timestamp_for_date64: bool,
 }
 
 impl CustomDialect {
-    pub fn new(identifier_quote_style: Option<char>) -> Self {
+    pub fn new(
+        identifier_quote_style: Option<char>,
+        supports_nulls_first_in_sort: bool,
+        use_timestamp_for_date64: bool,
+    ) -> Self {
         Self {
             identifier_quote_style,
+            supports_nulls_first_in_sort,
+            use_timestamp_for_date64,
         }
     }
 }
@@ -94,5 +108,13 @@ impl CustomDialect {
 impl Dialect for CustomDialect {
     fn identifier_quote_style(&self, _: &str) -> Option<char> {
         self.identifier_quote_style
+    }
+
+    fn supports_nulls_first_in_sort(&self) -> bool {
+        self.supports_nulls_first_in_sort
+    }
+
+    fn use_timestamp_for_date64(&self) -> bool {
+        self.use_timestamp_for_date64
     }
 }

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -91,16 +91,22 @@ pub struct CustomDialect {
     use_timestamp_for_date64: bool,
 }
 
+impl Default for CustomDialect {
+    fn default() -> Self {
+        Self {
+            identifier_quote_style: None,
+            supports_nulls_first_in_sort: true,
+            use_timestamp_for_date64: false,
+        }
+    }
+}
+
 impl CustomDialect {
-    pub fn new(
-        identifier_quote_style: Option<char>,
-        supports_nulls_first_in_sort: bool,
-        use_timestamp_for_date64: bool,
-    ) -> Self {
+    #[deprecated(note = "please use `CustomDialectBuilder` instead")]
+    pub fn new(identifier_quote_style: Option<char>) -> Self {
         Self {
             identifier_quote_style,
-            supports_nulls_first_in_sort,
-            use_timestamp_for_date64,
+            ..Default::default()
         }
     }
 }
@@ -116,5 +122,51 @@ impl Dialect for CustomDialect {
 
     fn use_timestamp_for_date64(&self) -> bool {
         self.use_timestamp_for_date64
+    }
+}
+
+// create a CustomDialectBuilder
+pub struct CustomDialectBuilder {
+    identifier_quote_style: Option<char>,
+    supports_nulls_first_in_sort: bool,
+    use_timestamp_for_date64: bool,
+}
+
+impl CustomDialectBuilder {
+    pub fn new() -> Self {
+        Self {
+            identifier_quote_style: None,
+            supports_nulls_first_in_sort: true,
+            use_timestamp_for_date64: false,
+        }
+    }
+
+    pub fn build(self) -> CustomDialect {
+        CustomDialect {
+            identifier_quote_style: self.identifier_quote_style,
+            supports_nulls_first_in_sort: self.supports_nulls_first_in_sort,
+            use_timestamp_for_date64: self.use_timestamp_for_date64,
+        }
+    }
+
+    pub fn with_identifier_quote_style(mut self, identifier_quote_style: char) -> Self {
+        self.identifier_quote_style = Some(identifier_quote_style);
+        self
+    }
+
+    pub fn with_supports_nulls_first_in_sort(
+        mut self,
+        supports_nulls_first_in_sort: bool,
+    ) -> Self {
+        self.supports_nulls_first_in_sort = supports_nulls_first_in_sort;
+        self
+    }
+
+    pub fn with_use_timestamp_for_date64(
+        mut self,
+        use_timestamp_for_date64: bool,
+    ) -> Self {
+        self.use_timestamp_for_date64 = use_timestamp_for_date64;
+        self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1070,7 +1070,7 @@ mod tests {
         Signature, Volatility, WindowFrame, WindowFunctionDefinition,
     };
 
-    use crate::unparser::dialect::CustomDialect;
+    use crate::unparser::dialect::{CustomDialect, CustomDialectBuilder};
 
     use super::*;
 
@@ -1505,7 +1505,9 @@ mod tests {
     }
     #[test]
     fn custom_dialect_with_identifier_quote_style() -> Result<()> {
-        let dialect = CustomDialect::new(Some('\''), true, false);
+        let dialect = CustomDialectBuilder::new()
+            .with_identifier_quote_style('\'')
+            .build();
         let unparser = Unparser::new(&dialect);
 
         let expr = col("a").gt(lit(4));
@@ -1521,7 +1523,7 @@ mod tests {
 
     #[test]
     fn custom_dialect_without_identifier_quote_style() -> Result<()> {
-        let dialect = CustomDialect::new(None, true, false);
+        let dialect = CustomDialect::default();
         let unparser = Unparser::new(&dialect);
 
         let expr = col("a").gt(lit(4));
@@ -1540,7 +1542,9 @@ mod tests {
         for (use_timestamp_for_date64, identifier) in
             [(false, "DATETIME"), (true, "TIMESTAMP")]
         {
-            let dialect = CustomDialect::new(None, true, use_timestamp_for_date64);
+            let dialect = CustomDialectBuilder::new()
+                .with_use_timestamp_for_date64(use_timestamp_for_date64)
+                .build();
             let unparser = Unparser::new(&dialect);
 
             let expr = Expr::Cast(Cast {
@@ -1565,7 +1569,9 @@ mod tests {
         ];
 
         for (expr, expected, supports_nulls_first_in_sort) in tests {
-            let dialect = CustomDialect::new(None, supports_nulls_first_in_sort, false);
+            let dialect = CustomDialectBuilder::new()
+                .with_supports_nulls_first_in_sort(supports_nulls_first_in_sort)
+                .build();
             let unparser = Unparser::new(&dialect);
             let ast = unparser.expr_to_unparsed(&expr)?;
 


### PR DESCRIPTION
this allow custom dialect to configure which identifier for unparsing date64: datetime or timestamp