### PR TITLE
Use // as DuckDB division operator

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -754,7 +754,7 @@ impl Unparser<'_> {
             Operator::Plus => Ok(BinaryOperator::Plus),
             Operator::Minus => Ok(BinaryOperator::Minus),
             Operator::Multiply => Ok(BinaryOperator::Multiply),
-            Operator::Divide => Ok(BinaryOperator::Divide),
+            Operator::Divide => Ok(self.dialect.division_operator()),
             Operator::Modulo => Ok(BinaryOperator::Modulo),
             Operator::And => Ok(BinaryOperator::And),
             Operator::Or => Ok(BinaryOperator::Or),
@@ -2417,6 +2417,32 @@ mod tests {
 
             let actual = format!("{}", ast);
             let expected = format!(r#"CAST(a AS {identifier})"#);
+
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_division_operator() -> Result<()> {
+        let default_dialect = CustomDialectBuilder::new().build();
+        let duckdb_dialect = CustomDialectBuilder::new()
+            .with_division_operator(BinaryOperator::DuckIntegerDivide)
+            .build();
+
+        for (dialect, expected) in
+            [(default_dialect, "(a / b)"), (duckdb_dialect, "(a // b)")]
+        {
+            let unparser = Unparser::new(&dialect);
+            let expr = Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(col("a")),
+                op: Operator::Divide,
+                right: Box::new(col("b")),
+            });
+            let ast = unparser.expr_to_sql(&expr)?;
+
+            let actual = format!("{}", ast);
+            let expected = format!("{}", expected);
 
             assert_eq!(actual, expected);
         }


### PR DESCRIPTION
## Which issue does this PR close?



## Rationale for this change

In Datafusion, the `/` operator is semantically integer division. When both a & b are integer, `a/b` result is a integer rounded down to 0. When unparsing Datafusion logical plan to DuckDB SQL query, the query needs to follow the same semantic meaning of integer division. Therefore, the `Operator::Divide` needs to be unparsed to `BinaryOperator::DuckIntegerDivide`, which is `//` in DuckDB.

Reference to DuckDB division operator: https://duckdb.org/docs/sql/functions/numeric.html#division-and-modulo-operators. The `//` operator has the same semantic meaning to Datafusion `/` operator
![image](https://github.com/user-attachments/assets/9af0c7c9-188c-48e0-9c04-1193218e7188)


## What changes are included in this PR?

- Add `division_operator` method in Dialect trait to return the division operator for a specific Dialect
- Use `BinaryOperator::DuckIntegerDivide` as the division operator for DuckDB Dialect
- Use the `division_operator` of dialect to unparse `Operator::Divide` in Unparser `op_to_sql` method

## Are these changes tested?

Yes

## Are there any user-facing changes?

All division will be unparsed to `//` instead of `/` for DuckDB Dialect.