### PR TITLE
Support alternate format for Date32 unparsing (TEXT/SQLite)

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -96,6 +96,12 @@ pub trait Dialect: Send + Sync {
 
         ast::DataType::Timestamp(None, tz_info)
     }
+
+    /// The SQL type to use for Arrow Date32 unparsing
+    /// Most dialects use Date, but some, like SQLite require TEXT
+    fn date32_cast_dtype(&self) -> sqlparser::ast::DataType {
+        sqlparser::ast::DataType::Date
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -208,6 +214,10 @@ impl Dialect for SqliteDialect {
     fn date_field_extract_style(&self) -> DateFieldExtractStyle {
         DateFieldExtractStyle::Strftime
     }
+
+    fn date32_cast_dtype(&self) -> sqlparser::ast::DataType {
+        sqlparser::ast::DataType::Text
+    }
 }
 
 pub struct CustomDialect {
@@ -222,6 +232,7 @@ pub struct CustomDialect {
     int64_cast_dtype: ast::DataType,
     timestamp_cast_dtype: ast::DataType,
     timestamp_tz_cast_dtype: ast::DataType,
+    date32_cast_dtype: sqlparser::ast::DataType,
 }
 
 impl Default for CustomDialect {
@@ -241,6 +252,7 @@ impl Default for CustomDialect {
                 None,
                 TimezoneInfo::WithTimeZone,
             ),
+            date32_cast_dtype: sqlparser::ast::DataType::Date,
         }
     }
 }
@@ -304,6 +316,10 @@ impl Dialect for CustomDialect {
             self.timestamp_cast_dtype.clone()
         }
     }
+
+    fn date32_cast_dtype(&self) -> sqlparser::ast::DataType {
+        self.date32_cast_dtype.clone()
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -332,6 +348,7 @@ pub struct CustomDialectBuilder {
     int64_cast_dtype: ast::DataType,
     timestamp_cast_dtype: ast::DataType,
     timestamp_tz_cast_dtype: ast::DataType,
+    date32_cast_dtype: ast::DataType,
 }
 
 impl Default for CustomDialectBuilder {
@@ -357,6 +374,7 @@ impl CustomDialectBuilder {
                 None,
                 TimezoneInfo::WithTimeZone,
             ),
+            date32_cast_dtype: sqlparser::ast::DataType::Date,
         }
     }
 
@@ -373,6 +391,7 @@ impl CustomDialectBuilder {
             int64_cast_dtype: self.int64_cast_dtype,
             timestamp_cast_dtype: self.timestamp_cast_dtype,
             timestamp_tz_cast_dtype: self.timestamp_tz_cast_dtype,
+            date32_cast_dtype: self.date32_cast_dtype,
         }
     }
 
@@ -453,6 +472,11 @@ impl CustomDialectBuilder {
     ) -> Self {
         self.timestamp_cast_dtype = timestamp_cast_dtype;
         self.timestamp_tz_cast_dtype = timestamp_tz_cast_dtype;
+        self
+    }
+
+    pub fn with_date32_cast_dtype(mut self, date32_cast_dtype: ast::DataType) -> Self {
+        self.date32_cast_dtype = date32_cast_dtype;
         self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1463,7 +1463,7 @@ impl Unparser<'_> {
             DataType::Timestamp(time_unit, tz) => {
                 Ok(self.dialect.timestamp_cast_dtype(time_unit, tz))
             }
-            DataType::Date32 => Ok(ast::DataType::Date),
+            DataType::Date32 => Ok(self.dialect.date32_cast_dtype()),
             DataType::Date64 => Ok(self.ast_type_for_date64_in_cast()),
             DataType::Time32(_) => {
                 not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
@@ -2339,7 +2339,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_dialect_with_teimstamp_cast_dtype() -> Result<()> {
+    fn custom_dialect_with_timestamp_cast_dtype() -> Result<()> {
         let default_dialect = CustomDialectBuilder::new().build();
         let mysql_dialect = CustomDialectBuilder::new()
             .with_timestamp_cast_dtype(
@@ -2366,6 +2366,33 @@ mod tests {
             let expr = Expr::Cast(Cast {
                 expr: Box::new(col("a")),
                 data_type: data_type.clone(),
+            });
+            let ast = unparser.expr_to_sql(&expr)?;
+
+            let actual = format!("{}", ast);
+            let expected = format!(r#"CAST(a AS {identifier})"#);
+
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_date32_ast_dtype() -> Result<()> {
+        let default_dialect = CustomDialectBuilder::default().build();
+        let sqlite_custom_dialect = CustomDialectBuilder::new()
+            .with_date32_cast_dtype(ast::DataType::Text)
+            .build();
+
+        for (dialect, data_type, identifier) in [
+            (&default_dialect, DataType::Date32, "DATE"),
+            (&sqlite_custom_dialect, DataType::Date32, "TEXT"),
+        ] {
+            let unparser = Unparser::new(dialect);
+
+            let expr = Expr::Cast(Cast {
+                expr: Box::new(col("a")),
+                data_type,
             });
             let ast = unparser.expr_to_sql(&expr)?;
 


### PR DESCRIPTION
## Which issue does this PR close?

PR improves unparser to produce valid CAST SQL for SQLite and Date32

## Rationale for this change

SQLite does not have dedicated DATE type and prefers a text string that is an [ISO 8601 date/time](https://www.sqlite.org/lang_datefunc.html) value:

```sql
SELECT CAST('1995-03-15' AS DATE), DATE('1995-03-15'), CAST('1995-03-15' AS TEXT)
```

![image](https://github.com/user-attachments/assets/a4a69235-0bbb-48af-ad5f-1ef238e93813)

Test query (native)
```sql
SELECT count(o_orderdate) FROM orders 
WHERE `orders`.`o_orderdate`< '1995-03-15'

7286 rows
```

Existing  unparser behavior, producing `'1995-03-15' AS DATE` SQL for SQLite
```sql
SELECT count(o_orderdate) FROM orders 
WHERE `orders`.`o_orderdate`< CAST('1995-03-15' AS DATE)

0 rows
```

Fixed unparser behavior, producing valid `'1995-03-15' AS TEXT` SQL for SQLite
```sql
select count(o_orderdate) from orders 
where `orders`.`o_orderdate` < CAST('1995-03-15' AS TEXT)

7286 rows
```


## What changes are included in this PR?

PR introduces configurable `date32_cast_dtype` dialect parameter that controls whether DATE vs TEXT is used for Date32 unparsing.

## Are these changes tested?

Yes, added unit tests + manual testing

## Are there any user-facing changes?

`CustomDialectBuilder` now supports `with_date32_cast_dtype` that can be used to specify desired type that should be used for Date32 unparsing.
