### PR TITLE
fix: unparser generates wrong sql for derived table with columns

### DIFF
--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -240,6 +240,36 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             parser_dialect: Box::new(GenericDialect {}),
             unparser_dialect: Box::new(UnparserDefaultDialect {}),
         },
+        // more tests around subquery/derived table roundtrip
+        TestStatementWithDialect {
+            sql: "SELECT string_count FROM (
+                    SELECT
+                        j1_id,
+                        MIN(j2_string)
+                    from
+                        j1 left outer join j2 on
+                                    j1_id = j2_id
+                    group by
+                        j1_id
+                ) as agg (id, string_count)
+
+            ",
+            expected: r#"SELECT agg.string_count FROM (SELECT j1.j1_id, MIN(j2.j2_string) FROM j1 LEFT JOIN j2 ON (j1.j1_id = j2.j2_id) GROUP BY j1.j1_id) AS agg (id, string_count)"#,
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "SELECT id FROM (SELECT j1_id from j1) AS c (id)",
+            expected: r#"SELECT c.id FROM (SELECT j1.j1_id FROM j1) AS c (id)"#,
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "SELECT id FROM (SELECT j1_id as id from j1) AS c",
+            expected: r#"SELECT c.id FROM (SELECT j1.j1_id AS id FROM j1) AS c"#,
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
     ];
 
     for query in tests {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -246,13 +246,12 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
                     SELECT
                         j1_id,
                         MIN(j2_string)
-                    from
-                        j1 left outer join j2 on
+                    FROM
+                        j1 LEFT OUTER JOIN j2 ON
                                     j1_id = j2_id
-                    group by
+                    GROUP BY
                         j1_id
-                ) as agg (id, string_count)
-
+                ) AS agg (id, string_count)
             ",
             expected: r#"SELECT agg.string_count FROM (SELECT j1.j1_id, MIN(j2.j2_string) FROM j1 LEFT JOIN j2 ON (j1.j1_id = j2.j2_id) GROUP BY j1.j1_id) AS agg (id, string_count)"#,
             parser_dialect: Box::new(GenericDialect {}),


### PR DESCRIPTION
### Why this happens:

ast parser will generate a logic plan for derived table with columns
```
roundtrip sql: SELECT c.id FROM (SELECT j1.j1_id FROM j1) AS c (id)
plan Projection: c.id
  SubqueryAlias: c
    Projection: j1.j1_id AS id
      Projection: j1.j1_id
        TableScan: j1
```
However the unparser wasn't able to understand the context of two projections are a result of derived table columns.
In contract, the other type of derived table will generate plan like below which unparser was capable to handle.
```
roundtrip sql: SELECT c.id FROM (SELECT j1.j1_id AS id FROM j1) AS c
plan Projection: c.id
  SubqueryAlias: c
    Projection: j1.j1_id AS id
      TableScan: j1
```

The fix is to have a strict rule to detect if a subquery plan matches the derived table with columns pattern, then unwrap the first layer `alias` projection into table alias with columns which ast has already supported.


### Background
The error was detected from the roundtrip of tpch-13 query

```
select
    c_count,
    count(*) as custdist
from
    (
        select
            c_custkey,
            count(o_orderkey)
        from
            customer left outer join orders on
                        c_custkey = o_custkey
                    and o_comment not like '%special%requests%'
        group by
            c_custkey
    ) as c_orders (c_custkey, c_count)
group by
    c_count
order by
    custdist desc,
    c_count desc;
```

related to the issue in https://github.com/spiceai/datafusion-federation/pull/11