### PR TITLE
Add dialect param to use CHAR instead of TEXT for Utf8 unparsing for MySQL

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -41,6 +41,13 @@ pub trait Dialect {
     fn use_timestamp_for_date64(&self) -> bool {
         false
     }
+
+    // Does the dialect use CHAR to cast Utf8 rather than TEXT?
+    // E.g. MySQL requires CHAR instead of TEXT and automatically produces a string with
+    // the VARCHAR, TEXT or LONGTEXT data type based on the length of the string
+    fn use_char_for_utf8_cast(&self) -> bool {
+        false
+    }
 }
 pub struct DefaultDialect {}
 
@@ -75,6 +82,10 @@ impl Dialect for MySqlDialect {
     fn supports_nulls_first_in_sort(&self) -> bool {
         false
     }
+
+    fn use_char_for_utf8_cast(&self) -> bool {
+        true
+    }
 }
 
 pub struct SqliteDialect {}
@@ -89,6 +100,7 @@ pub struct CustomDialect {
     identifier_quote_style: Option<char>,
     supports_nulls_first_in_sort: bool,
     use_timestamp_for_date64: bool,
+    use_char_for_utf8_cast: bool,
 }
 
 impl Default for CustomDialect {
@@ -97,6 +109,7 @@ impl Default for CustomDialect {
             identifier_quote_style: None,
             supports_nulls_first_in_sort: true,
             use_timestamp_for_date64: false,
+            use_char_for_utf8_cast: false,
         }
     }
 }
@@ -123,6 +136,10 @@ impl Dialect for CustomDialect {
     fn use_timestamp_for_date64(&self) -> bool {
         self.use_timestamp_for_date64
     }
+
+    fn use_char_for_utf8_cast(&self) -> bool {
+        self.use_char_for_utf8_cast
+    }
 }
 
 // create a CustomDialectBuilder
@@ -130,6 +147,7 @@ pub struct CustomDialectBuilder {
     identifier_quote_style: Option<char>,
     supports_nulls_first_in_sort: bool,
     use_timestamp_for_date64: bool,
+    use_char_for_utf8_cast: bool,
 }
 
 impl CustomDialectBuilder {
@@ -138,6 +156,7 @@ impl CustomDialectBuilder {
             identifier_quote_style: None,
             supports_nulls_first_in_sort: true,
             use_timestamp_for_date64: false,
+            use_char_for_utf8_cast: false,
         }
     }
 
@@ -146,6 +165,7 @@ impl CustomDialectBuilder {
             identifier_quote_style: self.identifier_quote_style,
             supports_nulls_first_in_sort: self.supports_nulls_first_in_sort,
             use_timestamp_for_date64: self.use_timestamp_for_date64,
+            use_char_for_utf8_cast: self.use_char_for_utf8_cast,
         }
     }
 
@@ -167,6 +187,11 @@ impl CustomDialectBuilder {
         use_timestamp_for_date64: bool,
     ) -> Self {
         self.use_timestamp_for_date64 = use_timestamp_for_date64;
+        self
+    }
+
+    pub fn with_use_char_for_utf8_cast(mut self, use_char_for_utf8_cast: bool) -> Self {
+        self.use_char_for_utf8_cast = use_char_for_utf8_cast;
         self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1000,8 +1000,16 @@ impl Unparser<'_> {
             DataType::BinaryView => {
                 not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
             }
-            DataType::Utf8 => Ok(ast::DataType::Varchar(None)),
-            DataType::LargeUtf8 => Ok(ast::DataType::Text),
+            DataType::Utf8 => Ok(if self.dialect.use_char_for_utf8_cast() {
+                ast::DataType::Char(None)
+            } else {
+                ast::DataType::Varchar(None)
+            }),
+            DataType::LargeUtf8 => Ok(if self.dialect.use_char_for_utf8_cast() {
+                ast::DataType::Char(None)
+            } else {
+                ast::DataType::Text
+            }),
             DataType::Utf8View => {
                 not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
             }
@@ -1580,6 +1588,33 @@ mod tests {
             assert_eq!(actual, expected);
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_use_char_for_utf8_cast() -> Result<()> {
+        for (use_char_for_utf8_cast, data_type, identifier) in [
+            (false, DataType::Utf8, "VARCHAR"),
+            (true, DataType::Utf8, "CHAR"),
+            (false, DataType::LargeUtf8, "TEXT"),
+            (true, DataType::LargeUtf8, "CHAR"),
+        ] {
+            let dialect = CustomDialectBuilder::new()
+                .with_use_char_for_utf8_cast(use_char_for_utf8_cast)
+                .build();
+            let unparser = Unparser::new(&dialect);
+
+            let expr = Expr::Cast(Cast {
+                expr: Box::new(col("a")),
+                data_type,
+            });
+            let ast = unparser.expr_to_sql(&expr)?;
+
+            let actual = format!("{}", ast);
+            let expected = format!(r#"CAST(a AS {identifier})"#);
+
+            assert_eq!(actual, expected);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Fixes https://github.com/spiceai/spiceai/issues/1948

## Rationale for this change

MySQL [cast function](https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#function_cast) does not support `TEXT` and requires `CHAR` (automatically returns VARCHAR, TEXT, LONGTEXT)

> CHAR[(N)] [charset_info]
> Produces a string with the [VARCHAR](https://dev.mysql.com/doc/refman/8.4/en/char.html) data type, unless the expression expr is empty (zero length), in which case the result type is CHAR(0). If the optional length N is given, CHAR(N) causes the cast to use no more than N characters of the argument. No padding occurs for values shorter than N characters. If the optional length N is not given, MySQL calculates the maximum length from the expression. If the supplied or calculated length is greater than an internal threshold, the result type is TEXT. If the length is still too long, the result type is LONGTEXT.

Example query:
```sql
 select * from customer where c_custkey = 'building
```

Before this change (fails in MySQL)

```
SELECT `customer`.`c_custkey`, ... FROM `customer` WHERE (CAST(`customer`.`c_custkey` AS TEXT) = 'building')
```

After this change (works in MySQL)
```
SELECT `customer`.`c_custkey`,  ... FROM `customer` WHERE (CAST(`customer`.`c_custkey` AS CHAR) = 'building')
```
