### PR TITLE
Alternate format support for Timestamp casting (DATETIME for MySQL)

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2193,21 +2193,3 @@ mod tests {
         Ok(())
     }
 }
-
-// (
-//     Expr::Cast(Cast {
-//         expr: Box::new(col("a")),
-//         data_type: DataType::Timestamp(
-//             TimeUnit::Nanosecond,
-//             Some("+08:00".into()),
-//         ),
-//     }),
-//     r#"CAST(a AS TIMESTAMP WITH TIME ZONE)"#,
-// ),
-// (
-//     Expr::Cast(Cast {
-//         expr: Box::new(col("a")),
-//         data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
-//     }),
-//     r#"CAST(a AS TIMESTAMP)"#,
-// ),

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1286,13 +1286,8 @@ impl Unparser<'_> {
             } else {
                 ast::DataType::Double
             }),
-            DataType::Timestamp(_, tz) => {
-                let tz_info = match tz {
-                    Some(_) => TimezoneInfo::WithTimeZone,
-                    None => TimezoneInfo::None,
-                };
-
-                Ok(ast::DataType::Timestamp(None, tz_info))
+            DataType::Timestamp(time_unit, tz) => {
+                Ok(self.dialect.timestamp_cast_dtype(time_unit, tz))
             }
             DataType::Date32 => Ok(ast::DataType::Date),
             DataType::Date64 => Ok(self.ast_type_for_date64_in_cast()),
@@ -2158,4 +2153,61 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn custom_dialect_with_teimstamp_cast_dtype() -> Result<()> {
+        let default_dialect = CustomDialectBuilder::new().build();
+        let mysql_dialect = CustomDialectBuilder::new()
+            .with_timestamp_cast_dtype(
+                ast::DataType::Datetime(None),
+                ast::DataType::Datetime(None),
+            )
+            .build();
+
+        let timestamp = DataType::Timestamp(TimeUnit::Nanosecond, None);
+        let timestamp_with_tz =
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("+08:00".into()));
+
+        for (dialect, data_type, identifier) in [
+            (&default_dialect, &timestamp, "TIMESTAMP"),
+            (
+                &default_dialect,
+                &timestamp_with_tz,
+                "TIMESTAMP WITH TIME ZONE",
+            ),
+            (&mysql_dialect, &timestamp, "DATETIME"),
+            (&mysql_dialect, &timestamp_with_tz, "DATETIME"),
+        ] {
+            let unparser = Unparser::new(dialect);
+            let expr = Expr::Cast(Cast {
+                expr: Box::new(col("a")),
+                data_type: data_type.clone(),
+            });
+            let ast = unparser.expr_to_sql(&expr)?;
+
+            let actual = format!("{}", ast);
+            let expected = format!(r#"CAST(a AS {identifier})"#);
+
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
 }
+
+// (
+//     Expr::Cast(Cast {
+//         expr: Box::new(col("a")),
+//         data_type: DataType::Timestamp(
+//             TimeUnit::Nanosecond,
+//             Some("+08:00".into()),
+//         ),
+//     }),
+//     r#"CAST(a AS TIMESTAMP WITH TIME ZONE)"#,
+// ),
+// (
+//     Expr::Cast(Cast {
+//         expr: Box::new(col("a")),
+//         data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
+//     }),
+//     r#"CAST(a AS TIMESTAMP)"#,
+// ),


### PR DESCRIPTION
## Which issue does this PR close?

PR addresses Timestamp unparser issue producing invalid `CAST(col AS Timestamp)` SQL for MySQL.

MySQL [cast function](https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#function_cast) does not support Timestamp for CAST and requires DATETIME
> DATETIME[(M)]
Produces a [DATETIME](https://dev.mysql.com/doc/refman/8.4/en/datetime.html) value. If the optional M value is given, it specifies the fractional seconds precision.

Tested that DATETIME correctly handles timezone information. MySQL uses the local time zone for Timestamps, so the converted value from datetime_utc is correctly shown as the original value -7 (Seattle / GMT-7 local time zone). The same applies to datetime_utc_plus_4, as it is the original value in GMT+4 time zone, so it is converted to the local time zone as the original value -11 (difference between the local time zone and UTC+4).

<img width="656" alt="image" src="https://github.com/user-attachments/assets/f7d87445-a3fb-4c6c-bda8-d335a39981fb">

