### PR TITLE
Improve UNION unparsing

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -550,6 +550,11 @@ impl Unparser<'_> {
                     );
                 }
 
+                // Covers cases where the UNION is a subquery and the projection is at the top level
+                if select.already_projected() {
+                    return self.derive(plan, relation);
+                }
+
                 let input_exprs: Vec<SetExpr> = union
                     .inputs
                     .iter()

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -139,6 +139,13 @@ fn roundtrip_statement() -> Result<()> {
             SELECT j2_string as string FROM j2
             ORDER BY string DESC
             LIMIT 10"#,
+            r#"SELECT col1, id FROM (
+                SELECT j1_string AS col1, j1_id AS id FROM j1
+                UNION ALL
+                SELECT j2_string AS col1, j2_id AS id FROM j2
+                UNION ALL
+                SELECT j3_string AS col1, j3_id AS id FROM j3
+            ) AS subquery GROUP BY col1, id ORDER BY col1 ASC, id ASC"#,
             "SELECT id, count(*) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
             last_name, sum(id) over (PARTITION BY first_name ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
             first_name from person",


### PR DESCRIPTION
## Which issue does this PR close?

Fix UNION unparsing for queries where where UNION is a subquery.

Original query
```sql
select
	channel,
	col_name
from
	(
	select
		'store' as channel,
		'ss_customer_sk' as col_name
	from
		store_sales
union all
	select
		'web' as channel,
		'ws_ship_hdemo_sk' as col_name
	from
		web_sales
    ) as foo
group by
	channel,
	col_name
order by
	channel,
	col_name
```

Before (invalid):
```sql
select
	'store' as "channel",
	'ss_customer_sk' as "col_name"
from
	"store_sales"
union all
select
	'web' as "channel",
	'ws_ship_hdemo_sk' as "col_name"
from
	"web_sales"
order by
	"foo"."channel" asc nulls last,
	"foo"."col_name" asc nulls last
```

After (correct)
```sql
select
	"foo"."channel",
	"foo"."col_name"
from
	(
	select
		'store' as "channel",
		'ss_customer_sk' as "col_name"
	from
		"store_sales"
union all
	select
		'web' as "channel",
		'ws_ship_hdemo_sk' as "col_name"
	from
		"web_sales") as "foo"
group by
	"foo"."channel",
	"foo"."col_name"
order by
	"foo"."channel" asc nulls last,
	"foo"."col_name" asc nulls last
```
