### PR TITLE
fix: More dangling references

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -51,6 +51,9 @@ impl QueryBuilder {
     pub fn take_body(&mut self) -> Option<Box<ast::SetExpr>> {
         self.body.take()
     }
+    pub fn get_order_by(&self) -> Vec<ast::OrderByExpr> {
+        self.order_by.clone()
+    }
     pub fn order_by(&mut self, value: Vec<ast::OrderByExpr>) -> &mut Self {
         self.order_by = value;
         self
@@ -216,6 +219,9 @@ impl SelectBuilder {
     pub fn sort_by(&mut self, value: Vec<ast::Expr>) -> &mut Self {
         self.sort_by = value;
         self
+    }
+    pub fn get_sort_by(&self) -> Vec<ast::Expr> {
+        self.sort_by.clone()
     }
     pub fn having(&mut self, value: Option<ast::Expr>) -> &mut Self {
         self.having = value;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -27,7 +27,7 @@ use datafusion_expr::{
     expr::Alias, BinaryExpr, Distinct, Expr, JoinConstraint, JoinType, LogicalPlan,
     LogicalPlanBuilder, Operator, Projection, SortExpr, TableScan,
 };
-use sqlparser::ast::{self, display_separated, Ident, SetExpr};
+use sqlparser::ast::{self, Ident, SetExpr};
 use std::{sync::Arc, vec};
 
 use super::{
@@ -37,7 +37,7 @@ use super::{
     },
     rewrite::{
         inject_column_aliases_into_subquery, normalize_union_schema,
-        rewrite_plan_for_sort_on_non_projected_fields,
+        remove_dangling_identifiers, rewrite_plan_for_sort_on_non_projected_fields,
         subquery_alias_inner_query_and_columns, TableAliasRewriter,
     },
     utils::{
@@ -198,30 +198,30 @@ impl Unparser<'_> {
             .iter_mut()
             .for_each(|select_item| match select_item {
                 ast::SelectItem::UnnamedExpr(ast::Expr::CompoundIdentifier(idents)) => {
-                    if idents.len() > 1 {
-                        let ident_source = display_separated(
-                            &idents
-                                .clone()
-                                .into_iter()
-                                .take(idents.len() - 1)
-                                .collect::<Vec<Ident>>(),
-                            ".",
-                        )
-                        .to_string();
-                        // If the identifier is not present in the list of all identifiers, it refers to a table that does not exist
-                        if !all_idents.contains(&ident_source) {
-                            let Some(last) = idents.last() else {
-                                unreachable!(
-                                    "CompoundIdentifier must have a last element"
-                                );
-                            };
-                            // Reset the identifiers to only the last element, which is the column name
-                            *idents = vec![last.clone()];
-                        }
-                    }
+                    remove_dangling_identifiers(idents, &all_idents);
                 }
                 _ => {}
             });
+
+        // Check the order by as well
+        if let Some(query) = query.as_mut() {
+            let mut order_by = query.get_order_by();
+            order_by.iter_mut().for_each(|sort_item| {
+                if let ast::Expr::CompoundIdentifier(idents) = &mut sort_item.expr {
+                    remove_dangling_identifiers(idents, &all_idents);
+                }
+            });
+
+            query.order_by(order_by);
+        }
+
+        // Order by could be a sort in the select builder
+        let mut sort = select_builder.get_sort_by();
+        sort.iter_mut().for_each(|sort_item| {
+            if let ast::Expr::CompoundIdentifier(idents) = sort_item {
+                remove_dangling_identifiers(idents, &all_idents);
+            }
+        });
 
         select_builder.projection(projection);
 
@@ -300,7 +300,7 @@ impl Unparser<'_> {
     ) -> Result<()> {
         let mut derived_builder = DerivedRelationBuilder::default();
         derived_builder.lateral(false).alias(alias).subquery({
-            let inner_statement = self.plan_to_sql(plan)?;
+            let inner_statement = self.plan_to_sql(&plan)?;
             if let ast::Statement::Query(inner_query) = inner_statement {
                 inner_query
             } else {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -318,6 +318,28 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             unparser_dialect: Box::new(UnparserDefaultDialect {}),
         },
         TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) order by j1_id",
+            expected:
+                "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) ORDER BY j1_id ASC NULLS LAST",
+            parser_dialect: Box::new(GenericDialect {}),
+            unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        },
+        // TODO: remove dangling identifiers from group by, filter, etc
+        // TestStatementWithDialect {
+        //     sql: "select j1_id from (select ta.j1_id from j1 ta) where j1_id = 1",
+        //     expected:
+        //         "SELECT j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) WHERE (ta.j1_id = 1)",
+        //     parser_dialect: Box::new(GenericDialect {}),
+        //     unparser_dialect: Box::new(UnparserDefaultDialect {}),
+        // },
+        TestStatementWithDialect {
+            sql: "select j1_id from (select ta.j1_id from j1 ta) order by j1_id",
+            expected:
+                "SELECT `j1_id` FROM (SELECT `ta`.`j1_id` FROM `j1` AS `ta`) AS `derived_projection` ORDER BY `j1_id` ASC",
+            parser_dialect: Box::new(MySqlDialect {}),
+            unparser_dialect: Box::new(UnparserMySqlDialect {}),
+        },
+        TestStatementWithDialect {
             sql: "select j1_id from (select ta.j1_id from j1 ta) AS tbl1",
             expected:
                 "SELECT tbl1.j1_id FROM (SELECT ta.j1_id FROM j1 AS ta) AS tbl1",


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the DataFusion SQL unparser. The key changes include the addition of new methods to retrieve `order_by` and `sort_by` expressions, the introduction of a utility function to remove dangling identifiers, and updates to the test cases to cover these new functionalities.

### Enhancements to expression retrieval:

* Added `get_order_by` method in `QueryBuilder` to retrieve a cloned list of `order_by` expressions. (`datafusion/sql/src/unparser/ast.rs`)
* Added `get_sort_by` method in `SelectBuilder` to retrieve a cloned list of `sort_by` expressions. (`datafusion/sql/src/unparser/ast.rs`)

### Utility function for identifier management:

* Introduced `remove_dangling_identifiers` function to clean up identifiers that do not correspond to any available tables. (`datafusion/sql/src/unparser/rewrite.rs`)

### Plan unparser updates:

* Modified the `Unparser` implementation to utilize the new `remove_dangling_identifiers` function for `order_by` and `sort_by` expressions. (`datafusion/sql/src/unparser/plan.rs`)

### Test case updates:

* Added new test cases to verify the correct handling of `order_by` expressions and ensure the removal of dangling identifiers. (`datafusion/sql/tests/cases/plan_to_sql.rs`)