### PR TITLE
Support unparsing plans after applying `optimize_projections` rule

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -612,7 +612,8 @@ config_namespace! {
         /// Coerces `Utf8View` to `LargeUtf8`, and `BinaryView` to `LargeBinary`.
         pub expand_views_at_output: bool, default = false
 
-        /// When set to true, the `optimize_projections` rule will not attempt to move, add or remove existing projections
+        /// When set to true, the `optimize_projections` rule will not attempt to move, add, or remove existing projections.
+        /// This is useful when optimization is used alongside unparsing logic to preserve the original layout and simplify the overall query structure.
         pub optimize_projections_preserve_existing_projections: bool, default = false
     }
 }

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -611,6 +611,9 @@ config_namespace! {
         /// then the output will be coerced to a non-view.
         /// Coerces `Utf8View` to `LargeUtf8`, and `BinaryView` to `LargeBinary`.
         pub expand_views_at_output: bool, default = false
+
+        /// When set to true, the `optimize_projections` rule will not attempt to move, add or remove existing projections
+        pub optimize_projections_preserve_existing_projections: bool, default = false
     }
 }
 

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -613,7 +613,7 @@ config_namespace! {
         pub expand_views_at_output: bool, default = false
 
         /// When set to true, the `optimize_projections` rule will not attempt to move, add, or remove existing projections.
-        /// This is useful when optimization is used alongside unparsing logic to preserve the original layout and simplify the overall query structure.
+        /// This flag helps maintain the original structure of the `LogicalPlan` when converting it back into SQL via the `unparser` module. It ensures the query layout remains simple and readable, relying on the underlying SQL engine to apply its own optimizations during execution.
         pub optimize_projections_preserve_existing_projections: bool, default = false
     }
 }

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -338,6 +338,14 @@ impl SessionConfig {
         self
     }
 
