### PR TITLE
Add dialect param to use CHAR for Utf8 unparsing for MySQL

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -45,6 +45,13 @@ pub trait Dialect {
     fn interval_style(&self) -> IntervalStyle {
         IntervalStyle::PostgresVerbose
     }
+
+    // Does the dialect use CHAR to cast Utf8 rather than TEXT?
+    // E.g. MySQL requires CHAR instead of TEXT and automatically produces a string with
+    // the VARCHAR, TEXT or LONGTEXT data type based on the length of the string
+    fn use_char_for_utf8_cast(&self) -> bool {
+        false
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -103,6 +110,10 @@ impl Dialect for MySqlDialect {
     fn interval_style(&self) -> IntervalStyle {
         IntervalStyle::MySQL
     }
+
+    fn use_char_for_utf8_cast(&self) -> bool {
+        true
+    }
 }
 
 pub struct SqliteDialect {}
@@ -118,6 +129,7 @@ pub struct CustomDialect {
     supports_nulls_first_in_sort: bool,
     use_timestamp_for_date64: bool,
     interval_style: IntervalStyle,
+    use_char_for_utf8_cast: bool,
 }
 
 impl Default for CustomDialect {
@@ -127,6 +139,7 @@ impl Default for CustomDialect {
             supports_nulls_first_in_sort: true,
             use_timestamp_for_date64: false,
             interval_style: IntervalStyle::SQLStandard,
+            use_char_for_utf8_cast: false,
         }
     }
 }
@@ -157,6 +170,10 @@ impl Dialect for CustomDialect {
     fn interval_style(&self) -> IntervalStyle {
         self.interval_style
     }
+
+    fn use_char_for_utf8_cast(&self) -> bool {
+        self.use_char_for_utf8_cast
+    }
 }
 
 // create a CustomDialectBuilder
@@ -165,6 +182,7 @@ pub struct CustomDialectBuilder {
     supports_nulls_first_in_sort: bool,
     use_timestamp_for_date64: bool,
     interval_style: IntervalStyle,
+    use_char_for_utf8_cast: bool,
 }
 
 impl Default for CustomDialectBuilder {
@@ -180,6 +198,7 @@ impl CustomDialectBuilder {
             supports_nulls_first_in_sort: true,
             use_timestamp_for_date64: false,
             interval_style: IntervalStyle::PostgresVerbose,
+            use_char_for_utf8_cast: false,
         }
     }
 
@@ -189,6 +208,7 @@ impl CustomDialectBuilder {
             supports_nulls_first_in_sort: self.supports_nulls_first_in_sort,
             use_timestamp_for_date64: self.use_timestamp_for_date64,
             interval_style: self.interval_style,
+            use_char_for_utf8_cast: self.use_char_for_utf8_cast,
         }
     }
 
@@ -215,6 +235,11 @@ impl CustomDialectBuilder {
 
     pub fn with_interval_style(mut self, interval_style: IntervalStyle) -> Self {
         self.interval_style = interval_style;
+        self
+    }
+
+    pub fn with_use_char_for_utf8_cast(mut self, use_char_for_utf8_cast: bool) -> Self {
+        self.use_char_for_utf8_cast = use_char_for_utf8_cast;
         self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1272,8 +1272,16 @@ impl Unparser<'_> {
             DataType::BinaryView => {
                 not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
             }
-            DataType::Utf8 => Ok(ast::DataType::Varchar(None)),
-            DataType::LargeUtf8 => Ok(ast::DataType::Text),
+            DataType::Utf8 => Ok(if self.dialect.use_char_for_utf8_cast() {
+                ast::DataType::Char(None)
+            } else {
+                ast::DataType::Varchar(None)
+            }),
+            DataType::LargeUtf8 => Ok(if self.dialect.use_char_for_utf8_cast() {
+                ast::DataType::Char(None)
+            } else {
+                ast::DataType::Text
+            }),
             DataType::Utf8View => {
                 not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
             }
@@ -1931,5 +1939,32 @@ mod tests {
 
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn custom_dialect_use_char_for_utf8_cast() -> Result<()> {
+        for (use_char_for_utf8_cast, data_type, identifier) in [
+            (false, DataType::Utf8, "VARCHAR"),
+            (true, DataType::Utf8, "CHAR"),
+            (false, DataType::LargeUtf8, "TEXT"),
+            (true, DataType::LargeUtf8, "CHAR"),
+        ] {
+            let dialect = CustomDialectBuilder::new()
+                .with_use_char_for_utf8_cast(use_char_for_utf8_cast)
+                .build();
+            let unparser = Unparser::new(&dialect);
+
+            let expr = Expr::Cast(Cast {
+                expr: Box::new(col("a")),
+                data_type,
+            });
+            let ast = unparser.expr_to_sql(&expr)?;
+
+            let actual = format!("{}", ast);
+            let expected = format!(r#"CAST(a AS {identifier})"#);
+
+            assert_eq!(actual, expected);
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

PR addresses Utf8 unparser issue producing invalid `CAST(col AS TEXT)` SQL for MySQL.

## Rationale for this change

MySQL [cast function](https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#function_cast) does not support `TEXT` and requires `CHAR` for CAST (automatically returns VARCHAR, TEXT, LONGTEXT)

> CHAR[(N)] [charset_info]
> Produces a string with the [VARCHAR](https://dev.mysql.com/doc/refman/8.4/en/char.html) data type, unless the expression expr is empty (zero length), in which case the result type is CHAR(0). If the optional length N is given, CHAR(N) causes the cast to use no more than N characters of the argument. No padding occurs for values shorter than N characters. If the optional length N is not given, MySQL calculates the maximum length from the expression. If the supplied or calculated length is greater than an internal threshold, the result type is TEXT. If the length is still too long, the result type is LONGTEXT.

Example query:
```sql
 select * from customer where c_custkey = 'building
```

Before this change (fails in MySQL)

```
SELECT `customer`.`c_custkey`, ... FROM `customer` WHERE (CAST(`customer`.`c_custkey` AS TEXT) = 'building')
```

After this change (works in MySQL)
```
SELECT `customer`.`c_custkey`,  ... FROM `customer` WHERE (CAST(`customer`.`c_custkey` AS CHAR) = 'building')
```

## What changes are included in this PR?

PR introduces configurable `use_char_for_utf8_cast` dialect parameter that contolrs wherther CHAR vs TEXT/VARCHAR is using for Utf8 unparsing.

## Are these changes tested?

Yes, added unit tests + manual testing

## Are there any user-facing changes?

`CustomDialogBuilder` now supports `use_char_for_utf8_cast` that can be used to specify whether CHAR vs TEXT/VARCHAR data type should be used for Utf8 unparsing.