### PR TITLE
Add support for IntervalStyle::MySQL

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1926,6 +1926,11 @@ mod tests {
                 IntervalStyle::MySQL,
                 r#"INTERVAL 0 DAY"#,
             ),
+            (
+                interval_month_day_nano_lit("1296000000 SECOND"),
+                IntervalStyle::MySQL,
+                r#"INTERVAL 15000 DAY"#,
+            ),
         ];
 
         for (value, style, expected) in tests {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -953,7 +953,8 @@ impl Unparser<'_> {
 
     /// MySQL requires INTERVAL sql to be in the format: INTERVAL 1 YEAR + INTERVAL 1 MONTH + INTERVAL 1 DAY etc
     /// https://dev.mysql.com/doc/refman/8.4/en/expressions.html#temporal-intervals
-    /// Interval sequence can't be wrapped in (INTERVAL 1 YEAR + INTERVAL 1 MONTH ...) so we need to generate a single INTERVAL expression
+    /// Interval sequence can't be wrapped in brackets - (INTERVAL 1 YEAR + INTERVAL 1 MONTH ...) so we need to generate
+    /// a single INTERVAL expression so it works correct for interval substraction cases
     /// MySQL supports the DAY_MICROSECOND unit type (format is DAYS HOURS:MINUTES:SECONDS.MICROSECONDS), but it is not supported by sqlparser
     /// so we calculate the best single interval to represent the provided duration
     fn interval_to_mysql_expr(
@@ -1187,7 +1188,7 @@ impl Unparser<'_> {
                     );
                 }
                 ScalarValue::IntervalMonthDayNano(Some(v)) => {
-                    if v.nanoseconds % 1_000 > 0 {
+                    if v.nanoseconds % 1_000 != 0 {
                         return not_impl_err!(
                             "Unsupported IntervalMonthDayNano scalar with nanoseconds precision for IntervalStyle::MySQL"
                         );


### PR DESCRIPTION
## Which issue does this PR close?

PR implements support for `IntervalStyle::MySQL`

This fixes https://github.com/spiceai/spiceai/issues/1950

MySQL Interval specification: https://dev.mysql.com/doc/refman/8.4/en/expressions.html#temporal-intervals

Note: 

~MySQL supports the `DAY_MICROSECOND` unit type (format is `DAYS HOURS:MINUTES:SECONDS.MICROSECONDS`), which can be used to optimize the number of `INTERVAL` elements for complex cases. The decision to use the current version (separate `INTERVALs`) is made to provide cleaner SQL for typical scenarios where only a few `INTERVAL` elements are used (day, hours, etc.).~

The implementation has been updated to generate single INTERVAL expression as generated intervals sequence can't be wrapped in brackets - (INTERVAL 1 YEAR + INTERVAL 1 MONTH ...) so we need single expression so it works correct for interval subtraction cases





