### PR TITLE
Improve SQLite subquery tables aliasing support

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -16,14 +16,14 @@
 // under the License.
 
 use datafusion_common::{
-    internal_err, not_impl_err, plan_err, Column, DataFusionError, Result,
+    internal_err, not_impl_err, plan_err, tree_node::{Transformed, TreeNode}, Column, DataFusionError, Result
 };
 use datafusion_expr::{
     expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, Projection,
 };
 use sqlparser::ast::{self, Ident, SetExpr};
 
-use crate::unparser::{rewrite::find_projection, utils::unproject_agg_exprs};
+use crate::unparser::utils::unproject_agg_exprs;
 
 use super::{
     ast::{
@@ -460,15 +460,65 @@ impl Unparser<'_> {
                 if !columns.is_empty()
                     && !self.dialect.supports_column_alias_in_table_alias()
                 {
-                     // if columns are returned than plan must contain a projection
-                    let Some(inner_p) = find_projection(plan) else {
-                        return plan_err!(
-                            "Inner projection for subquery alias is expected"
-                        );
+                    let plan_rewrite_result = match plan {
+                        LogicalPlan::Projection(inner_p) => Ok(inject_column_aliases(inner_p, columns)),
+                        _ => {
+                            // complex subquery where projection is wrapped by other operator: LIMIT, SORT, DISTINCT, etc
+                            match plan.clone().map_children(|child| {
+                                if let LogicalPlan::Projection(p) = &child {
+                                    // Instead of specifying column aliases as part of the outer table, inject them directly into the inner projection
+                                    Ok(Transformed::yes(inject_column_aliases(p, columns.clone())))
+                                } else {
+                                    Ok(Transformed::no(child))
+                                }
+                            }) {
+                                Ok(plan) => Ok(plan.data),
+                                Err(e) => Err(e),
+                            }
+                        }
                     };
 
-                    // Instead of specifying column aliases as part of the outer table, inject them directly into the inner projection
-                    let rewritten_plan = inject_column_aliases(inner_p, columns);
+                    let rewritten_plan = match plan_rewrite_result {
+                        Ok(p) => p,
+                        Err(e) => return internal_err!("Failed to transform SubqueryAlias plan: {e}")
+                    };
+                        // LogicalPlan::Limit(limit) => {
+                        //     let LogicalPlan::Projection(inner_p) = limit.input.as_ref() else {
+                        //         return plan_err!(
+                        //             "Inner projection for subquery alias is expected"
+                        //         );
+                        //     };
+
+                        //     let mut updated_limit  = limit.clone();
+                        //     updated_limit.input = std::sync::Arc::new(inject_column_aliases(inner_p, columns));
+                        //     LogicalPlan::Limit(updated_limit)
+                        // },
+                        // LogicalPlan::Sort(sort) => {
+                        //     let LogicalPlan::Projection(inner_p) = sort.input.as_ref() else {
+                        //         return plan_err!(
+                        //             "Inner projection for subquery alias is expected"
+                        //         );
+                        //     };
+
+                        //     let mut updated_sort  = sort.clone();
+                        //     updated_sort.input = std::sync::Arc::new(inject_column_aliases(inner_p, columns));
+                        //     LogicalPlan::Sort(updated_sort)
+                        // },
+                        // LogicalPlan::Distinct(distinct) => {
+                        //     let LogicalPlan::Projection(inner_p) = distinct.input().as_ref() else {
+                        //         return plan_err!(
+                        //             "Inner projection for subquery alias is expected"
+                        //         );
+                        //     };
+
+                        //     let mut updated_distinct  = distinct.clone();
+                        //     TODO: distinct is actuall two type as well
+                    
+                        //     updated_distinct
+
+                        // _ => unreachable!(),
+                    //};
+
                     columns = vec![];
 
                     self.select_to_sql_recursively(

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -280,7 +280,6 @@ pub(super) fn inject_column_aliases(
         .into_iter()
         .zip(aliases)
         .map(|(expr, col_alias)| {
-
             let relation = match &expr {
                 Expr::Column(col) => col.relation.clone(),
                 _ => None,

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -263,8 +263,37 @@ pub(super) fn subquery_alias_inner_query_and_columns(
     (outer_projections.input.as_ref(), columns)
 }
 
-/// Injects column aliases into the projection of a logical plan by wrapping `Expr::Column` expressions
-/// with `Expr::Alias` using the provided list of aliases. Non-column expressions are left unchanged.
+/// Injects column aliases into a subquery's logical plan. The function searches for a `Projection`
+/// within the given plan, which may be wrapped by other operators (e.g., LIMIT, SORT).
+/// If the top-level plan is a `Projection`, it directly injects the column aliases.
+/// Otherwise, it iterates through the plan's children to locate and transform the `Projection`.
+///
+/// Example:
+/// - `SELECT col1, col2 FROM table LIMIT 10` plan with aliases `["alias_1", "some_alias_2"]` will be transformed to
+/// - `SELECT col1 AS alias_1, col2 AS some_alias_2 FROM table LIMIT 10`
+pub(super) fn inject_column_aliases_into_subquery(
+    plan: &LogicalPlan,
+    aliases: Vec<Ident>,
+) -> Result<LogicalPlan> {
+    match plan {
+        LogicalPlan::Projection(inner_p) => Ok(inject_column_aliases(inner_p, aliases)),
+        _ => {
+            // projection is wrapped by other operator (LIMIT, SORT, etc), iterate through the plan to find it
+            plan.to_owned()
+                .map_children(|child| {
+                    if let LogicalPlan::Projection(p) = &child {
+                        Ok(Transformed::yes(inject_column_aliases(p, aliases.clone())))
+                    } else {
+                        Ok(Transformed::no(child))
+                    }
+                })
+                .map(|plan| plan.data)
+        }
+    }
+}
+
+/// Injects column aliases into the projection of a logical plan by wrapping expressions
+/// with `Expr::Alias` using the provided list of aliases.
 ///
 /// Example:
 /// - `SELECT col1, col2 FROM table` with aliases `["alias_1", "some_alias_2"]` will be transformed to

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -22,7 +22,7 @@ use std::{
 
 use datafusion_common::{
     tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeIterator},
-    Result, TableReference,
+    Result,
 };
 use datafusion_expr::{expr::Alias, Expr, LogicalPlan, Projection, Sort};
 use sqlparser::ast::Ident;

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -299,7 +299,7 @@ pub(super) fn inject_column_aliases(
     LogicalPlan::Projection(updated_projection)
 }
 
-pub fn find_projection(logical_plan: &LogicalPlan) -> Option<&Projection> {
+fn find_projection(logical_plan: &LogicalPlan) -> Option<&Projection> {
     match logical_plan {
         LogicalPlan::Projection(p) => Some(p),
         LogicalPlan::Limit(p) => find_projection(p.input.as_ref()),

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -413,7 +413,19 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
         },
         TestStatementWithDialect {
             sql: "SELECT temp_j.id2 FROM (SELECT j1_id, j1_string FROM j1) AS temp_j(id2, string2)",
-            expected: r#"SELECT temp_j.id2 FROM (SELECT j1.j1_id AS id2, j1.j1_string AS string2 FROM j1) AS temp_j"#,
+            expected: r#"SELECT `temp_j`.`id2` FROM (SELECT `j1`.`j1_id` AS `id2`, `j1`.`j1_string` AS `string2` FROM `j1`) AS `temp_j`"#,
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(SqliteDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "SELECT * FROM (SELECT j1_id + 1 FROM j1) AS temp_j(id2)",
+            expected: r#"SELECT `temp_j`.`id2` FROM (SELECT (`j1`.`j1_id` + 1) AS `id2` FROM `j1`) AS `temp_j`"#,
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(SqliteDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "SELECT * FROM (SELECT j1_id FROM j1 LIMIT 1) AS temp_j(id2)",
+            expected: r#"SELECT `temp_j`.`id2` FROM (SELECT `j1`.`j1_id` AS `id2` FROM `j1` LIMIT 1) AS `temp_j`"#,
             parser_dialect: Box::new(GenericDialect {}),
             unparser_dialect: Box::new(SqliteDialect {}),
         },


### PR DESCRIPTION
## Which issue does this PR close?

Improves SQLite subquery tables aliasing unparsing to support the following queries

```sql
SELECT * FROM (SELECT o_orderkey + 1 FROM orders) AS c(key) LIMIT 10

SELECT * FROM (SELECT o_orderkey FROM orders LIMIT 10) AS c(key) LIMIT 10

```

## 🤔 Concerns

There is potentially a room for optimizing few unnecessary copies, for example `columns` as we know that there could only be a single projection so `columns` could be fully consumed by `inject_column_aliases`