### PR TITLE
Make DFSchema::datatype_is_semantically_equal public

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -693,7 +693,7 @@ impl DFSchema {
     /// name and type), ignoring both metadata and nullability.
     ///
     /// request to upstream: <https://github.com/apache/arrow-rs/issues/3199>
-    fn datatype_is_semantically_equal(dt1: &DataType, dt2: &DataType) -> bool {
+    pub fn datatype_is_semantically_equal(dt1: &DataType, dt2: &DataType) -> bool {
         // check nested fields
         match (dt1, dt2) {
             (DataType::Dictionary(k1, v1), DataType::Dictionary(k2, v2)) => {


### PR DESCRIPTION
## Which issue does this PR close?

Make `DFSchema::datatype_is_semantically_equal` method public. This is needed for the schema verification in Spice where an unoptimized plan schema is compared with result schema. Since the result may based on an optimized datafusion logical plan, which has data type changes subject to rules in `DFSchema::datatype_is_semantically_equal`

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
