### PR TITLE
feat: Unparse LogicalPlans with grouping aggregate functions

### DIFF
--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -58,6 +58,8 @@ datafusion-functions = { workspace = true, default-features = true }
 datafusion-functions-aggregate = { workspace = true }
 datafusion-functions-nested = { workspace = true }
 datafusion-functions-window = { workspace = true }
+datafusion-optimizer = { workspace = true }
+datafusion-common = { workspace = true }
 env_logger = { workspace = true }
 paste = "^1.0"
 rstest = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

DataFusion v43 added a new analyzer rule `ResolveGroupingFunction` that supports grouping aggregate functions in select expressions with grouping set aggregations.

i.e.
```sql
SELECT 
  id, 
  first_name, 
  grouping(id) -- <- This!
FROM person 
GROUP BY ROLLUP(id, first_name)
```

As mentioned in the implementing PR (https://github.com/apache/datafusion/pull/12704) this is necessary to run several queries in the TPC-DS benchmark suite.

Unfortunately, logical plans that contain a `grouping` function that are run through this analyzer cannot be unparsed anymore, running into the error: `Internal error: Tried to unproject column referring to internal grouping id.`

This was because the plan was being transformed from this:

```bash
  Projection: lineitem.l_orderkey, grouping(lineitem.l_orderkey), avg(lineitem.l_quantity) AS avg_quantity
      Aggregate: groupBy=[[ROLLUP (lineitem.l_orderkey)]], aggr=[[avg(lineitem.l_quantity)]]
        TableScan: lineitem
```

to this:

```bash
  Projection: lineitem.l_orderkey, grouping(lineitem.l_orderkey), avg(lineitem.l_quantity) AS avg_quantity
    Projection: lineitem.l_orderkey, CAST(__grouping_id AS Int32) AS grouping(lineitem.l_orderkey), avg(lineitem.l_quantity)
      Aggregate: groupBy=[[ROLLUP (lineitem.l_orderkey)]], aggr=[[avg(lineitem.l_quantity)]]
        TableScan: lineitem
```

With this change, the unparser correctly supports unparsing back to the original SQL by taking the original SQL that was preserved in the column alias, and returning it directly in a Placeholder expression.

## What changes are included in this PR?

When the unparser encounters the internal grouping id column, it returns a placeholder expression with the original SQL representing the grouping aggregate function.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
