### PR TITLE
Allow adding custom scalar to sql overrides for DuckDB

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use arrow_schema::TimeUnit;
 use datafusion_expr::Expr;
@@ -28,6 +28,9 @@ use sqlparser::{
 use datafusion_common::Result;
 
 use super::{utils::character_length_to_sql, utils::date_part_to_sql, Unparser};
+
+pub type ScalarFnToSqlHandler =
+    Box<dyn Fn(&Unparser, &[Expr]) -> Result<Option<ast::Expr>> + Send + Sync>;
 
 /// `Dialect` to use for Unparsing
 ///
@@ -286,7 +289,30 @@ impl PostgreSqlDialect {
     }
 }
 
-pub struct DuckDBDialect {}
+#[derive(Default)]
+pub struct DuckDBDialect {
+    custom_scalar_fn_overrides: HashMap<String, ScalarFnToSqlHandler>,
+}
+
+impl DuckDBDialect {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            custom_scalar_fn_overrides: HashMap::new(),
+        }
+    }
+
+    pub fn with_custom_scalar_overrides(
+        mut self,
+        handlers: Vec<(&str, ScalarFnToSqlHandler)>,
+    ) -> Self {
+        for (func_name, handler) in handlers {
+            self.custom_scalar_fn_overrides
+                .insert(func_name.to_string(), handler);
+        }
+        self
+    }
+}
 
 impl Dialect for DuckDBDialect {
     fn identifier_quote_style(&self, _: &str) -> Option<char> {
@@ -307,6 +333,10 @@ impl Dialect for DuckDBDialect {
         func_name: &str,
         args: &[Expr],
     ) -> Result<Option<ast::Expr>> {
+        if let Some(handler) = self.custom_scalar_fn_overrides.get(func_name) {
+            return handler(unparser, args);
+        }
+
         if func_name == "character_length" {
             return character_length_to_sql(
                 unparser,


### PR DESCRIPTION
## Which issue does this PR close?

Allow adding custom scalar to sql overrides for DuckDB, for example

```rust
let dialect = DuckDBDialect::new().with_custom_scalar_overrides(vec![
      (
          "cosine_distance",
          Box::new(cosine_distance_to_sql) as ScalarFnToSqlHandler
      ),
  ]);
```



## Concern

1. This is a breaking change for DuckDB as we are adding new field so `DuckDBDialect {}` must be replaced with `DuckDBDialect::new()` constructor, I've tried to avoid this by using Default trait but it does not help, with this change we require to update the way `DuckDBDialect` is created. Note: DuckDB was added by us so most likely only us are affected by this change.

1. I was thinking to add `fn get_custom_scalar_overrides()->Option<&HashMap<String, ScalarFnToSqlHandler>>` to Dialect Trait as an example of what Dialects should use to provide custom overrides but I don't think we should restrict how Dialects should implement this. We have `Type ScalarFnToSqlHandler = Box<dyn Fn(&Unparser, &[Expr]) -> Result<Option<ast::Expr>> + Send + Sync>` that specifies the signature and this should be enough for dialects IMO.

