### PR TITLE
fix: Dialect requires table alias

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -120,6 +120,12 @@ pub trait Dialect: Send + Sync {
         true
     }
 
+    /// Whether the dialect requires a table alias for any subquery in the FROM clause
+    /// This affects behavior when deriving logical plans for Sort, Limit, etc.
+    fn requires_table_alias(&self) -> bool {
+        false
+    }
+
     fn scalar_function_to_sql_overrides(
         &self,
         _unparser: &Unparser,
@@ -295,6 +301,10 @@ impl Dialect for MySqlDialect {
         _tz: &Option<Arc<str>>,
     ) -> ast::DataType {
         ast::DataType::Datetime(None)
+    }
+
+    fn requires_table_alias(&self) -> bool {
+        true
     }
 
     fn scalar_function_to_sql_overrides(

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -369,6 +369,7 @@ pub struct CustomDialect {
     timestamp_tz_cast_dtype: ast::DataType,
     date32_cast_dtype: sqlparser::ast::DataType,
     supports_column_alias_in_table_alias: bool,
+    requires_table_alias: bool,
 }
 
 impl Default for CustomDialect {
@@ -391,6 +392,7 @@ impl Default for CustomDialect {
             ),
             date32_cast_dtype: sqlparser::ast::DataType::Date,
             supports_column_alias_in_table_alias: true,
+            requires_table_alias: false,
         }
     }
 }
@@ -479,6 +481,10 @@ impl Dialect for CustomDialect {
 
         Ok(None)
     }
+
+    fn requires_table_alias(&self) -> bool {
+        self.requires_table_alias
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -510,6 +516,7 @@ pub struct CustomDialectBuilder {
     timestamp_tz_cast_dtype: ast::DataType,
     date32_cast_dtype: ast::DataType,
     supports_column_alias_in_table_alias: bool,
+    requires_table_alias: bool,
 }
 
 impl Default for CustomDialectBuilder {
@@ -538,6 +545,7 @@ impl CustomDialectBuilder {
             ),
             date32_cast_dtype: sqlparser::ast::DataType::Date,
             supports_column_alias_in_table_alias: true,
+            requires_table_alias: false,
         }
     }
 
@@ -558,6 +566,7 @@ impl CustomDialectBuilder {
             date32_cast_dtype: self.date32_cast_dtype,
             supports_column_alias_in_table_alias: self
                 .supports_column_alias_in_table_alias,
+            requires_table_alias: self.requires_table_alias,
         }
     }
 
@@ -658,6 +667,11 @@ impl CustomDialectBuilder {
         supports_column_alias_in_table_alias: bool,
     ) -> Self {
         self.supports_column_alias_in_table_alias = supports_column_alias_in_table_alias;
+        self
+    }
+
+    pub fn with_requires_table_alias(mut self, requires_table_alias: bool) -> Self {
+        self.requires_table_alias = requires_table_alias;
         self
     }
 }

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -122,7 +122,7 @@ pub trait Dialect: Send + Sync {
 
     /// Whether the dialect requires a table alias for any subquery in the FROM clause
     /// This affects behavior when deriving logical plans for Sort, Limit, etc.
-    fn requires_table_alias(&self) -> bool {
+    fn requires_derived_table_alias(&self) -> bool {
         false
     }
 
@@ -303,7 +303,7 @@ impl Dialect for MySqlDialect {
         ast::DataType::Datetime(None)
     }
 
-    fn requires_table_alias(&self) -> bool {
+    fn requires_derived_table_alias(&self) -> bool {
         true
     }
 
@@ -369,7 +369,7 @@ pub struct CustomDialect {
     timestamp_tz_cast_dtype: ast::DataType,
     date32_cast_dtype: sqlparser::ast::DataType,
     supports_column_alias_in_table_alias: bool,
-    requires_table_alias: bool,
+    requires_derived_table_alias: bool,
 }
 
 impl Default for CustomDialect {
@@ -392,7 +392,7 @@ impl Default for CustomDialect {
             ),
             date32_cast_dtype: sqlparser::ast::DataType::Date,
             supports_column_alias_in_table_alias: true,
-            requires_table_alias: false,
+            requires_derived_table_alias: false,
         }
     }
 }
@@ -482,8 +482,8 @@ impl Dialect for CustomDialect {
         Ok(None)
     }
 
-    fn requires_table_alias(&self) -> bool {
-        self.requires_table_alias
+    fn requires_derived_table_alias(&self) -> bool {
+        self.requires_derived_table_alias
     }
 }
 
@@ -516,7 +516,7 @@ pub struct CustomDialectBuilder {
     timestamp_tz_cast_dtype: ast::DataType,
     date32_cast_dtype: ast::DataType,
     supports_column_alias_in_table_alias: bool,
-    requires_table_alias: bool,
+    requires_derived_table_alias: bool,
 }
 
 impl Default for CustomDialectBuilder {
@@ -545,7 +545,7 @@ impl CustomDialectBuilder {
             ),
             date32_cast_dtype: sqlparser::ast::DataType::Date,
             supports_column_alias_in_table_alias: true,
-            requires_table_alias: false,
+            requires_derived_table_alias: false,
         }
     }
 
