### PR TITLE
DuckDB `array_element` unparsing support

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -27,7 +27,10 @@ use sqlparser::{
 
 use datafusion_common::Result;
 
-use super::{utils::character_length_to_sql, utils::date_part_to_sql, Unparser};
+use super::{
+    utils::{array_element_to_sql_subscript, character_length_to_sql, date_part_to_sql},
+    Unparser,
+};
 
 pub type ScalarFnToSqlHandler =
     Box<dyn Fn(&Unparser, &[Expr]) -> Result<Option<ast::Expr>> + Send + Sync>;
@@ -337,15 +340,13 @@ impl Dialect for DuckDBDialect {
             return handler(unparser, args);
         }
 
-        if func_name == "character_length" {
-            return character_length_to_sql(
-                unparser,
-                self.character_length_style(),
-                args,
-            );
+        match func_name {
+            "character_length" => {
+                character_length_to_sql(unparser, self.character_length_style(), args)
+            }
+            "array_element" => array_element_to_sql_subscript(unparser, args),
+            _ => Ok(None),
         }
-
-        Ok(None)
     }
 }
 

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -469,3 +469,21 @@ pub(crate) fn character_length_to_sql(
         unparser.scalar_function_to_sql(func_name, character_length_args)?,
     ));
 }
+
+/// Converts the `array_element` function call into a SQL subscript expression: `array_expr[index_expr]`.
+pub(crate) fn array_element_to_sql_subscript(
+    unparser: &Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    if args.len() != 2 {
+        return internal_err!("array_element expects 2 arguments, found {}", args.len());
+    }
+
+    let array_expr = unparser.expr_to_sql(&args[0])?;
+    let index_expr = unparser.expr_to_sql(&args[1])?;
+
+    Ok(Some(ast::Expr::Subscript {
+        expr: Box::new(array_expr),
+        subscript: Box::new(ast::Subscript::Index { index: index_expr }),
+    }))
+}


### PR DESCRIPTION
## Which issue does this PR close?

DuckDB does not support `array_element` used by DataFusion and requires array element access by index.

Note: tests will be added when creating upstream PR.
