### PR TITLE
Improve unparsing for ORDER BY with Aggregation functions

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -339,13 +339,44 @@ impl Unparser<'_> {
                 if select.already_projected() {
                     return self.derive(plan, relation);
                 }
-                if let Some(query_ref) = query {
-                    query_ref.order_by(self.sorts_to_sql(sort.expr.clone())?);
-                } else {
+                let Some(query_ref) = query else {
                     return internal_err!(
                         "Sort operator only valid in a statement context."
                     );
-                }
+                };
+
+                let sort_exprs: &Vec<SortExpr> =
+                    // In case of aggregation there could be columns containing aggregation functions we need to unproject
+                    match find_agg_node_within_select(plan, select.already_projected()) {
+                        Some(agg) => &sort
+                            .expr
+                            .iter()
+                            .map(|sort_expr| {
+                                let mut sort_expr = sort_expr.clone();
+
+                                // ORDER BY can't have aliases, this indicates that the column was not properly unaprsed, update it
+                                if let Expr::Alias(alias) = &sort_expr.expr {
+                                    sort_expr.expr = *alias.expr.clone();
+                                }
+
+                                // Unproject the sort expression if it is a column from the aggregation
+                                if let Expr::Column(c) = &sort_expr.expr {
+                                    if c.relation.is_none() && agg.schema.is_column_from_schema(&c) {
+                                        sort_expr.expr = unproject_agg_exprs(
+                                            &sort_expr.expr,
+                                            agg,
+                                            None,
+                                        )?;
+                                    }
+                                }
+
+                                Ok::<_, DataFusionError>(sort_expr)
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                        None => &sort.expr,
+                    };
+
+                query_ref.order_by(self.sorts_to_sql(sort_exprs)?);
 
                 self.select_to_sql_recursively(
                     sort.input.as_ref(),
@@ -383,7 +414,7 @@ impl Unparser<'_> {
                             .collect::<Result<Vec<_>>>()?;
                         if let Some(sort_expr) = &on.sort_expr {
                             if let Some(query_ref) = query {
-                                query_ref.order_by(self.sorts_to_sql(sort_expr.clone())?);
+                                query_ref.order_by(self.sorts_to_sql(sort_expr)?);
                             } else {
                                 return internal_err!(
                                     "Sort operator only valid in a statement context."
@@ -644,7 +675,7 @@ impl Unparser<'_> {
         }
     }
 
-    fn sorts_to_sql(&self, sort_exprs: Vec<SortExpr>) -> Result<Vec<ast::OrderByExpr>> {
+    fn sorts_to_sql(&self, sort_exprs: &Vec<SortExpr>) -> Result<Vec<ast::OrderByExpr>> {
         sort_exprs
             .iter()
             .map(|sort_expr| self.sort_to_sql(sort_expr))

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -354,7 +354,7 @@ impl Unparser<'_> {
                             .map(|sort_expr| {
                                 let mut sort_expr = sort_expr.clone();
 
-                                // ORDER BY can't have aliases, this indicates that the column was not properly unaprsed, update it
+                                // ORDER BY can't have aliases, this indicates that the column was not properly unparsed, update it
                                 if let Expr::Alias(alias) = &sort_expr.expr {
                                     sort_expr.expr = *alias.expr.clone();
                                 }


### PR DESCRIPTION
## Which issue does this PR close?

PR improves unparsing to handle cases when `ORDER BY` clause contains  aggregation functions that needs to be unprojected, otherwise it will result in unparsed/incorrect sql  - `Referenced column "sum(catalog_returns.cr_net_loss)" not found in FROM clause` / `Referenced column "count(DISTINCT cs1.cs_order_number)" not found in FROM clause`

For example TPC-DS Q92

>Referenced column "sum(catalog_returns.cr_net_loss)" not found in FROM clause


```sql
select  dt.d_year
 	,item.i_category_id
 	,item.i_category
 	,sum(ss_ext_sales_price)
 from 	date_dim dt
 	,store_sales
 	,item
 where dt.d_date_sk = store_sales.ss_sold_date_sk
 	and store_sales.ss_item_sk = item.i_item_sk
 	and item.i_manager_id = 1
 	and dt.d_moy=11
 	and dt.d_year=1998
 group by 	dt.d_year
 		,item.i_category_id
 		,item.i_category
 order by       sum(ss_ext_sales_price) desc,dt.d_year
 		,item.i_category_id
 		,item.i_category
 LIMIT 100 ;
```

This fixes unparsing for [TPC-DS benchmark queries](https://github.com/apache/datafusion-benchmarks/tree/main/tpcds/queries) 16, 42, 62, 91, 92, 94, 95, 99