@@ -566,7 +566,7 @@ impl CustomDialectBuilder {
             date32_cast_dtype: self.date32_cast_dtype,
             supports_column_alias_in_table_alias: self
                 .supports_column_alias_in_table_alias,
-            requires_table_alias: self.requires_table_alias,
+            requires_derived_table_alias: self.requires_derived_table_alias,
         }
     }
 
@@ -670,8 +670,11 @@ impl CustomDialectBuilder {
         self
     }
 
-    pub fn with_requires_table_alias(mut self, requires_table_alias: bool) -> Self {
-        self.requires_table_alias = requires_table_alias;
+    pub fn with_requires_derived_table_alias(
+        mut self,
+        requires_derived_table_alias: bool,
+    ) -> Self {
+        self.requires_derived_table_alias = requires_derived_table_alias;
         self
     }
 }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -20,7 +20,8 @@ use datafusion_common::{
     internal_err, not_impl_err, Column, DataFusionError, Result, TableReference,
 };
 use datafusion_expr::{
-   expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan, LogicalPlanBuilder, Projection, SortExpr
+    expr::Alias, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
+    LogicalPlanBuilder, Projection, SortExpr,
 };
 use sqlparser::ast::{self, Ident, SetExpr};
 use std::sync::Arc;
@@ -36,7 +37,8 @@ use super::{
         subquery_alias_inner_query_and_columns,
     },
     utils::{
-        find_agg_node_within_select, find_window_nodes_within_select, unproject_sort_expr, unproject_window_exprs
+        find_agg_node_within_select, find_window_nodes_within_select,
+        unproject_sort_expr, unproject_window_exprs,
     },
     Unparser,
 };
@@ -219,9 +221,14 @@ impl Unparser<'_> {
         Ok(())
     }
 
