### PR TITLE
Preserve the filter order when eliminating duplicated filter

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -362,7 +362,6 @@ impl<F: FileOpener> FileStream<F> {
                         }
                     }
                     Err(e) => {
-                        // println!("{:?}", e);
                         self.file_stream_metrics.file_open_errors.add(1);
                         match self.on_error {
                             OnError::Skip => {

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -362,6 +362,7 @@ impl<F: FileOpener> FileStream<F> {
                         }
                     }
                     Err(e) => {
+                        // println!("{:?}", e);
                         self.file_stream_metrics.file_open_errors.add(1);
                         match self.on_error {
                             OnError::Skip => {


### PR DESCRIPTION
## Rationale for this change

- Improve the approach of eliminating duplicated filter in https://github.com/spiceai/datafusion/pull/51 to preserve the filter order

## What changes are included in this PR?

- Use Vec to store filter and preserve ordering
- Check if filter exist in Vec when adding filter

## Are these changes tested?

Yes