### PR TITLE
Customize window frame support for dialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use arrow_schema::TimeUnit;
 use datafusion_expr::Expr;
@@ -28,6 +28,9 @@ use sqlparser::{
 use datafusion_common::Result;
 
 use super::{utils::character_length_to_sql, utils::date_part_to_sql, Unparser};
+
+pub type ScalarFnToSqlHandler =
+    Box<dyn Fn(&Unparser, &[Expr]) -> Result<Option<ast::Expr>> + Send + Sync>;
 
 /// `Dialect` to use for Unparsing
 ///
@@ -286,7 +289,30 @@ impl PostgreSqlDialect {
     }
 }
 
-pub struct DuckDBDialect {}
+#[derive(Default)]
+pub struct DuckDBDialect {
+    custom_scalar_fn_overrides: HashMap<String, ScalarFnToSqlHandler>,
+}
+
+impl DuckDBDialect {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            custom_scalar_fn_overrides: HashMap::new(),
+        }
+    }
+
+    pub fn with_custom_scalar_overrides(
+        mut self,
+        handlers: Vec<(&str, ScalarFnToSqlHandler)>,
+    ) -> Self {
+        for (func_name, handler) in handlers {
+            self.custom_scalar_fn_overrides
+                .insert(func_name.to_string(), handler);
+        }
+        self
+    }
+}
 
 impl Dialect for DuckDBDialect {
     fn identifier_quote_style(&self, _: &str) -> Option<char> {
@@ -307,6 +333,10 @@ impl Dialect for DuckDBDialect {
         func_name: &str,
         args: &[Expr],
     ) -> Result<Option<ast::Expr>> {
+        if let Some(handler) = self.custom_scalar_fn_overrides.get(func_name) {
+            return handler(unparser, args);
+        }
+
         if func_name == "character_length" {
             return character_length_to_sql(
                 unparser,

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -21,7 +21,9 @@ use arrow_schema::TimeUnit;
 use datafusion_expr::Expr;
 use regex::Regex;
 use sqlparser::{
-    ast::{self, BinaryOperator, Function, Ident, ObjectName, TimezoneInfo},
+    ast::{
+        self, BinaryOperator, Function, Ident, ObjectName, TimezoneInfo, WindowFrameBound,
+    },
     keywords::ALL_KEYWORDS,
 };
 
@@ -153,7 +155,15 @@ pub trait Dialect: Send + Sync {
         Ok(None)
     }
 
-    fn window_func_support_window_frame(&self, _func_name: &str) -> bool {
+    /// Allows the dialect to choose to omit window frame in unparsing
+    /// based on function name and window frame bound
+    /// Returns false if specific function name / window frame bound inidcates no window frame is needed in unparsing
+    fn window_func_support_window_frame(
+        &self,
+        _func_name: &str,
+        _start_bound: &WindowFrameBound,
+        _end_bound: &WindowFrameBound,
+    ) -> bool {
         true
     }
 }
@@ -613,7 +623,12 @@ impl Dialect for CustomDialect {
         self.division_operator.clone()
     }
 
-    fn window_func_support_window_frame(&self, _func_name: &str) -> bool {
+    fn window_func_support_window_frame(
+        &self,
+        _func_name: &str,
+        _start_bound: &WindowFrameBound,
+        _end_bound: &WindowFrameBound,
+    ) -> bool {
         self.window_func_support_window_frame
     }
 }

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -152,6 +152,10 @@ pub trait Dialect: Send + Sync {
     ) -> Result<Option<ast::Expr>> {
         Ok(None)
     }
+
+    fn window_func_support_window_frame(&self, _func_name: &str) -> bool {
+        true
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -473,6 +477,7 @@ pub struct CustomDialect {
     supports_column_alias_in_table_alias: bool,
     requires_derived_table_alias: bool,
     division_operator: BinaryOperator,
+    window_func_support_window_frame: bool,
 }
 
 impl Default for CustomDialect {
@@ -498,6 +503,7 @@ impl Default for CustomDialect {
             supports_column_alias_in_table_alias: true,
             requires_derived_table_alias: false,
             division_operator: BinaryOperator::Divide,
+            window_func_support_window_frame: true,
         }
     }
 }
@@ -606,6 +612,10 @@ impl Dialect for CustomDialect {
     fn division_operator(&self) -> BinaryOperator {
         self.division_operator.clone()
     }
+
+    fn window_func_support_window_frame(&self, _func_name: &str) -> bool {
+        self.window_func_support_window_frame
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -640,6 +650,7 @@ pub struct CustomDialectBuilder {
     supports_column_alias_in_table_alias: bool,
     requires_derived_table_alias: bool,
     division_operator: BinaryOperator,
+    window_func_support_window_frame: bool,
 }
 
 impl Default for CustomDialectBuilder {
@@ -671,6 +682,7 @@ impl CustomDialectBuilder {
             supports_column_alias_in_table_alias: true,
             requires_derived_table_alias: false,
             division_operator: BinaryOperator::Divide,
+            window_func_support_window_frame: true,
         }
     }
 
@@ -694,6 +706,7 @@ impl CustomDialectBuilder {
                 .supports_column_alias_in_table_alias,
             requires_derived_table_alias: self.requires_derived_table_alias,
             division_operator: self.division_operator,
+            window_func_support_window_frame: self.window_func_support_window_frame,
         }
     }
 
@@ -813,6 +826,14 @@ impl CustomDialectBuilder {
 
     pub fn with_division_operator(mut self, division_operator: BinaryOperator) -> Self {
         self.division_operator = division_operator;
+        self
+    }
+
+    pub fn with_window_func_support_window_frame(
+        mut self,
+        window_func_support_window_frame: bool,
+    ) -> Self {
+        self.window_func_support_window_frame = window_func_support_window_frame;
         self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -2543,13 +2543,13 @@ mod tests {
         for (dialect, expected) in [
             (
                 default_dialect,
-                "rank(a) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+                "rank() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
             ),
-            (test_dialect, "rank(a) OVER ()"),
+            (test_dialect, "rank() OVER ()"),
         ] {
             let unparser = Unparser::new(dialect.as_ref());
             let func = WindowFunctionDefinition::WindowUDF(rank_udwf());
-            let window_func = WindowFunction::new(func, vec![col("a")]);
+            let window_func = WindowFunction::new(func, vec![]);
             let expr = Expr::WindowFunction(window_func);
             let ast = unparser.expr_to_sql(&expr)?;
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -213,8 +213,20 @@ impl Unparser<'_> {
                     .map(|sort_expr| self.sort_to_sql(sort_expr))
                     .collect::<Result<Vec<_>>>()?;
 
-                let start_bound = self.convert_bound(&window_frame.start_bound)?;
-                let end_bound = self.convert_bound(&window_frame.end_bound)?;
+                let window_frame =
+                    if self.dialect.window_func_support_window_frame(func_name) {
+                        let start_bound =
+                            self.convert_bound(&window_frame.start_bound)?;
+                        let end_bound = self.convert_bound(&window_frame.end_bound)?;
+                        Some(ast::WindowFrame {
+                            units,
+                            start_bound,
+                            end_bound: Some(end_bound),
+                        })
+                    } else {
+                        None
+                    };
+
                 let over = Some(ast::WindowType::WindowSpec(ast::WindowSpec {
                     window_name: None,
                     partition_by: partition_by
@@ -222,11 +234,7 @@ impl Unparser<'_> {
                         .map(|e| self.expr_to_sql_inner(e))
                         .collect::<Result<Vec<_>>>()?,
                     order_by,
-                    window_frame: Some(ast::WindowFrame {
-                        units,
-                        start_bound,
-                        end_bound: Option::from(end_bound),
-                    }),
+                    window_frame,
                 }));
 
                 Ok(ast::Expr::Function(Function {
@@ -1479,12 +1487,13 @@ mod tests {
     use datafusion_expr::{
         case, col, cube, exists, grouping_set, interval_datetime_lit,
         interval_year_month_lit, lit, not, not_exists, out_ref_col, placeholder, rollup,
-        table_scan, try_cast, when, wildcard, ColumnarValue, ScalarUDF, ScalarUDFImpl,
-        Signature, Volatility, WindowFrame, WindowFunctionDefinition,
+        table_scan, try_cast, when, wildcard, window_function, ColumnarValue, ScalarUDF,
+        ScalarUDFImpl, Signature, Volatility, WindowFrame, WindowFunctionDefinition,
     };
     use datafusion_expr::{interval_month_day_nano_lit, ExprFunctionExt};
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::sum;
+    use datafusion_functions_window::rank::rank_udwf;
     use datafusion_functions_window::row_number::row_number_udwf;
 
     use crate::unparser::dialect::{
@@ -2196,22 +2205,26 @@ mod tests {
 
     #[test]
     fn test_cast_value_to_binary_expr() {
-        let tests = [(
-            Expr::Cast(Cast {
-                expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
-                    "blah".to_string(),
-                )))),
-                data_type: DataType::Binary,
-            }),
-            "'blah'",
-            Expr::Cast(Cast {
-                expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
-                    "blah".to_string(),
-                )))),
-                data_type: DataType::BinaryView,
-            }),
-            "'blah'",
-        )];
+        let tests = [
+            (
+                Expr::Cast(Cast {
+                    expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
+                        "blah".to_string(),
+                    )))),
+                    data_type: DataType::Binary,
+                }),
+                "'blah'",
+            ),
+            (
+                Expr::Cast(Cast {
+                    expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
+                        "blah".to_string(),
+                    )))),
+                    data_type: DataType::BinaryView,
+                }),
+                "'blah'",
+            ),
+        ];
         for (value, expected) in tests {
             let dialect = CustomDialectBuilder::new().build();
             let unparser = Unparser::new(&dialect);
@@ -2507,6 +2520,38 @@ mod tests {
 
             let actual = format!("{}", ast);
             let expected = format!(r#"round(CAST("a" AS {identifier}), 2)"#);
+
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_window_func_support_window_frame() -> Result<()> {
+        let default_dialect: Arc<dyn Dialect> =
+            Arc::new(CustomDialectBuilder::new().build());
+
+        let test_dialect: Arc<dyn Dialect> = Arc::new(
+            CustomDialectBuilder::new()
+                .with_window_func_support_window_frame(false)
+                .build(),
+        );
+
+        for (dialect, expected) in [
+            (
+                default_dialect,
+                "rank(a) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+            ),
+            (test_dialect, "rank(a) OVER ()"),
+        ] {
+            let unparser = Unparser::new(dialect.as_ref());
+            let func = WindowFunctionDefinition::WindowUDF(rank_udwf());
+            let window_func = WindowFunction::new(func, vec![col("a")]);
+            let expr = Expr::WindowFunction(window_func);
+            let ast = unparser.expr_to_sql(&expr)?;
+
+            let actual = format!("{ast}");
+            let expected = format!("{expected}");
 
             assert_eq!(actual, expected);
         }


### PR DESCRIPTION
## Which issue does this PR close?

- https://github.com/spiceai/spiceai/issues/3994

## Rationale for this change

Some dialect doesn't support window frames in window function, for example, in dremio, window frame doesn't work with RANK, DENSE_RANK or ROW_NUMBER functions, and would cause error like will cause error like `ROW/RANGE not allowed with RANK, DENSE_RANK or ROW_NUMBER functions`.

## What changes are included in this PR?

Include a method for Dialect determining whether the Dialect support window frame based on the window function name, start_bound, end_bound. When the window frame start_bound and end_bound indicates that no frame is specified in the original query, and the window function requires no window frame to function in the expected way, the window function will be unparsed as None in ast.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No