### PR TITLE
Support dictionary expression in unparser

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -248,7 +248,7 @@ impl Unparser<'_> {
             Expr::Cast(Cast { expr, data_type }) => {
                 let inner_expr = self.expr_to_sql_inner(expr)?;
                 match data_type {
-                    // Dictionary value don't need to be casted to other types when rewritten back to sql
+                    // Dictionary values don't need to be cast to other types when rewritten back to sql
                     DataType::Dictionary(_, _) => Ok(inner_expr),
                     _ => Ok(ast::Expr::Cast {
                         kind: ast::CastKind::Cast,

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1520,7 +1520,7 @@ impl Unparser<'_> {
                 not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
             }
             DataType::Dictionary(_, _) => {
-                unreachable!()
+                not_impl_err!("Unsupported DataType: conversion: {data_type:?}")
             }
             DataType::Decimal128(precision, scale)
             | DataType::Decimal256(precision, scale) => {


### PR DESCRIPTION
## Which issue does this PR close?

Datafusion enforces an eager cast of value to dictionary value in the execution plan where a comparison with dictionary value is presented. However, when using unparser to convert plan back to sql, the cast is not needed, since dictionary raw value can be directly used in SQL engines, casting to other types would cause error in querying

This will enable Postgres support for enum types in Datafusion table provider

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
