### PR TITLE
Support unparsing plans with both Aggregation and Window functions

### DIFF
--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -18,27 +18,19 @@
 use datafusion_common::{
     internal_err,
     tree_node::{Transformed, TreeNode},
-    Result,
+    Column, Result,
 };
 use datafusion_expr::{Aggregate, Expr, LogicalPlan, Window};
 
-/// One of the possible aggregation plans which can be found within a single select query.
-pub(crate) enum AggVariant<'a> {
-    Aggregate(&'a Aggregate),
-    Window(Vec<&'a Window>),
-}
-
-/// Recursively searches children of [LogicalPlan] to find an Aggregate or window node if one exists
+/// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
-/// If an Aggregate or window node is not found prior to this or at all before reaching the end
-/// of the tree, None is returned. It is assumed that a Window and Aggregate node cannot both
-/// be found in a single select query.
-pub(crate) fn find_agg_node_within_select<'a>(
-    plan: &'a LogicalPlan,
-    mut prev_windows: Option<AggVariant<'a>>,
+/// If an Aggregate or node is not found prior to this or at all before reaching the end
+/// of the tree, None is returned.
+pub(crate) fn find_agg_node_within_select(
+    plan: &LogicalPlan,
     already_projected: bool,
-) -> Option<AggVariant<'a>> {
-    // Note that none of the nodes that have a corresponding agg node can have more
+) -> Option<&Aggregate> {
+    // Note that none of the nodes that have a corresponding node can have more
     // than 1 input node. E.g. Projection / Filter always have 1 input node.
     let input = plan.inputs();
     let input = if input.len() > 1 {
@@ -46,30 +38,61 @@ pub(crate) fn find_agg_node_within_select<'a>(
     } else {
         input.first()?
     };
-
     // Agg nodes explicitly return immediately with a single node
+    if let LogicalPlan::Aggregate(agg) = input {
+        Some(agg)
+    } else if let LogicalPlan::TableScan(_) = input {
+        None
+    } else if let LogicalPlan::Projection(_) = input {
+        if already_projected {
+            None
+        } else {
+            find_agg_node_within_select(input, true)
+        }
+    } else {
+        find_agg_node_within_select(input, already_projected)
+    }
+}
+
+/// Recursively searches children of [LogicalPlan] to find Window nodes if exist
+/// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
+/// If Window node is not found prior to this or at all before reaching the end
+/// of the tree, None is returned.
+pub(crate) fn find_window_nodes_within_select<'a>(
+    plan: &'a LogicalPlan,
+    mut prev_windows: Option<Vec<&'a Window>>,
+    already_projected: bool,
+) -> Option<Vec<&'a Window>> {
+    // Note that none of the nodes that have a corresponding node can have more
+    // than 1 input node. E.g. Projection / Filter always have 1 input node.
+    let input = plan.inputs();
+    let input = if input.len() > 1 {
+        return prev_windows;
+    } else {
+        input.first()?
+    };
+
     // Window nodes accumulate in a vec until encountering a TableScan or 2nd projection
     match input {
-        LogicalPlan::Aggregate(agg) => Some(AggVariant::Aggregate(agg)),
         LogicalPlan::Window(window) => {
             prev_windows = match &mut prev_windows {
-                Some(AggVariant::Window(windows)) => {
+                Some(windows) => {
                     windows.push(window);
                     prev_windows
                 }
-                _ => Some(AggVariant::Window(vec![window])),
+                _ => Some(vec![window]),
             };
-            find_agg_node_within_select(input, prev_windows, already_projected)
+            find_window_nodes_within_select(input, prev_windows, already_projected)
         }
         LogicalPlan::Projection(_) => {
             if already_projected {
                 prev_windows
             } else {
-                find_agg_node_within_select(input, prev_windows, true)
+                find_window_nodes_within_select(input, prev_windows, true)
             }
         }
         LogicalPlan::TableScan(_) => prev_windows,
-        _ => find_agg_node_within_select(input, prev_windows, already_projected),
+        _ => find_window_nodes_within_select(input, prev_windows, already_projected),
     }
 }
 
@@ -78,19 +101,30 @@ pub(crate) fn find_agg_node_within_select<'a>(
 ///
 /// For example, if expr contains the column expr "COUNT(*)" it will be transformed
 /// into an actual aggregate expression COUNT(*) as identified in the aggregate node.
