### PR TITLE
Emulate cross joins for inner joins with no conditions

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -330,11 +330,13 @@ impl From<&DataType> for TypeCategory {
                     return TypeCategory::Array;
                 }
 
-                // String literal is possible to cast to many other types like numeric or datetime,
-                // therefore, it is categorized as a unknown type
+                // It is categorized as unknown type because the type will be resolved later on
                 if matches!(
                     data_type,
-                    DataType::Utf8 | DataType::LargeUtf8 | DataType::Null
+                    DataType::Utf8
+                        | DataType::LargeUtf8
+                        | DataType::Utf8View
+                        | DataType::Null
                 ) {
                     return TypeCategory::Unknown;
                 }

--- a/datafusion/sqllogictest/test_files/coalesce.slt
+++ b/datafusion/sqllogictest/test_files/coalesce.slt
@@ -242,6 +242,14 @@ none_set
 statement ok
 drop table test1
 
+# coalesce with utf8view
+query TTT
+select coalesce(arrow_cast(null, 'Utf8View'), arrow_cast('t', 'Utf8')),
+       arrow_typeof(coalesce(arrow_cast(null, 'Utf8View'), arrow_cast('t', 'Utf8'))),
+       arrow_typeof(coalesce(arrow_cast(null, 'Utf8'), arrow_cast('t', 'Utf8View')));
+----
+t Utf8View Utf8View
+
 # test dict coercion with value
 statement ok
 create table t(c varchar) as values ('a'), (null);


### PR DESCRIPTION
## Which issue does this PR close?

Inner joins with no conditions are invalid SQL in most database systems (i.e. tableA JOIN tableB JOIN tableC). This PR adds a join constraint that is always true to simulate a cross join for inner joins with no conditions (i.e. tableA JOIN tableB ON true JOIN tableC ON true)

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
