### PR TITLE
Fix omitted predicate in parquet reading

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -2092,6 +2092,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_predicate_no_pushdown_parquet() -> Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let path = tmp_dir.path().to_str().unwrap().to_string() + "/test.parquet";
+        write_file(&path);
+        let ctx = SessionContext::new();
+        let opt = ListingOptions::new(Arc::new(ParquetFormat::default()));
+        ctx.register_listing_table("base_table", path, opt, None, None)
+            .await
+            .unwrap();
+        let sql = "
+        with tmp as (
+ select *, 's' flag from base_table)
+ select * from tmp where flag = 'w';
+ ";
+        let batch = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        assert_eq!(batch.len(), 1);
+        let expected = [
+            "+--------+----+------+------+",
+            "| struct | id | name | flag |",
+            "+--------+----+------+------+",
+            "+--------+----+------+------+",
+        ];
+        crate::assert_batches_eq!(expected, &batch);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_struct_filter_parquet_with_view_types() -> Result<()> {
         let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path().to_str().unwrap().to_string() + "/test.parquet";

--- a/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/opener.rs
@@ -31,7 +31,6 @@ use crate::physical_optimizer::pruning::PruningPredicate;
 use arrow_schema::{ArrowError, Schema, SchemaRef};
 use datafusion_common::{exec_err, Result};
 use datafusion_physical_expr::expressions::Column;
-use datafusion_physical_expr::split_conjunction;
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_plan::filter::batch_filter;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;


### PR DESCRIPTION
## Which issue does this PR close?

- https://github.com/spiceai/spiceai/issues/3084

## Rationale for this change

In ParquetExec, when filter_pushdown is not enabled, predicates are simply ignored, causing incorrect results for queries with filters pushed down in TableScan.

For example, for the following query that's supposed to return empty results:
```SQL
with tmp as (
 select ss_quantity, 's' sale_type from store_sales)
 select * from tmp where sale_type = 'w';
```
The `predicate=false` in physical plan simply get ignored in `ParquetExec` implementation, causing wrong results.
```
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                                                                                                                            |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | SubqueryAlias: tmp                                                                                                                                                                                                                                                                                                                                                                              |
|               |   Projection: store_sales.ss_quantity, Utf8("s") AS sale_type                                                                                                                                                                                                                                                                                                                                   |
|               |     BytesProcessedNode                                                                                                                                                                                                                                                                                                                                                                          |
|               |       TableScan: store_sales projection=[ss_quantity], full_filters=[Boolean(false) AS Utf8("s") = Utf8("w")]                                                                                                                                                                                                                                                                                   |
| physical_plan | ProjectionExec: expr=[ss_quantity@0 as ss_quantity, s as sale_type]                                                                                                                                                                                                                                                                                                                             |
|               |   BytesProcessedExec                                                                                                                                                                                                                                                                                                                                                                            |
|               |     ParquetExec: file_groups={10 groups: [[tpcds/store_sales/store_sales.parquet:0..15420768], [tpcds/store_sales/store_sales.parquet:15420768..30841536], [tpcds/store_sales/store_sales.parquet:30841536..46262304], [tpcds/store_sales/store_sales.parquet:46262304..61683072], [tpcds/store_sales/store_sales.parquet:61683072..77103840], ...]}, projection=[ss_quantity], predicate=false |
|               |                                                                                                                                                                                                                                                                                                                                                                                                 |
+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

## What changes are included in this PR?

Changes in this PR will ensure that predicates don't get omitted when filter_pushdown is not enabled, including.
- When filter_pushdown is not enabled, ese predicates to evaluate and filter `RecordBatch` returned from parquet.
- A function to recursively update the column indexes of filter according to the schema of `RecordBatch`. 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No