-    fn derive(&self, plan: &LogicalPlan, relation: &mut RelationBuilder) -> Result<()> {
+    fn derive(
+        &self,
+        plan: &LogicalPlan,
+        relation: &mut RelationBuilder,
+        alias: Option<ast::TableAlias>,
+    ) -> Result<()> {
         let mut derived_builder = DerivedRelationBuilder::default();
-        derived_builder.lateral(false).alias(None).subquery({
+        derived_builder.lateral(false).alias(alias).subquery({
             let inner_statement = self.plan_to_sql(plan)?;
             if let ast::Statement::Query(inner_query) = inner_statement {
                 inner_query
@@ -234,6 +241,22 @@ impl Unparser<'_> {
         relation.derived(derived_builder);
 
         Ok(())
+    }
+
+    fn derive_with_dialect_alias(
+        &self,
+        alias: &str,
+        plan: &LogicalPlan,
+        relation: &mut RelationBuilder,
+    ) -> Result<()> {
+        match self.dialect.requires_table_alias() {
+            false => self.derive(plan, relation, None),
+            true => self.derive(
+                plan,
+                relation,
+                Some(self.new_table_alias(alias.to_string(), vec![])),
+            ),
+        }
     }
 
     fn select_to_sql_recursively(
@@ -284,7 +307,11 @@ impl Unparser<'_> {
 
                 // Projection can be top-level plan for derived table
                 if select.already_projected() {
-                    return self.derive(plan, relation);
+                    return self.derive_with_dialect_alias(
+                        "derived_projection",
+                        plan,
+                        relation,
+                    );
                 }
                 self.reconstruct_select_statement(plan, p, select)?;
                 self.select_to_sql_recursively(p.input.as_ref(), query, select, relation)
@@ -297,7 +324,6 @@ impl Unparser<'_> {
                     let filter_expr = self.expr_to_sql(&unprojected)?;
                     select.having(Some(filter_expr));
                 } else {
-
                     let filter_expr = self.expr_to_sql(&filter.predicate)?;
                     select.selection(Some(filter_expr));
                 }
@@ -312,8 +338,13 @@ impl Unparser<'_> {
             LogicalPlan::Limit(limit) => {
                 // Limit can be top-level plan for derived table
                 if select.already_projected() {
-                    return self.derive(plan, relation);
+                    return self.derive_with_dialect_alias(
+                        "derived_limit",
+                        plan,
+                        relation,
+                    );
                 }
+
                 if let Some(fetch) = limit.fetch {
                     let Some(query) = query.as_mut() else {
                         return internal_err!(
@@ -336,7 +367,11 @@ impl Unparser<'_> {
             LogicalPlan::Sort(sort) => {
                 // Sort can be top-level plan for derived table
                 if select.already_projected() {
-                    return self.derive(plan, relation);
+                    return self.derive_with_dialect_alias(
+                        "derived_sort",
+                        plan,
+                        relation,
+                    );
                 }
                 let Some(query_ref) = query else {
                     return internal_err!(
@@ -346,9 +381,13 @@ impl Unparser<'_> {
 
                 let agg = find_agg_node_within_select(plan, select.already_projected());
                 // unproject sort expressions
-                let sort_exprs: Vec<SortExpr> = sort.expr.iter().map(|sort_expr| {
-                    unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
-                }).collect::<Result<Vec<_>>>()?;
+                let sort_exprs: Vec<SortExpr> = sort
+                    .expr
+                    .iter()
+                    .map(|sort_expr| {
+                        unproject_sort_expr(sort_expr, agg, sort.input.as_ref())
+                    })
+                    .collect::<Result<Vec<_>>>()?;
 
                 query_ref.order_by(self.sorts_to_sql(&sort_exprs)?);
 
@@ -371,7 +410,11 @@ impl Unparser<'_> {
             LogicalPlan::Distinct(distinct) => {
                 // Distinct can be top-level plan for derived table
                 if select.already_projected() {
-                    return self.derive(plan, relation);
+                    return self.derive_with_dialect_alias(
+                        "derived_distinct",
+                        plan,
+                        relation,
+                    );
                 }
                 let (select_distinct, input) = match distinct {
                     Distinct::All(input) => (ast::Distinct::Distinct, input.as_ref()),
@@ -526,7 +569,11 @@ impl Unparser<'_> {
 
                 // Covers cases where the UNION is a subquery and the projection is at the top level
                 if select.already_projected() {
-                    return self.derive(plan, relation);
+                    return self.derive_with_dialect_alias(
+                        "derived_union",
+                        plan,
+                        relation,
+                    );
                 }
 
                 let input_exprs: Vec<SetExpr> = union

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -249,7 +249,7 @@ impl Unparser<'_> {
         plan: &LogicalPlan,
         relation: &mut RelationBuilder,
     ) -> Result<()> {
-        match self.dialect.requires_table_alias() {
+        match self.dialect.requires_derived_table_alias() {
             false => self.derive(plan, relation, None),
             true => self.derive(
                 plan,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -247,6 +247,24 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
     }
     let tests: Vec<TestStatementWithDialect> = vec![
         TestStatementWithDialect {
+            sql: "select min(ta.j1_id) as j1_min from j1 ta order by min(ta.j1_id) limit 10;",
+            expected:
+                // top projection sort gets derived into a subquery
+                // for MySQL, this subquery needs an alias
+                "SELECT `j1_min` FROM (SELECT min(`ta`.`j1_id`) AS `j1_min`, min(`ta`.`j1_id`) FROM `j1` AS `ta` ORDER BY min(`ta`.`j1_id`) ASC) AS `derived_sort` LIMIT 10",
+            parser_dialect: Box::new(MySqlDialect {}),
+            unparser_dialect: Box::new(UnparserMySqlDialect {}),
+        },
+        TestStatementWithDialect {
+            sql: "select min(ta.j1_id) as j1_min from j1 ta order by min(ta.j1_id) limit 10;",
+            expected:
+                // top projection sort still gets derived into a in default dialect subquery
+                // except for the default dialect, the subquery is left non-aliased
+                "SELECT j1_min FROM (SELECT min(ta.j1_id) AS j1_min, min(ta.j1_id) FROM j1 AS ta ORDER BY min(ta.j1_id) ASC NULLS LAST) LIMIT 10",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        TestStatementWithDialect {
             sql: "select ta.j1_id from j1 ta order by j1_id limit 10;",
             expected:
                 "SELECT `ta`.`j1_id` FROM `j1` AS `ta` ORDER BY `ta`.`j1_id` ASC LIMIT 10",
@@ -644,10 +662,10 @@ fn sql_round_trip(query: &str, expect: &str) {
 
     let context = MockContextProvider {
         state: MockSessionState::default()
-        .with_aggregate_function(sum_udaf())
-        .with_aggregate_function(max_udaf())
-        .with_aggregate_function(grouping_udaf())
-        .with_scalar_function(Arc::new(unicode::substr().as_ref().clone()))
+            .with_aggregate_function(sum_udaf())
+            .with_aggregate_function(max_udaf())
+            .with_aggregate_function(grouping_udaf())
+            .with_scalar_function(Arc::new(unicode::substr().as_ref().clone())),
     };
     let sql_to_rel = SqlToRel::new(&context);
     let plan = sql_to_rel.sql_statement_to_plan(statement).unwrap();

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -258,7 +258,7 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
         TestStatementWithDialect {
             sql: "select min(ta.j1_id) as j1_min from j1 ta order by min(ta.j1_id) limit 10;",
             expected:
-                // top projection sort still gets derived into a in default dialect subquery
+                // top projection sort still gets derived into a subquery in default dialect
                 // except for the default dialect, the subquery is left non-aliased
                 "SELECT j1_min FROM (SELECT min(ta.j1_id) AS j1_min, min(ta.j1_id) FROM j1 AS ta ORDER BY min(ta.j1_id) ASC NULLS LAST) LIMIT 10",
             parser_dialect: Box::new(GenericDialect {}),


### PR DESCRIPTION
Adds a fix to allow a `Dialect` to control whether aliases are required when the logical plan `self.derive`'s. By default, no alias is provided, but some syntax's (MySQL) require an alias for every derived table that appears in `FROM`.

https://dev.mysql.com/doc/refman/8.4/en/derived-tables.html

> The [AS] tbl_name clause is mandatory because every table in a FROM clause must have a name.