### PR TITLE
Add basic support for `unnest` unparsing

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -15,12 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::unparser::utils::unproject_agg_exprs;
+use crate::unparser::utils::{
+    find_unnest_node_within_select, unproject_agg_exprs, unproject_unnest_expr,
+};
 use datafusion_common::{
     internal_err, not_impl_err, Column, DataFusionError, Result, TableReference,
 };
 use datafusion_expr::{
-   expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, LogicalPlanBuilder, Projection, SortExpr
+    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
+    LogicalPlanBuilder, Projection, SortExpr,
 };
 use sqlparser::ast::{self, Ident, SetExpr};
 use std::sync::Arc;
@@ -36,7 +39,8 @@ use super::{
         subquery_alias_inner_query_and_columns,
     },
     utils::{
-        find_agg_node_within_select, find_window_nodes_within_select, unproject_sort_expr, unproject_window_exprs
+        find_agg_node_within_select, find_window_nodes_within_select,
+        unproject_sort_expr, unproject_window_exprs,
     },
     Unparser,
 };
@@ -171,15 +175,24 @@ impl Unparser<'_> {
         p: &Projection,
         select: &mut SelectBuilder,
     ) -> Result<()> {
+        let mut exprs = p.expr.clone();
+
+        // If an Unnest node is found within the select, find and unproject the unnest column
+        if let Some(unnest) = find_unnest_node_within_select(plan) {
+            exprs = exprs
+                .into_iter()
+                .map(|e| unproject_unnest_expr(e, unnest))
+                .collect::<Result<Vec<_>>>()?;
+        };
+
         match (
             find_agg_node_within_select(plan, true),
             find_window_nodes_within_select(plan, None, true),
         ) {
             (Some(agg), window) => {
                 let window_option = window.as_deref();
-                let items = p
-                    .expr
-                    .iter()
+                let items = exprs
+                    .into_iter()
                     .map(|proj_expr| {
                         let unproj = unproject_agg_exprs(proj_expr, agg, window_option)?;
                         self.select_item_to_sql(&unproj)
@@ -196,9 +209,8 @@ impl Unparser<'_> {
                 ));
             }
             (None, Some(window)) => {
-                let items = p
-                    .expr
-                    .iter()
+                let items = exprs
+                    .into_iter()
                     .map(|proj_expr| {
                         let unproj = unproject_window_exprs(proj_expr, &window)?;
                         self.select_item_to_sql(&unproj)
@@ -208,8 +220,7 @@ impl Unparser<'_> {
                 select.projection(items);
             }
             _ => {
-                let items = p
-                    .expr
+                let items = exprs
                     .iter()
                     .map(|e| self.select_item_to_sql(e))
                     .collect::<Result<Vec<_>>>()?;
@@ -293,11 +304,10 @@ impl Unparser<'_> {
                 if let Some(agg) =
                     find_agg_node_within_select(plan, select.already_projected())
                 {
-                    let unprojected = unproject_agg_exprs(&filter.predicate, agg, None)?;
+                    let unprojected = unproject_agg_exprs(filter.predicate.clone(), agg, None)?;
                     let filter_expr = self.expr_to_sql(&unprojected)?;
                     select.having(Some(filter_expr));
                 } else {
-
                     let filter_expr = self.expr_to_sql(&filter.predicate)?;
                     select.selection(Some(filter_expr));
                 }
@@ -346,9 +356,13 @@ impl Unparser<'_> {
 
                 let agg = find_agg_node_within_select(plan, select.already_projected());
                 // unproject sort expressions
-                let sort_exprs: Vec<SortExpr> = sort.expr.iter().map(|sort_expr| {
-                    unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
-                }).collect::<Result<Vec<_>>>()?;
+                let sort_exprs: Vec<SortExpr> = sort
+                    .expr
+                    .iter()
+                    .map(|sort_expr| {
+                        unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
+                    })
+                    .collect::<Result<Vec<_>>>()?;
 
                 query_ref.order_by(self.sorts_to_sql(&sort_exprs)?);
 
@@ -565,6 +579,25 @@ impl Unparser<'_> {
                 Ok(())
             }
             LogicalPlan::Extension(_) => not_impl_err!("Unsupported operator: {plan:?}"),
+            LogicalPlan::Unnest(unnest) => {
+
+                if !unnest.struct_type_columns.is_empty() {
+                    return internal_err!("Struct type columns are not currently supported in UNNEST: {:?}", unnest.struct_type_columns);
+                }
+
+                // In the case of UNNEST, the Unnest node is followed by a duplicate Projection node that we need to skip
+                // | Projection: table.col1, UNNEST(table.col2)
+                // |   Unnest: UNNEST(table.col2)
+                // |     Projection: table.col1, table.col2 AS UNNEST(table.col2)
+                // |       Filter: table.col3 = Int64(3)
+                // |         TableScan: table projection=None
+                if let LogicalPlan::Projection(p) = unnest.input.as_ref() {
+                    // continue with projection input
+                    self.select_to_sql_recursively(&p.input, query, select, relation)
+                } else {
+                    return internal_err!("Unnest input is not a Projection: {unnest:?}");
+                }
+            }
             _ => not_impl_err!("Unsupported operator: {plan:?}"),
         }
     }

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -21,7 +21,7 @@ use datafusion_common::{
     Column, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
-    utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr, Window
+    expr, utils::grouping_set_to_exprlist, Aggregate, Expr, LogicalPlan, Projection, SortExpr, Unnest, Window
 };
 use sqlparser::ast;
 
@@ -56,6 +56,30 @@ pub(crate) fn find_agg_node_within_select(
         }
     } else {
         find_agg_node_within_select(input, already_projected)
+    }
+}
+
+/// Recursively searches children of [LogicalPlan] to find Unnest node if exist
+pub(crate) fn find_unnest_node_within_select(
+    plan: &LogicalPlan,
+) -> Option<&Unnest> {
+    // Note that none of the nodes that have a corresponding node can have more
+    // than 1 input node. E.g. Projection / Filter always have 1 input node.
+    let input = plan.inputs();
+    let input = if input.len() > 1 {
+        return None;
+    } else {
+        input.first()?
+    };
+
+    if let LogicalPlan::Unnest(unnest) = input {
+        Some(unnest)
+    } else if let LogicalPlan::TableScan(_) = input {
+        None
+    } else if let LogicalPlan::Projection(_) = input {
+        None
+    } else {
+        find_unnest_node_within_select(input)
     }
 }
 
