### PR TITLE
fix: support date_trunc and from_unixtime in SQLite

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -28,7 +28,10 @@ use sqlparser::{
 use datafusion_common::Result;
 
 use super::{
-    utils::{array_element_to_sql_subscript, character_length_to_sql, date_part_to_sql},
+    utils::{
+        array_element_to_sql_subscript, character_length_to_sql, date_part_to_sql,
+        sqlite_date_trunc_to_sql, sqlite_from_unixtime_to_sql,
+    },
     Unparser,
 };
 
@@ -450,6 +453,12 @@ impl Dialect for SqliteDialect {
                     self.character_length_style(),
                     args,
                 );
+            }
+            "from_unixtime" => {
+                return sqlite_from_unixtime_to_sql(unparser, args);
+            }
+            "date_trunc" => {
+                return sqlite_date_trunc_to_sql(unparser, args);
             }
             _ => return Ok(None),
         }

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -476,7 +476,8 @@ pub(crate) fn character_length_to_sql(
 ///
 /// # Errors
 ///
-/// Returns an error if the number of arguments is not 1 - the column or expression to convert.
+/// - If the number of arguments is not 1 - the column or expression to convert.
+/// - If the scalar function cannot be converted to SQL.
 pub(crate) fn sqlite_from_unixtime_to_sql(
     unparser: &Unparser,
     from_unixtime_args: &[Expr],
@@ -502,7 +503,8 @@ pub(crate) fn sqlite_from_unixtime_to_sql(
 ///
 /// # Errors
 ///
-/// Returns an error if the number of arguments is not 2 - truncation unit and the column or expression to convert.
+/// - If the number of arguments is not 2 - truncation unit and the column or expression to convert.
+/// - If the scalar function cannot be converted to SQL.
 pub(crate) fn sqlite_date_trunc_to_sql(
     unparser: &Unparser,
     date_trunc_args: &[Expr],

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -470,6 +470,73 @@ pub(crate) fn character_length_to_sql(
     ));
 }
 
+/// SQLite does not support timestamp/date scalars like `to_timestamp`, `from_unixtime`, `date_trunc`, etc.
+/// This remaps `from_unixtime` to `datetime(expr, 'unixepoch')`, expecting the input to be in seconds.
+/// It supports no other arguments, so if any are supplied it will return an error.
+///
+/// # Errors
+///
+/// Returns an error if the number of arguments is not 1 - the column or expression to convert.
+pub(crate) fn sqlite_from_unixtime_to_sql(
+    unparser: &Unparser,
+    from_unixtime_args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    if from_unixtime_args.len() != 1 {
+        return internal_err!(
+            "from_unixtime for SQLite expects 1 argument, found {}",
+            from_unixtime_args.len()
+        );
+    }
+
+    Ok(Some(unparser.scalar_function_to_sql(
+        "datetime",
+        &[
+            from_unixtime_args[0].clone(),
+            Expr::Literal(ScalarValue::Utf8(Some("unixepoch".to_string()))),
+        ],
+    )?))
+}
+
+/// SQLite does not support timestamp/date scalars like `to_timestamp`, `from_unixtime`, `date_trunc`, etc.
+/// This uses the `strftime` function to format the timestamp as a string depending on the truncation unit.
+///
+/// # Errors
+///
+/// Returns an error if the number of arguments is not 2 - truncation unit and the column or expression to convert.
+pub(crate) fn sqlite_date_trunc_to_sql(
+    unparser: &Unparser,
+    date_trunc_args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    if date_trunc_args.len() != 2 {
+        return internal_err!(
+            "date_trunc for SQLite expects 2 arguments, found {}",
+            date_trunc_args.len()
+        );
+    }
+
+    if let Expr::Literal(ScalarValue::Utf8(Some(unit))) = &date_trunc_args[0] {
+        let format = match unit.to_lowercase().as_str() {
+            "year" => "%Y",
+            "month" => "%Y-%m",
+            "day" => "%Y-%m-%d",
+            "hour" => "%Y-%m-%d %H",
+            "minute" => "%Y-%m-%d %H:%M",
+            "second" => "%Y-%m-%d %H:%M:%S",
+            _ => return Ok(None),
+        };
+
+        return Ok(Some(unparser.scalar_function_to_sql(
+            "strftime",
+            &[
+                Expr::Literal(ScalarValue::Utf8(Some(format.to_string()))),
+                date_trunc_args[1].clone(),
+            ],
+        )?));
+    }
+
+    Ok(None)
+}
+
 /// Converts the `array_element` function call into a SQL subscript expression: `array_expr[index_expr]`.
 pub(crate) fn array_element_to_sql_subscript(
     unparser: &Unparser,


### PR DESCRIPTION
# Description

* Adds parsing support for `from_unixtime` for SQLite
* Adds parsing support for `date_trunc` for SQLite

## Issues

* Part of https://github.com/spiceai/spiceai/issues/3873