-pub(crate) fn unproject_agg_exprs(expr: &Expr, agg: &Aggregate) -> Result<Expr> {
+pub(crate) fn unproject_agg_exprs(
+    expr: &Expr,
+    agg: &Aggregate,
+    windows: Option<&[&Window]>,
+) -> Result<Expr> {
     expr.clone()
         .transform(|sub_expr| {
             if let Expr::Column(c) = sub_expr {
-                // find the column in the agg schema
-                if let Ok(n) = agg.schema.index_of_column(&c) {
-                    let unprojected_expr = agg
-                        .group_expr
-                        .iter()
-                        .chain(agg.aggr_expr.iter())
-                        .nth(n)
-                        .unwrap();
+                if let Some(unprojected_expr) = find_agg_expr(agg, &c) {
                     Ok(Transformed::yes(unprojected_expr.clone()))
+                } else if let Some(mut unprojected_expr) =
+                    windows.and_then(|w| find_window_expr(w, &c.name).cloned())
+                {
+                    if let Expr::WindowFunction(func) = &mut unprojected_expr {
+                        // Window function can contain aggregation column, for ex 'avg(sum(ss_sales_price)) over ..' that needs to be unprojected
+                        for arg in &mut func.args {
+                            if let Expr::Column(c) = arg {
+                                if let Some(expr) = find_agg_expr(agg, c) {
+                                    *arg = expr.clone();
+                                }
+                            }
+                        }
+                    }
+                    Ok(Transformed::yes(unprojected_expr))
                 } else {
                     internal_err!(
                         "Tried to unproject agg expr not found in provided Aggregate!"
@@ -112,11 +146,7 @@ pub(crate) fn unproject_window_exprs(expr: &Expr, windows: &[&Window]) -> Result
     expr.clone()
         .transform(|sub_expr| {
             if let Expr::Column(c) = sub_expr {
-                if let Some(unproj) = windows
-                    .iter()
-                    .flat_map(|w| w.window_expr.iter())
-                    .find(|window_expr| window_expr.schema_name().to_string() == c.name)
-                {
+                if let Some(unproj) = find_window_expr(windows, &c.name) {
                     Ok(Transformed::yes(unproj.clone()))
                 } else {
                     Ok(Transformed::no(Expr::Column(c)))
@@ -126,4 +156,22 @@ pub(crate) fn unproject_window_exprs(expr: &Expr, windows: &[&Window]) -> Result
             }
         })
         .map(|e| e.data)
+}
+
+fn find_agg_expr<'a>(agg: &'a Aggregate, column: &Column) -> Option<&'a Expr> {
+    if let Ok(index) = agg.schema.index_of_column(column) {
+        agg.group_expr.iter().chain(agg.aggr_expr.iter()).nth(index)
+    } else {
+        None
+    }
+}
+
+fn find_window_expr<'a>(
+    windows: &'a [&'a Window],
+    column_name: &'a str,
+) -> Option<&'a Expr> {
+    windows
+        .iter()
+        .flat_map(|w| w.window_expr.iter())
+        .find(|expr| expr.schema_name().to_string() == column_name)
 }


### PR DESCRIPTION
## Which issue does this PR close?

Improve unparsing to support queries containing simultaneously Aggregation and [Window functions](https://www.postgresql.org/docs/current/tutorial-window.html). Existing version fails with error `Tried to unproject agg expr not found in provided Aggregate!`

This makes unparsing to correctly handle TPC-DS Q47, Q53, Q57, Q63, Q89

Query Q47:

```sql
with v1 as(
 select i_category, i_brand,
        s_store_name, s_company_name,
        d_year, d_moy,
        sum(ss_sales_price) sum_sales,
        avg(sum(ss_sales_price)) over
          (partition by i_category, i_brand,
                     s_store_name, s_company_name, d_year)
          avg_monthly_sales,
        rank() over
          (partition by i_category, i_brand,
                     s_store_name, s_company_name
           order by d_year, d_moy) rn
 from item, store_sales, date_dim, store
 where ss_item_sk = i_item_sk and
       ss_sold_date_sk = d_date_sk and
       ss_store_sk = s_store_sk and
       (
         d_year = 2001 or
         ( d_year = 2001-1 and d_moy =12) or
         ( d_year = 2001+1 and d_moy =1)
       )
 group by i_category, i_brand,
          s_store_name, s_company_name,
          d_year, d_moy),
 v2 as(
 select v1.i_category, v1.i_brand, v1.s_store_name, v1.s_company_name
        ,v1.d_year
        ,v1.avg_monthly_sales
        ,v1.sum_sales, v1_lag.sum_sales psum, v1_lead.sum_sales nsum
 from v1, v1 v1_lag, v1 v1_lead
 where v1.i_category = v1_lag.i_category and
       v1.i_category = v1_lead.i_category and
       v1.i_brand = v1_lag.i_brand and
       v1.i_brand = v1_lead.i_brand and
       v1.s_store_name = v1_lag.s_store_name and
       v1.s_store_name = v1_lead.s_store_name and
       v1.s_company_name = v1_lag.s_company_name and
       v1.s_company_name = v1_lead.s_company_name and
       v1.rn = v1_lag.rn + 1 and
       v1.rn = v1_lead.rn - 1)
  select  *
 from v2
 where  d_year = 2001 and    
        avg_monthly_sales > 0 and
        case when avg_monthly_sales > 0 then abs(sum_sales - avg_monthly_sales) / avg_monthly_sales else null end > 0.1
 order by sum_sales - avg_monthly_sales, nsum
  LIMIT 100;

```




