### PR TITLE
Keep the float information in scalar_to_sql

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -956,13 +956,25 @@ impl Unparser<'_> {
                 Ok(ast::Expr::Value(ast::Value::Number(f.to_string(), false)))
             }
             ScalarValue::Float16(None) => Ok(ast::Expr::Value(ast::Value::Null)),
-            ScalarValue::Float32(Some(f)) => {
-                Ok(ast::Expr::Value(ast::Value::Number(f.to_string(), false)))
-            }
+            ScalarValue::Float32(Some(f)) => Ok(ast::Expr::Cast {
+                kind: ast::CastKind::Cast,
+                expr: Box::new(ast::Expr::Value(ast::Value::Number(
+                    f.to_string(),
+                    false,
+                ))),
+                data_type: self.arrow_dtype_to_ast_dtype(&DataType::Float32)?,
+                format: None,
+            }),
             ScalarValue::Float32(None) => Ok(ast::Expr::Value(ast::Value::Null)),
-            ScalarValue::Float64(Some(f)) => {
-                Ok(ast::Expr::Value(ast::Value::Number(f.to_string(), false)))
-            }
+            ScalarValue::Float64(Some(f)) => Ok(ast::Expr::Cast {
+                kind: ast::CastKind::Cast,
+                expr: Box::new(ast::Expr::Value(ast::Value::Number(
+                    f.to_string(),
+                    false,
+                ))),
+                data_type: self.arrow_dtype_to_ast_dtype(&DataType::Float64)?,
+                format: None,
+            }),
             ScalarValue::Float64(None) => Ok(ast::Expr::Value(ast::Value::Null)),
             ScalarValue::Decimal128(Some(value), precision, scale) => {
                 Ok(ast::Expr::Value(ast::Value::Number(
@@ -2181,6 +2193,51 @@ mod tests {
 
             let ast = unparser.expr_to_sql(&value).expect("to be unparsed");
 
+            let actual = format!("{ast}");
+
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_float64_scalar_to_expr() {
+        let tests = [
+            (
+                Expr::Literal(ScalarValue::Float64(Some(3f64))),
+                sqlparser::ast::DataType::Double,
+                "CAST(3 AS DOUBLE)",
+            ),
+            (
+                Expr::Literal(ScalarValue::Float64(Some(3f64))),
+                sqlparser::ast::DataType::DoublePrecision,
+                "CAST(3 AS DOUBLE PRECISION)",
+            ),
+        ];
+        for (value, float64_ast_dtype, expected) in tests {
+            let dialect = CustomDialectBuilder::new()
+                .with_float64_ast_dtype(float64_ast_dtype)
+                .build();
+            let unparser = Unparser::new(&dialect);
+
+            let ast = unparser.expr_to_sql(&value).expect("to be unparsed");
+            let actual = format!("{ast}");
+
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_float32_scalar_to_expr() {
+        let tests = [(
+            Expr::Literal(ScalarValue::Float32(Some(3f32))),
+            "CAST(3 AS FLOAT)",
+        )];
+
+        for (value, expected) in tests {
+            let dialect = CustomDialectBuilder::new().build();
+            let unparser = Unparser::new(&dialect);
+
+            let ast = unparser.expr_to_sql(&value).expect("to be unparsed");
             let actual = format!("{ast}");
 
             assert_eq!(actual, expected);


### PR DESCRIPTION
## Which issue does this PR close?

- https://github.com/spiceai/spiceai/issues/2728

## Rationale for this change

The unparser omits the float scalar value information, causing incorrect sql from unparser.

When sending a query like 
```
select * from inventory where inv_warehouse_sk between 3.0/2.0 AND 4.0/2.0
```
to Datafusion, the query plan related to the scalar value is 
```
Filter: CAST(inventory.inv_warehouse_sk AS Float64) BETWEEN Float64(3) / Float64(2) AND Float64(4) / Float64(2)`. 
```
However, the unparser omits the `Float64()` information, causing wrong query from unparser
```SQL
SELECT "inventory"."inv_date_sk", "inventory"."inv_item_sk", "inventory"."inv_warehouse_sk", "inventory"."inv_quantity_on_hand" FROM "inventory" WHERE (CAST("inventory"."inv_warehouse_sk" AS DOUBLE PRECISION) BETWEEN (3 / 2) AND (4 / 2))
```

This will cause incorrect data in some engine, for example, in postgres `3 / 2` is `1` and `3.0/2.0` is `1.5`

## What changes are included in this PR?

* Add an explicit cast for scalar value of type `Float64` and `Float32` to preserve the type information in unparser
* Add tests to cover the changes

## Are these changes tested?

Yes

## Are there any user-facing changes?

User will receive float scalar value that correctly preserves the float information.