### PR TITLE
Don't preserve functional dependency when generating UNION logical plan

### DIFF
--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -2318,6 +2318,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_aggregate_with_union() -> Result<()> {
+        let df = test_table().await?;
+
+        let df1 = df
+            .clone()
+            // GROUP BY `c1`
+            .aggregate(vec![col("c1")], vec![min(col("c2"))])?
+            // SELECT `c1` , min(c2) as `result`
+            .select(vec![col("c1"), min(col("c2")).alias("result")])?;
+        let df2 = df
+            .clone()
+            // GROUP BY `c1`
+            .aggregate(vec![col("c1")], vec![max(col("c3"))])?
+            // SELECT `c1` , max(c3) as `result`
+            .select(vec![col("c1"), max(col("c3")).alias("result")])?;
+
+        let df_union = df1.clone().union(df2.clone())?;
+        let df = df_union
+            // GROUP BY `c1`
+            .aggregate(
+                vec![col("c1")],
+                vec![sum(col("result")).alias("sum_result")],
+            )?
+            // SELECT `c1`, sum(result) as `sum_result`
+            .select(vec![(col("c1")), col("sum_result")])?;
+
+        df1.show().await?;
+        df2.show().await?;
+        df.clone().show().await?;
+
+        let df_results = df.collect().await?;
+
+        #[rustfmt::skip]
+        assert_batches_sorted_eq!(
+            [
+                "+----+------------+",
+                "| c1 | sum_result |",
+                "+----+------------+",
+                "| a  | 84         |",
+                "| b  | 69         |",
+                "| c  | 124        |",
+                "| d  | 126        |",
+                "| e  | 121        |",
+                "+----+------------+"
+            ],
+            &df_results
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_aggregate_subexpr() -> Result<()> {
         let df = test_table().await?;
 

--- a/datafusion/core/src/dataframe/mod.rs
+++ b/datafusion/core/src/dataframe/mod.rs
@@ -2334,7 +2334,7 @@ mod tests {
             // SELECT `c1` , max(c3) as `result`
             .select(vec![col("c1"), max(col("c3")).alias("result")])?;
 
-        let df_union = df1.clone().union(df2.clone())?;
+        let df_union = df1.union(df2)?;
         let df = df_union
             // GROUP BY `c1`
             .aggregate(
@@ -2343,10 +2343,6 @@ mod tests {
             )?
             // SELECT `c1`, sum(result) as `sum_result`
             .select(vec![(col("c1")), col("sum_result")])?;
-
-        df1.show().await?;
-        df2.show().await?;
-        df.clone().show().await?;
 
         let df_results = df.collect().await?;
 

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -50,8 +50,8 @@ use datafusion_common::display::ToStringifiedPlan;
 use datafusion_common::file_options::file_type::FileType;
 use datafusion_common::{
     get_target_functional_dependencies, internal_err, not_impl_err, plan_datafusion_err,
-    plan_err, Column, DFSchema, DFSchemaRef, DataFusionError, Result, ScalarValue,
-    TableReference, ToDFSchema, UnnestOptions,
+    plan_err, Column, DFSchema, DFSchemaRef, DataFusionError, FunctionalDependencies,
+    Result, ScalarValue, TableReference, ToDFSchema, UnnestOptions,
 };
 
 /// Default table name for unnamed table
@@ -1374,7 +1374,12 @@ pub fn validate_unique_names<'a>(
 pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalPlan> {
     // Temporarily use the schema from the left input and later rely on the analyzer to
     // coerce the two schemas into a common one.
-    let schema = Arc::clone(left_plan.schema());
+
+    // Functional Dependencies doesn't preserve after UNION operation
+    let schema = (**left_plan.schema()).clone();
+    let schema =
+        Arc::new(schema.with_functional_dependencies(FunctionalDependencies::empty())?);
+
     Ok(LogicalPlan::Union(Union {
         inputs: vec![Arc::new(left_plan), Arc::new(right_plan)],
         schema,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/spiceai/spiceai/issues/3085

## Rationale for this change

This PR discards the functional dependencies when generating the UNION logical plan, thus helping avoid FDs that no longer exist being used by further operations, e.g. aggregation.

When the datafusion logical planner build the `AGGREGATE` plan, it adds additional columns in the `group_expr` based on the functional dependencies. 

However, for queries that are aggregating upon table obatined through `UNION` operation, the functional dependency is still preserved in the schema of `UNION` plan, while the functional dependency no longer retains after the `UNION`.

Table 1:
```
col1 | col2
-----|-----
a    | 1
b    | 2
```
Table 2:
```
col1 | col2
-----|-----
a    | 2
b    | 4
```

In both Table1 and Table2, the functional dependency `col1 -> col2` holds. However, when `select * from table1 UNION select * from table2`, the functional dependency `col1 -> col2` no longer holds.

This causes trouble in further aggregation based on UNION results, consider the following query:
```SQL
with t1 as (
    select i_manufact_id, count(*) as extra from item
    group by i_manufact_id
),
t2 as (
    select i_manufact_id, count(*) as extra from item
    group by i_manufact_id
)
select i_manufact_id, sum(extra)
 from  (select * from t1
        union all
        select * from t2) tmp1
 group by i_manufact_id
 order by i_manufact_id;
```
Due to the wrongly preserved functional dependency, the query generates wrong logical plan in the final aggregation step
```
Aggregate: groupBy=[[tmp1.i_manufact_id, tmp1.extra]], aggr=[[sum(tmp1. extra)]]       
```

In the test added, the result would contain duplicated groups without changes made in this PR:
![image](https://github.com/user-attachments/assets/440c7418-6e1d-4ca9-ba92-be461e3a803c)

## What changes are included in this PR?

- Changes to eliminate functional dependency when building `UNION` logical plan
- Unit test to verify the changes

## Are these changes tested?

Yes

## Are there any user-facing changes?

The target columns described by FD will no longer be wrongly included in the aggregate `group_by` columns