### PR TITLE
Improve unparsing to handle aggregations with grouping set

### DIFF
--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -129,7 +129,7 @@ pub(crate) fn unproject_agg_exprs(
                     Ok(Transformed::yes(unprojected_expr))
                 } else {
                     internal_err!(
-                        "Tried to unproject agg expr not found in provided Aggregate!"
+                        "Tried to unproject agg expr for column '{}' that was not found in the provided Aggregate!", &c.name
                     )
                 }
             } else {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -151,6 +151,7 @@ fn roundtrip_statement() -> Result<()> {
             SUM(id) OVER (PARTITION BY first_name ROWS BETWEEN 5 PRECEDING AND 2 FOLLOWING) AS moving_sum,
             MAX(SUM(id)) OVER (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS max_total
             FROM person GROUP BY id, first_name"#,
+            "SELECT id, first_name, last_name, SUM(id) AS total_sum FROM person GROUP BY ROLLUP(id, first_name, last_name)",
         ];
 
     // For each test sql string, we transform as follows:


### PR DESCRIPTION
## Which issue does this PR close?

PR improves Aggregation unparsing logic to handle plans with grouping sets.  When Aggregation is created (below) `grouping_set_to_exprlist` is used to retrieve grouping set expressions and populate schema (qualified_fields)

https://github.com/apache/datafusion/blob/f54712d8c2545fc0dd60cdc693704992e9d82eef/datafusion/expr/src/logical_plan/plan.rs#L2953C9-L2977C6
```rust
        let group_expr = enumerate_grouping_sets(group_expr)?;

        let is_grouping_set = matches!(group_expr.as_slice(), [Expr::GroupingSet(_)]);

        let grouping_expr: Vec<&Expr> = grouping_set_to_exprlist(group_expr.as_slice())?;

        let mut qualified_fields = exprlist_to_fields(grouping_expr, &input)?;
..
        qualified_fields.extend(exprlist_to_fields(aggr_expr.as_slice(), &input)?);

        let schema = DFSchema::new_with_metadata(
            qualified_fields,
            input.schema().metadata().clone(),
        )?;

        Self::try_new_with_schema(input, group_expr, aggr_expr, Arc::new(schema))
    }
```

PR adds the same step/logic to correctly retrieve all aggregation expressions when unproject columns. W/o this logic current unproject logic fails as `schema` does not match `agg.group_exp + agg.aggr_expr`  (must be `grouping_set_to_exprlist(agg.group_exp) + agg.aggr_expr`) : can't get and then unwrap unprojected expression by index: https://github.com/apache/datafusion/blob/f54712d8c2545fc0dd60cdc693704992e9d82eef/datafusion/sql/src/unparser/utils.rs#L92


## Concern

`grouping_set_to_exprlist` is used directly in `find_agg_exp` so invoked for each column to unproject (in case of grouping set). This could be optimized to do this only once. Decided to keep this logic this way as pre-calculating and passing such expressions as argument or changing `find_agg_exp` signature will make code less clean and `grouping_set_to_exprlist` does NOT create expressions copies (operates by Vec<&Expr>)
