### PR TITLE
dialect with interval style

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -247,6 +247,7 @@ impl CustomDialectBuilder {
 
     pub fn with_interval_style(mut self, interval_style: IntervalStyle) -> Self {
         self.interval_style = interval_style;
+        self
     }
 
     pub fn with_use_double_precision_for_float64(

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -43,7 +43,6 @@ pub trait Dialect {
     }
 
     fn interval_style(&self) -> IntervalStyle {
-        // keep the backward compatible
         IntervalStyle::PostgresVerbose
     }
 }
@@ -56,7 +55,7 @@ pub trait Dialect {
 /// compatible with arrow display format, as well as duckdb
 /// sql standard format is '1-2' for year-month, or '1 10:10:10.123456' for day-time
 /// https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum IntervalStyle {
     PostgresVerbose,
     SQLStandard,
@@ -156,7 +155,7 @@ impl Dialect for CustomDialect {
     }
 
     fn interval_style(&self) -> IntervalStyle {
-        self.interval_style.clone()
+        self.interval_style
     }
 }
 

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use datafusion_common::ScalarValue;
 use regex::Regex;
 use sqlparser::keywords::ALL_KEYWORDS;
 
@@ -41,7 +42,15 @@ pub trait Dialect {
     fn use_timestamp_for_date64(&self) -> bool {
         false
     }
+
+    fn custom_scalar_to_sql(
+        &self,
+        _: &ScalarValue,
+    ) -> Option<datafusion_common::Result<sqlparser::ast::Expr>> {
+        None
+    }
 }
+
 pub struct DefaultDialect {}
 
 impl Dialect for DefaultDialect {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -672,6 +672,10 @@ impl Unparser<'_> {
     /// DataFusion ScalarValues sometimes require a ast::Expr to construct.
     /// For example ScalarValue::Date32(d) corresponds to the ast::Expr CAST('datestr' as DATE)
     fn scalar_to_sql(&self, v: &ScalarValue) -> Result<ast::Expr> {
+        if let Some(value) = self.dialect.custom_scalar_to_sql(v) {
+            return value;
+        }
+
         match v {
             ScalarValue::Null => Ok(ast::Expr::Value(ast::Value::Null)),
             ScalarValue::Boolean(Some(b)) => {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1710,9 +1710,7 @@ mod tests {
                 .build();
             let unparser = Unparser::new(&dialect);
 
-            let ast = unparser
-                .expr_to_sql(&value)
-                .expect("to be unparsed");
+            let ast = unparser.expr_to_sql(&value).expect("to be unparsed");
 
             let actual = format!("{ast}");
 


### PR DESCRIPTION
Add interval style for dialect.

Keep dialect to be simple as a few toggles, and unparsing logic sit within `expr`