### PR TITLE
Improve scalar functions in ORDER BY unparsing

### DIFF
--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -18,10 +18,11 @@
 use datafusion_common::{
     internal_err,
     tree_node::{Transformed, TreeNode},
-    Column, Result, ScalarValue,
+    Column, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
-    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Window,
+    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr,
+    Window,
 };
 use sqlparser::ast;
 
@@ -188,6 +189,54 @@ fn find_window_expr<'a>(
         .iter()
         .flat_map(|w| w.window_expr.iter())
         .find(|expr| expr.schema_name().to_string() == column_name)
+}
+
+/// Transforms a Column expression into the actual expression from aggregation or projection if found.
+/// This is required because if an ORDER BY expression is present in an Aggregate or Select, it is replaced
+/// with a Column expression (e.g., "sum(catalog_returns.cr_net_loss)"). We need to transform it back to
+/// the actual expression, such as sum("catalog_returns"."cr_net_loss").
+pub(crate) fn unproject_sort_expr(
+    sort_expr: &SortExpr,
+    agg: Option<&Aggregate>,
+    input: &LogicalPlan,
+) -> Result<SortExpr> {
+    let mut sort_expr = sort_expr.clone();
+
+    // Remove alias if present, because ORDER BY cannot use aliases
+    if let Expr::Alias(alias) = &sort_expr.expr {
+        sort_expr.expr = *alias.expr.clone();
+    }
+
+    let Expr::Column(ref col_ref) = sort_expr.expr else {
+        return Ok::<_, DataFusionError>(sort_expr);
+    };
+
+    if col_ref.relation.is_some() {
+        return Ok::<_, DataFusionError>(sort_expr);
+    };
+
+    // In case of aggregation there could be columns containing aggregation functions we need to unproject
+    if let Some(agg) = agg {
+        if agg.schema.is_column_from_schema(col_ref) {
+            let new_expr = unproject_agg_exprs(&sort_expr.expr, agg, None)?;
+            sort_expr.expr = new_expr;
+            return Ok::<_, DataFusionError>(sort_expr);
+        }
+    }
+
+    // If SELECT and ORDER BY contain the same expression with a scalar function, the ORDER BY expression will
+    // be replaced by a Column expression (e.g., "substr(customer.c_last_name, Int64(0), Int64(5))"), and we need
+    // to transform it back to the actual expression.
+    if let LogicalPlan::Projection(Projection { expr, schema, .. }) = input {
+        if let Ok(idx) = schema.index_of_column(col_ref) {
+            if let Some(Expr::ScalarFunction(scalar_fn)) = expr.get(idx) {
+                sort_expr.expr = Expr::ScalarFunction(scalar_fn.clone());
+            }
+        }
+        return Ok::<_, DataFusionError>(sort_expr);
+    }
+
+    Ok::<_, DataFusionError>(sort_expr)
 }
 
 /// Converts a date_part function to SQL, tailoring it to the supported date field extraction style.


### PR DESCRIPTION
## Which issue does this PR close?

Improves unparsing to correctly handle scalar functions in ORDER BY. If SELECT and ORDER BY contain the same expression with a scalar function, the ORDER BY expression will be replaced by a Column expression (e.g., "substr(customer.c_last_name, Int64(0), Int64(5))"), and we need to transform it back to the actual expression. This is done for scalar function expressions only.


```
  select c_last_name,c_first_name, substr(c_last_name,0,5)
  from customer
  order by substr(c_last_name,0,5)
  limit 10;
```

Before
```sql
select
	"customer"."c_last_name",
	"customer"."c_first_name",
	substr("customer"."c_last_name",0,5)
from
	"customer"
order by
	"substr(customer.c_last_name,Int64(0),Int64(5))" asc nulls last
limit 10
```

After
```sql
select
	"customer"."c_last_name",
	"customer"."c_first_name",
	substr("customer"."c_last_name",0,5)
from
	"customer"
order by
	substr("customer"."c_last_name",0,5) asc nulls last
limit 10

```
Foxes [TPC-DS Benchmark](https://github.com/spiceai/spiceai/tree/trunk/crates/runtime/benches/queries/tpcds) Q85, Q79

Closes https://github.com/spiceai/spiceai/issues/2962

```
ORDER BY `substr(reason.r_reason_desc,Int64(1),Int64(20))`
```