### PR TITLE
Fix unparsing for complex Window functions with Aggregation

### DIFF
--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -21,8 +21,7 @@ use datafusion_common::{
     Column, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
-    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr,
-    Window,
+    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr, Window
 };
 use sqlparser::ast;
 
@@ -117,20 +116,16 @@ pub(crate) fn unproject_agg_exprs(
             if let Expr::Column(c) = sub_expr {
                 if let Some(unprojected_expr) = find_agg_expr(agg, &c)? {
                     Ok(Transformed::yes(unprojected_expr.clone()))
-                } else if let Some(mut unprojected_expr) =
+                } else if let Some(unprojected_expr) =
                     windows.and_then(|w| find_window_expr(w, &c.name).cloned())
-                {
-                    if let Expr::WindowFunction(func) = &mut unprojected_expr {
-                        // Window function can contain an aggregation column, e.g., 'avg(sum(ss_sales_price)) over ...' that needs to be unprojected
-                        for arg in &mut func.args {
-                            if let Expr::Column(c) = arg {
-                                if let Some(expr) = find_agg_expr(agg, c)? {
-                                    *arg = expr.clone();
-                                }
-                            }
-                        }
+                {   
+                    if matches!([&unprojected_expr], [Expr::WindowFunction(_)]) {
+                         // Window function can contain an aggregation columns, e.g., 'avg(sum(ss_sales_price)) over ...' that needs to be unprojected
+                        return Ok(Transformed::yes(unproject_agg_exprs(&unprojected_expr, agg, None)?));
+                    } else {
+                        Ok(Transformed::yes(unprojected_expr))
                     }
-                    Ok(Transformed::yes(unprojected_expr))
+                    
                 } else {
                     internal_err!(
                         "Tried to unproject agg expr for column '{}' that was not found in the provided Aggregate!", &c.name


### PR DESCRIPTION
## Which issue does this PR close?

PR improves Window function unparsing with aggregation when aggregation functions present in  When/Then and Order By parts.

For example `case when grouping(i_class) = 0 then i_category end` and  `order by sum(ws_net_paid) desc` in Window `rank()`:


```sql
select
    sum(ws_net_paid) as total_sum
   ,i_category
   ,i_class
   ,grouping(i_category)+grouping(i_class) as lochierarchy
   ,rank() over (
 	partition by grouping(i_category)+grouping(i_class),
 	case when grouping(i_class) = 0 then i_category end
 	order by sum(ws_net_paid) desc) as rank_within_parent
 from
    web_sales
   ,date_dim       d1
   ,item
 where
    d1.d_month_seq between 1205 and 1205+11
 and d1.d_date_sk = ws_sold_date_sk
 and i_item_sk  = ws_item_sk
 group by rollup(i_category,i_class)
 order by
   lochierarchy desc,
   case when lochierarchy = 0 then i_category end,
   rank_within_parent
  LIMIT 100;
```

Fixes 

- [Bug: TPCDS error Referenced column "grouping(item.i_category)" not found in FROM clause](https://github.com/spiceai/spiceai/issues/2961)
- [Bug: TPCDS error Referenced column "sum(store_sales.ss_net_profit)" not found](https://github.com/spiceai/spiceai/issues/2965)
