### PR TITLE
Fix duckdb & sqlite character_length scalar unparsing

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -175,6 +175,9 @@ pub enum DateFieldExtractStyle {
 
 /// `CharacterLengthStyle` to use for unparsing
 ///
+/// Different DBMSs uses different names for function calculating the number of characters in the string
+/// `Length` style uses length(x)
+/// `SQLStandard` style uses character_length(x)
 #[derive(Clone, Copy, PartialEq)]
 pub enum CharacterLengthStyle {
     Length,

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -80,9 +80,9 @@ pub trait Dialect: Send + Sync {
         DateFieldExtractStyle::DatePart
     }
 
-    /// The date field extract style to use: `DateFieldExtractStyle`
+    /// The character length extraction style to use: `CharacterLengthStyle`
     fn character_length_style(&self) -> CharacterLengthStyle {
-        CharacterLengthStyle::SQLStandard
+        CharacterLengthStyle::CharacterLength
     }
 
     /// The SQL type to use for Arrow Int64 unparsing
@@ -181,7 +181,7 @@ pub enum DateFieldExtractStyle {
 #[derive(Clone, Copy, PartialEq)]
 pub enum CharacterLengthStyle {
     Length,
-    SQLStandard,
+    CharacterLength,
 }
 
 pub struct DefaultDialect {}
@@ -444,7 +444,7 @@ impl Default for CustomDialect {
             utf8_cast_dtype: ast::DataType::Varchar(None),
             large_utf8_cast_dtype: ast::DataType::Text,
             date_field_extract_style: DateFieldExtractStyle::DatePart,
-            character_length_style: CharacterLengthStyle::SQLStandard,
+            character_length_style: CharacterLengthStyle::CharacterLength,
             int64_cast_dtype: ast::DataType::BigInt(None),
             int32_cast_dtype: ast::DataType::Integer(None),
             timestamp_cast_dtype: ast::DataType::Timestamp(None, TimezoneInfo::None),
@@ -611,7 +611,7 @@ impl CustomDialectBuilder {
             utf8_cast_dtype: ast::DataType::Varchar(None),
             large_utf8_cast_dtype: ast::DataType::Text,
             date_field_extract_style: DateFieldExtractStyle::DatePart,
-            character_length_style: CharacterLengthStyle::SQLStandard,
+            character_length_style: CharacterLengthStyle::CharacterLength,
             int64_cast_dtype: ast::DataType::BigInt(None),
             int32_cast_dtype: ast::DataType::Integer(None),
             timestamp_cast_dtype: ast::DataType::Timestamp(None, TimezoneInfo::None),

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -27,7 +27,7 @@ use sqlparser::{
 
 use datafusion_common::Result;
 
-use super::{utils::date_part_to_sql, Unparser};
+use super::{utils::character_length_to_sql, utils::date_part_to_sql, Unparser};
 
 /// `Dialect` to use for Unparsing
 ///
@@ -78,6 +78,11 @@ pub trait Dialect: Send + Sync {
     /// The date field extract style to use: `DateFieldExtractStyle`
     fn date_field_extract_style(&self) -> DateFieldExtractStyle {
         DateFieldExtractStyle::DatePart
+    }
+
+    /// The date field extract style to use: `DateFieldExtractStyle`
+    fn character_length_style(&self) -> CharacterLengthStyle {
+        CharacterLengthStyle::SQLStandard
     }
 
     /// The SQL type to use for Arrow Int64 unparsing
@@ -166,6 +171,14 @@ pub enum DateFieldExtractStyle {
     DatePart,
     Extract,
     Strftime,
+}
+
+/// `CharacterLengthStyle` to use for unparsing
+///
+#[derive(Clone, Copy, PartialEq)]
+pub enum CharacterLengthStyle {
+    Length,
+    SQLStandard,
 }
 
 pub struct DefaultDialect {}
@@ -263,6 +276,35 @@ impl PostgreSqlDialect {
     }
 }
 
+pub struct DuckDBDialect {}
+
+impl Dialect for DuckDBDialect {
+    fn identifier_quote_style(&self, _: &str) -> Option<char> {
+        Some('"')
+    }
+
+    fn character_length_style(&self) -> CharacterLengthStyle {
+        CharacterLengthStyle::Length
+    }
+
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        func_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        if func_name == "character_length" {
+            return character_length_to_sql(
+                unparser,
+                self.character_length_style(),
+                args,
+            );
+        }
+
+        Ok(None)
+    }
+}
+
 pub struct MySqlDialect {}
 
 impl Dialect for MySqlDialect {
@@ -339,6 +381,10 @@ impl Dialect for SqliteDialect {
         ast::DataType::Text
     }
 
+    fn character_length_style(&self) -> CharacterLengthStyle {
+        CharacterLengthStyle::Length
+    }
+
     fn supports_column_alias_in_table_alias(&self) -> bool {
         false
     }
@@ -349,11 +395,19 @@ impl Dialect for SqliteDialect {
         func_name: &str,
         args: &[Expr],
     ) -> Result<Option<ast::Expr>> {
-        if func_name == "date_part" {
-            return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+        match func_name {
+            "date_part" => {
+                return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+            }
+            "character_length" => {
+                return character_length_to_sql(
+                    unparser,
+                    self.character_length_style(),
+                    args,
+                );
+            }
+            _ => return Ok(None),
         }
-
-        Ok(None)
     }
 }
 
@@ -366,6 +420,7 @@ pub struct CustomDialect {
     utf8_cast_dtype: ast::DataType,
     large_utf8_cast_dtype: ast::DataType,
     date_field_extract_style: DateFieldExtractStyle,
+    character_length_style: CharacterLengthStyle,
     int64_cast_dtype: ast::DataType,
     int32_cast_dtype: ast::DataType,
     timestamp_cast_dtype: ast::DataType,
@@ -386,6 +441,7 @@ impl Default for CustomDialect {
             utf8_cast_dtype: ast::DataType::Varchar(None),
             large_utf8_cast_dtype: ast::DataType::Text,
             date_field_extract_style: DateFieldExtractStyle::DatePart,
+            character_length_style: CharacterLengthStyle::SQLStandard,
             int64_cast_dtype: ast::DataType::BigInt(None),
             int32_cast_dtype: ast::DataType::Integer(None),
             timestamp_cast_dtype: ast::DataType::Timestamp(None, TimezoneInfo::None),
@@ -444,6 +500,10 @@ impl Dialect for CustomDialect {
         self.date_field_extract_style
     }
 
+    fn character_length_style(&self) -> CharacterLengthStyle {
+        self.character_length_style
+    }
+
     fn int64_cast_dtype(&self) -> ast::DataType {
         self.int64_cast_dtype.clone()
     }
@@ -478,11 +538,19 @@ impl Dialect for CustomDialect {
         func_name: &str,
         args: &[Expr],
     ) -> Result<Option<ast::Expr>> {
-        if func_name == "date_part" {
-            return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+        match func_name {
+            "date_part" => {
+                return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+            }
+            "character_length" => {
+                return character_length_to_sql(
+                    unparser,
+                    self.character_length_style(),
+                    args,
+                )
+            }
+            _ => return Ok(None),
         }
-
-        Ok(None)
     }
 
     fn requires_derived_table_alias(&self) -> bool {
@@ -513,6 +581,7 @@ pub struct CustomDialectBuilder {
     utf8_cast_dtype: ast::DataType,
     large_utf8_cast_dtype: ast::DataType,
     date_field_extract_style: DateFieldExtractStyle,
+    character_length_style: CharacterLengthStyle,
     int64_cast_dtype: ast::DataType,
     int32_cast_dtype: ast::DataType,
     timestamp_cast_dtype: ast::DataType,
@@ -539,6 +608,7 @@ impl CustomDialectBuilder {
             utf8_cast_dtype: ast::DataType::Varchar(None),
             large_utf8_cast_dtype: ast::DataType::Text,
             date_field_extract_style: DateFieldExtractStyle::DatePart,
+            character_length_style: CharacterLengthStyle::SQLStandard,
             int64_cast_dtype: ast::DataType::BigInt(None),
             int32_cast_dtype: ast::DataType::Integer(None),
             timestamp_cast_dtype: ast::DataType::Timestamp(None, TimezoneInfo::None),
@@ -562,6 +632,7 @@ impl CustomDialectBuilder {
             utf8_cast_dtype: self.utf8_cast_dtype,
             large_utf8_cast_dtype: self.large_utf8_cast_dtype,
             date_field_extract_style: self.date_field_extract_style,
+            character_length_style: self.character_length_style,
             int64_cast_dtype: self.int64_cast_dtype,
             int32_cast_dtype: self.int32_cast_dtype,
             timestamp_cast_dtype: self.timestamp_cast_dtype,
@@ -600,6 +671,15 @@ impl CustomDialectBuilder {
     /// Customize the dialect with a specific interval style listed in `IntervalStyle`
     pub fn with_interval_style(mut self, interval_style: IntervalStyle) -> Self {
         self.interval_style = interval_style;
+        self
+    }
+
+    /// Customize the dialect with a specific character_length_style listed in `CharacterLengthStyle`
+    pub fn with_character_length_style(
+        mut self,
+        character_length_style: CharacterLengthStyle,
+    ) -> Self {
+        self.character_length_style = character_length_style;
         self
     }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1483,8 +1483,8 @@ mod tests {
     use datafusion_functions_window::row_number::row_number_udwf;
 
     use crate::unparser::dialect::{
-        CustomDialect, CustomDialectBuilder, DateFieldExtractStyle, Dialect,
-        PostgreSqlDialect,
+        CharacterLengthStyle, CustomDialect, CustomDialectBuilder, DateFieldExtractStyle,
+        Dialect, PostgreSqlDialect,
     };
 
     use super::*;
@@ -2000,6 +2000,33 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_character_length_scalar_to_expr() {
+        let tests = [
+            (CharacterLengthStyle::Length, "length(x)"),
+            (CharacterLengthStyle::SQLStandard, "character_length(x)"),
+        ];
+
+        for (style, expected) in tests {
+            let dialect = CustomDialectBuilder::new()
+                .with_character_length_style(style)
+                .build();
+            let unparser = Unparser::new(&dialect);
+
+            let expr = ScalarUDF::new_from_impl(
+                datafusion_functions::unicode::character_length::CharacterLengthFunc::new(
+                ),
+            )
+            .call(vec![col("x")]);
+
+            let ast = unparser.expr_to_sql(&expr).expect("to be unparsed");
+
+            let actual = format!("{ast}");
+
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2006,7 +2006,7 @@ mod tests {
     fn test_character_length_scalar_to_expr() {
         let tests = [
             (CharacterLengthStyle::Length, "length(x)"),
-            (CharacterLengthStyle::SQLStandard, "character_length(x)"),
+            (CharacterLengthStyle::CharacterLength, "character_length(x)"),
         ];
 
         for (style, expected) in tests {

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -28,7 +28,10 @@ use datafusion_expr::{
 };
 use sqlparser::ast;
 
-use super::{dialect::DateFieldExtractStyle, dialect::CharacterLengthStyle, rewrite::TableAliasRewriter, Unparser};
+use super::{
+    dialect::CharacterLengthStyle, dialect::DateFieldExtractStyle,
+    rewrite::TableAliasRewriter, Unparser,
+};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
@@ -458,10 +461,11 @@ pub(crate) fn character_length_to_sql(
     character_length_args: &[Expr],
 ) -> Result<Option<ast::Expr>> {
     let func_name = match style {
-        CharacterLengthStyle::SQLStandard => "character_length",
-        CharacterLengthStyle::Length => "length"
+        CharacterLengthStyle::CharacterLength => "character_length",
+        CharacterLengthStyle::Length => "length",
     };
 
-    return Ok(Some(unparser.scalar_function_to_sql(func_name, character_length_args)?))
-
+    return Ok(Some(
+        unparser.scalar_function_to_sql(func_name, character_length_args)?,
+    ));
 }

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -28,7 +28,7 @@ use datafusion_expr::{
 };
 use sqlparser::ast;
 
-use super::{dialect::DateFieldExtractStyle, rewrite::TableAliasRewriter, Unparser};
+use super::{dialect::DateFieldExtractStyle, dialect::CharacterLengthStyle, rewrite::TableAliasRewriter, Unparser};
 
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
@@ -450,4 +450,18 @@ pub(crate) fn date_part_to_sql(
     };
 
     Ok(None)
+}
+
+pub(crate) fn character_length_to_sql(
+    unparser: &Unparser,
+    style: CharacterLengthStyle,
+    character_length_args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    let func_name = match style {
+        CharacterLengthStyle::SQLStandard => "character_length",
+        CharacterLengthStyle::Length => "length"
+    };
+
+    return Ok(Some(unparser.scalar_function_to_sql(func_name, character_length_args)?))
+
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Close https://github.com/spiceai/spiceai/issues/3315
- Close https://github.com/spiceai/spiceai/issues/3168

## Rationale for this change

When unparsing `CharacterLengthFunc` scalar function to DuckDB & SQLite syntax SQL query, the `CharacterLengthFunc` scalar function need to be unparsed to `length`, since `length` is the equivalence of `CharacterLengthFunc` in DuckDB & SQLite.

DuckDB [length()](https://duckdb.org/docs/sql/functions/char.html#lengthstring)
SQLite [length()](https://www.sqlite.org/lang_corefunc.html#length)

## What changes are included in this PR?

- Add struct `DuckDBDialect`, which implements the `Dialect` trait
- Add new method `character_length_style` for `Dialect` trait for determining the `CharacterLengthStyle` to use for a dialect
- Add helper function `character_length_to_sql`, which unparses the `CharacterLengthFunc` to `length` or `character_length` based on  `CharacterLengthStyle` 

## Are these changes tested?

Yes

## Are there any user-facing changes?

No