### PR TITLE
feat: Add DateFieldExtractStyle::Strftime support for SqliteDialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -124,6 +124,7 @@ pub enum IntervalStyle {
 pub enum DateFieldExtractStyle {
     DatePart,
     Extract,
+    Strftime,
 }
 
 pub struct DefaultDialect {}
@@ -202,6 +203,10 @@ pub struct SqliteDialect {}
 impl Dialect for SqliteDialect {
     fn identifier_quote_style(&self, _: &str) -> Option<char> {
         Some('`')
+    }
+
+    fn date_field_extract_style(&self) -> DateFieldExtractStyle {
+        DateFieldExtractStyle::Strftime
     }
 }
 


### PR DESCRIPTION
Adds new `DateFieldExtractStyle` variant `Strftime`, implementing custom unparsing logic for it and setting it as the style for `SqliteDialect`.