### PR TITLE
Fix binary view cast

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -848,7 +848,9 @@ impl Unparser<'_> {
         let inner_expr = self.expr_to_sql_inner(expr)?;
         match inner_expr {
             ast::Expr::Value(_) => match data_type {
-                DataType::Dictionary(_, _) | DataType::Binary => Ok(inner_expr),
+                DataType::Dictionary(_, _) | DataType::Binary | DataType::BinaryView => {
+                    Ok(inner_expr)
+                }
                 _ => Ok(ast::Expr::Cast {
                     kind: ast::CastKind::Cast,
                     expr: Box::new(inner_expr),
@@ -2202,6 +2204,13 @@ mod tests {
                     "blah".to_string(),
                 )))),
                 data_type: DataType::Binary,
+            }),
+            "'blah'",
+            Expr::Cast(Cast {
+                expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
+                    "blah".to_string(),
+                )))),
+                data_type: DataType::BinaryView,
             }),
             "'blah'",
         )];


### PR DESCRIPTION
## Which issue does this PR close?

- This PR serves as a subsequent improvement for https://github.com/spiceai/datafusion/pull/60 after Datafusion 43 upgrade.
In Datafusion 43, bianry / large binary types are read as BianryView from parquet, therefore update the cast logic to include Binary View type

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