+    /// When set to true, the `optimize_projections` rule will not attempt to move, add or remove existing projections
+    ///
+    /// [optimize_projections_preserve_existing_projections]: datafusion_common::config::OptimizerOptions::optimize_projections_preserve_existing_projections
+    pub fn with_optimize_projections_preserve_existing_projections(mut self, enabled: bool) -> Self {
+        self.options.optimizer.optimize_projections_preserve_existing_projections = enabled;
+        self
+    }
+
     /// Enables or disables the use of pruning predicate for parquet readers to skip row groups
     pub fn with_parquet_pruning(mut self, enabled: bool) -> Self {
         self.options.execution.parquet.pruning = enabled;

--- a/datafusion/execution/src/config.rs
+++ b/datafusion/execution/src/config.rs
@@ -338,7 +338,8 @@ impl SessionConfig {
         self
     }
 
-    /// When set to true, the `optimize_projections` rule will not attempt to move, add or remove existing projections
+    /// When set to true, the `optimize_projections` rule will not attempt to move, add, or remove existing projections.
+    /// This is useful when optimization is used alongside unparsing logic to preserve the original layout and simplify the overall query structure.
     ///
     /// [optimize_projections_preserve_existing_projections]: datafusion_common::config::OptimizerOptions::optimize_projections_preserve_existing_projections
     pub fn with_optimize_projections_preserve_existing_projections(mut self, enabled: bool) -> Self {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -41,9 +41,7 @@ use super::{
         subquery_alias_inner_query_and_columns, TableAliasRewriter,
     },
     utils::{
-        find_agg_node_within_select, find_window_nodes_within_select,
-        try_transform_to_simple_table_scan_with_filters, unproject_sort_expr,
-        unproject_window_exprs,
+        find_agg_node_within_select, find_window_nodes_within_select, try_transform_to_simple_table_scan_with_filters, unproject_sort_expr, unproject_window_exprs
     },
     Unparser,
 };
@@ -340,7 +338,7 @@ impl Unparser<'_> {
         match plan {
             LogicalPlan::TableScan(scan) => {
                 if let Some(unparsed_table_scan) =
-                    Self::unparse_table_scan_pushdown(plan, None)?
+                    Self::unparse_table_scan_pushdown(plan, None, select)?
                 {
                     return self.select_to_sql_recursively(
                         &unparsed_table_scan,
@@ -672,7 +670,8 @@ impl Unparser<'_> {
                 let unparsed_table_scan = Self::unparse_table_scan_pushdown(
                     plan,
                     Some(plan_alias.alias.clone()),
-                )?;
+                    select,
+            )?;
                 // if the child plan is a TableScan with pushdown operations, we don't need to
                 // create an additional subquery for it
                 if !select.already_projected() && unparsed_table_scan.is_none() {
@@ -800,6 +799,7 @@ impl Unparser<'_> {
     fn unparse_table_scan_pushdown(
         plan: &LogicalPlan,
         alias: Option<TableReference>,
+        select: &mut SelectBuilder,
     ) -> Result<Option<LogicalPlan>> {
         match plan {
             LogicalPlan::TableScan(table_scan) => {
@@ -829,24 +829,29 @@ impl Unparser<'_> {
                     builder = builder.alias(alias.clone().unwrap())?;
                 }
 
-                if let Some(project_vec) = &table_scan.projection {
-                    let project_columns = project_vec
-                        .iter()
-                        .cloned()
-                        .map(|i| {
-                            let schema = table_scan.source.schema();
-                            let field = schema.field(i);
-                            if alias.is_some() {
-                                Column::new(alias.clone(), field.name().clone())
-                            } else {
-                                Column::new(
-                                    Some(table_scan.table_name.clone()),
-                                    field.name().clone(),
-                                )
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    builder = builder.project(project_columns)?;
+                // Avoid creating a duplicate Projection node, which would result in an additional subquery if a projection already exists.
+                // For example, if the `optimize_projection` rule is applied, there will be a Projection node, and duplicate projection 
+                // information included in the TableScan node.
+                if !select.already_projected() {
+                    if let Some(project_vec) = &table_scan.projection {
+                        let project_columns = project_vec
+                            .iter()
+                            .cloned()
+                            .map(|i| {
+                                let schema = table_scan.source.schema();
+                                let field = schema.field(i);
+                                if alias.is_some() {
+                                    Column::new(alias.clone(), field.name().clone())
+                                } else {
+                                    Column::new(
+                                        Some(table_scan.table_name.clone()),
+                                        field.name().clone(),
+                                    )
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        builder = builder.project(project_columns)?;
+                    }
                 }
 
                 let filter_expr: Result<Option<Expr>> = table_scan
@@ -891,14 +896,17 @@ impl Unparser<'_> {
                 Self::unparse_table_scan_pushdown(
                     &subquery_alias.input,
                     Some(subquery_alias.alias.clone()),
+                    select,
                 )
             }
             // SubqueryAlias could be rewritten to a plan with a projection as the top node by [rewrite::subquery_alias_inner_query_and_columns].
             // The inner table scan could be a scan with pushdown operations.
             LogicalPlan::Projection(projection) => {
-                if let Some(plan) =
-                    Self::unparse_table_scan_pushdown(&projection.input, alias.clone())?
-                {
+                if let Some(plan) = Self::unparse_table_scan_pushdown(
+                    &projection.input,
+                    alias.clone(),
+                    select,
+                )? {
                     let exprs = if alias.is_some() {
                         let mut alias_rewriter =
                             alias.as_ref().map(|alias_name| TableAliasRewriter {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -885,6 +885,7 @@ fn test_table_scan_pushdown() -> Result<()> {
     let query_from_table_scan_with_projection = LogicalPlanBuilder::from(
         table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?,
     )
+    .project(vec![col("id"), col("age")])?
     .project(vec![wildcard()])?
     .build()?;
     let query_from_table_scan_with_projection =


### PR DESCRIPTION
## Which issue does this PR close?

PR adds support for unparsing plans after `optimization_projections` is applied

1. Added `optimize_projections_preserve_existing_projections` config option to prevent optimization logic to aggressivly create / remove proejctions, as a result optimized plan can look like to following. This makes sense for Datafusion execution logic but not for unparsing use cases.
https://gist.github.com/sgrebnov/5071d2834e812b62bfdf434cf7e7e54c
![image](https://github.com/user-attachments/assets/1a389586-4ed5-4306-b5a2-067bad0816f6)

1. Improved unparsing logic to support TableScans with pushed down projection.