@@ -101,18 +125,48 @@ pub(crate) fn find_window_nodes_within_select<'a>(
     }
 }
 
+/// Recursively identify Column expressions and transform them into the appropriate unnest expression
+///
+/// For example, if expr contains the column expr "UNNEST(make_array(Int64(1),Int64(2),Int64(2),Int64(5),NULL))" it will be transformed
+/// into an actual unnest expression UNNEST([1, 2, 2, 5, NULL])
+pub(crate) fn unproject_unnest_expr(
+    expr: Expr,
+    unnest: &Unnest,
+) -> Result<Expr> {
+    expr.transform(|sub_expr| {
+            if let Expr::Column(col_ref) = &sub_expr {
+                // Check if the column is among the columns to run unnest on
+                if unnest.exec_columns.iter().find(|e| e.name == col_ref.name).is_some() {
+                    if let LogicalPlan::Projection(Projection { expr, schema, .. }) = unnest.input.as_ref() {
+                        if let Ok(idx) = schema.index_of_column(col_ref) {
+                            if let Some(unprojected_expr) = expr.get(idx) {
+                                let unnest_expr = Expr::Unnest(expr::Unnest::new(unprojected_expr.clone()));
+                                return Ok(Transformed::no(unnest_expr));
+                            }
+                        }
+                    }
+                    return internal_err!(
+                        "Tried to unproject unnest expr for column '{}' that was not found in the provided Unnest!", &col_ref.name
+                    )
+                }
+            }
+
+            Ok(Transformed::no(sub_expr))
+
+        }).map(|e| e.data)
+    }
+
 /// Recursively identify all Column expressions and transform them into the appropriate
 /// aggregate expression contained in agg.
 ///
 /// For example, if expr contains the column expr "COUNT(*)" it will be transformed
 /// into an actual aggregate expression COUNT(*) as identified in the aggregate node.
 pub(crate) fn unproject_agg_exprs(
-    expr: &Expr,
+    expr: Expr,
     agg: &Aggregate,
     windows: Option<&[&Window]>,
 ) -> Result<Expr> {
-    expr.clone()
-        .transform(|sub_expr| {
+    expr.transform(|sub_expr| {
             if let Expr::Column(c) = sub_expr {
                 if let Some(unprojected_expr) = find_agg_expr(agg, &c)? {
                     Ok(Transformed::yes(unprojected_expr.clone()))
@@ -121,7 +175,7 @@ pub(crate) fn unproject_agg_exprs(
                 {   
                     if matches!([&unprojected_expr], [Expr::WindowFunction(_)]) {
                          // Window function can contain an aggregation columns, e.g., 'avg(sum(ss_sales_price)) over ...' that needs to be unprojected
-                        return Ok(Transformed::yes(unproject_agg_exprs(&unprojected_expr, agg, None)?));
+                        return Ok(Transformed::yes(unproject_agg_exprs(unprojected_expr, agg, None)?));
                     } else {
                         Ok(Transformed::yes(unprojected_expr))
                     }
@@ -143,9 +197,8 @@ pub(crate) fn unproject_agg_exprs(
 ///
 /// For example, if expr contains the column expr "COUNT(*) PARTITION BY id" it will be transformed
 /// into an actual window expression as identified in the window node.
-pub(crate) fn unproject_window_exprs(expr: &Expr, windows: &[&Window]) -> Result<Expr> {
-    expr.clone()
-        .transform(|sub_expr| {
+pub(crate) fn unproject_window_exprs(expr: Expr, windows: &[&Window]) -> Result<Expr> {
+    expr.transform(|sub_expr| {
             if let Expr::Column(c) = sub_expr {
                 if let Some(unproj) = find_window_expr(windows, &c.name) {
                     Ok(Transformed::yes(unproj.clone()))
@@ -213,7 +266,7 @@ pub(crate) fn unproject_sort_expr(
     // In case of aggregation there could be columns containing aggregation functions we need to unproject
     if let Some(agg) = agg {
         if agg.schema.is_column_from_schema(col_ref) {
-            let new_expr = unproject_agg_exprs(&sort_expr.expr, agg, None)?;
+            let new_expr = unproject_agg_exprs(sort_expr.expr, agg, None)?;
             sort_expr.expr = new_expr;
             return Ok::<_, DataFusionError>(sort_expr);
         }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -859,3 +859,11 @@ FROM person
 GROUP BY person.id, person.first_name"#.replace("\n", " ").as_str(),
     );
 }
+
+#[test]
+fn test_unnest_to_sql() {
+    sql_round_trip(
+        r#"SELECT unnest(array_col) as u1, struct_col, array_col FROM unnest_table WHERE array_col != NULL ORDER BY struct_col, array_col"#,
+        r#"SELECT UNNEST(unnest_table.array_col) AS u1, unnest_table.struct_col, unnest_table.array_col FROM unnest_table WHERE (unnest_table.array_col <> NULL) ORDER BY unnest_table.struct_col ASC NULLS LAST, unnest_table.array_col ASC NULLS LAST"#,
+    );
+}


### PR DESCRIPTION
## Which issue does this PR close?

Add initial support for `unnest` unparsing:
 - simple queries
 - only array type columns (no structs support)

```sql
select gas, hash, unnest(blob_versioned_hashes) from eth_recent_transactions where transaction_type=3 order by hash desc limit 10;

+---------+--------------------------------------------------------------------+--------------------------------------------------------------------+
| gas     | hash                                                               | UNNEST(eth_recent_transactions.blob_versioned_hashes)              |
+---------+--------------------------------------------------------------------+--------------------------------------------------------------------+
| 21000   | 0xffdc63c8172ea3e53d295ef16d7de00ee08661f2fe5e32719279f05769ca7457 | 0x013981cbd5dfc6d643b9a41d848af454992fd22d5b9ff335e85c4800f52f175c |
| 21000   | 0xffdc63c8172ea3e53d295ef16d7de00ee08661f2fe5e32719279f05769ca7457 | 0x01c532ec397af7b42d9768c06b7125272fdeb9fd38f5035d797d14b078d74ff6 |
| 21000   | 0xffdc63c8172ea3e53d295ef16d7de00ee08661f2fe5e32719279f05769ca7457 | 0x01b230777e3a631b4369d0050c205da03c745d1f767a5b15be2edf632b9f28e3 |
| 21000   | 0xffdc63c8172ea3e53d295ef16d7de00ee08661f2fe5e32719279f05769ca7457 | 0x01698285f315c1858ece2c1f37f2320e35791ef2cf87c3c80ff67a85b733bc3a |
| 21000   | 0xffdc63c8172ea3e53d295ef16d7de00ee08661f2fe5e32719279f05769ca7457 | 0x0126a4c99a9639c5c7ee52062a2c8689ef849df3da0b6a2083cb3c84518d3b1b |
| 3000000 | 0xf499c3028955556d478b2efc71357c5297c32a70a9b8af55dad1c401968cfe10 | 0x013e5cb4fd8220d07c8541e7435bbfb63d42257d3dc3718ed93349864c869efa |
| 21000   | 0xf114c1792b3a1ff2ca7e272e30c9d4ee3f7d31005011e5d69c2a44572e74dc0d | 0x01b16bccb5d6c22097db9c7351fe38d7b2dc53dcc97e33279db27286e6da7571 |
| 21000   | 0xf114c1792b3a1ff2ca7e272e30c9d4ee3f7d31005011e5d69c2a44572e74dc0d | 0x0133a30f664a94f1b9f1ef7a94bd8158890db989206f39912be6e5a30665ee98 |
| 21000   | 0xf114c1792b3a1ff2ca7e272e30c9d4ee3f7d31005011e5d69c2a44572e74dc0d | 0x0144d4173c123d6f4dc802d7878adc9a71bfde9b69d13daed070365a0f760e55 |
| 21000   | 0xf114c1792b3a1ff2ca7e272e30c9d4ee3f7d31005011e5d69c2a44572e74dc0d | 0x01547da4b67d1e5c38921fb2af38c1cb150c6fa63c82a8d9c58a2c3191a7d56c |
+---------+--------------------------------------------------------------------+--------------------------------------------------------------------+
```

```sql
sql> SELECT UNNEST([1, 2, 2, 5, NULL]) as u1, hash from eth_recent_transactions limit 10;
+----+--------------------------------------------------------------------+
| u1 | hash                                                               |
+----+--------------------------------------------------------------------+
| 1  | 0x753363a19cc3ae70987e612796e4f99b13b1e29cbcfab6a126e3304616a0246d |
| 2  | 0x753363a19cc3ae70987e612796e4f99b13b1e29cbcfab6a126e3304616a0246d |
| 2  | 0x753363a19cc3ae70987e612796e4f99b13b1e29cbcfab6a126e3304616a0246d |
| 5  | 0x753363a19cc3ae70987e612796e4f99b13b1e29cbcfab6a126e3304616a0246d |
|    | 0x753363a19cc3ae70987e612796e4f99b13b1e29cbcfab6a126e3304616a0246d |
| 1  | 0x2ba408612018643d5bf9512cb957fc7ff94bc479956118b35fed66bbc85f5e33 |
| 2  | 0x2ba408612018643d5bf9512cb957fc7ff94bc479956118b35fed66bbc85f5e33 |
| 2  | 0x2ba408612018643d5bf9512cb957fc7ff94bc479956118b35fed66bbc85f5e33 |
| 5  | 0x2ba408612018643d5bf9512cb957fc7ff94bc479956118b35fed66bbc85f5e33 |
|    | 0x2ba408612018643d5bf9512cb957fc7ff94bc479956118b35fed66bbc85f5e33 |
+----+--------------------------------------------------------------------+

```
