### PR TITLE
Support for metadata columns (`location`, `size`, `last_modified`)  in ListingTableProvider

### DIFF
--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -29,7 +29,8 @@ use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{BinaryExpr, Operator};
 
 use arrow::{
-    array::{Array, ArrayRef, AsArray, StringBuilder},
+    array::{Array, ArrayRef, AsArray, BooleanArray, StringBuilder},
+    buffer::BooleanBuffer,
     compute::{and, cast, prep_null_mask_filter},
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
@@ -272,42 +273,18 @@ async fn prune_partitions(
         .collect();
     let schema = Arc::new(Schema::new(fields));
 
-    let df_schema = DFSchema::from_unqualified_fields(
-        partition_cols
-            .iter()
-            .map(|(n, d)| Field::new(n, d.clone(), true))
-            .collect(),
-        Default::default(),
-    )?;
-
     let batch = RecordBatch::try_new(schema, arrays)?;
 
     // TODO: Plumb this down
     let props = ExecutionProps::new();
 
-    // Applies `filter` to `batch` returning `None` on error
-    let do_filter = |filter| -> Result<ArrayRef> {
-        let expr = create_physical_expr(filter, &df_schema, &props)?;
-        expr.evaluate(&batch)?.into_array(partitions.len())
-    };
-
-    //.Compute the conjunction of the filters
-    let mask = filters
-        .iter()
-        .map(|f| do_filter(f).map(|a| a.as_boolean().clone()))
-        .reduce(|a, b| Ok(and(&a?, &b?)?));
-
-    let mask = match mask {
-        Some(Ok(mask)) => mask,
-        Some(Err(err)) => return Err(err),
-        None => return Ok(partitions),
-    };
-
     // Don't retain partitions that evaluated to null
-    let prepared = match mask.null_count() {
-        0 => mask,
-        _ => prep_null_mask_filter(&mask),
-    };
+    let prepared = apply_filters(&batch, filters, &props)?;
+
+    // If all rows are retained, return all partitions
+    if prepared.true_count() == prepared.len() {
+        return Ok(partitions);
+    }
 
     // Sanity check
     assert_eq!(prepared.len(), partitions.len());
@@ -319,6 +296,54 @@ async fn prune_partitions(
         .collect();
 
     Ok(filtered)
+}
+
+/// Applies the given filters to the input batch and returns a boolean mask that represents
+/// the result of the filters applied to each row.
+pub(crate) fn apply_filters(
+    batch: &RecordBatch,
+    filters: &[Expr],
+    props: &ExecutionProps,
+) -> Result<BooleanArray> {
+    if filters.is_empty() {
+        return Ok(BooleanArray::new(
+            BooleanBuffer::new_set(batch.num_rows()),
+            None,
+        ));
+    }
+
+    let num_rows = batch.num_rows();
+
+    let df_schema = DFSchema::from_unqualified_fields(
+        batch.schema().fields().clone(),
+        HashMap::default(),
+    )?;
+
+    // Applies `filter` to `batch` returning `None` on error
+    let do_filter = |filter| -> Result<ArrayRef> {
+        let expr = create_physical_expr(filter, &df_schema, props)?;
+        expr.evaluate(batch)?.into_array(num_rows)
+    };
+
+    // Compute the conjunction of the filters
+    let mask = filters
+        .iter()
+        .map(|f| do_filter(f).map(|a| a.as_boolean().clone()))
+        .reduce(|a, b| Ok(and(&a?, &b?)?));
+
+    let mask = match mask {
+        Some(Ok(mask)) => mask,
+        Some(Err(err)) => return Err(err),
+        None => return Ok(BooleanArray::new(BooleanBuffer::new_set(num_rows), None)),
+    };
+
+    // Don't retain rows that evaluated to null
+    let prepared = match mask.null_count() {
+        0 => mask,
+        _ => prep_null_mask_filter(&mask),
+    };
+
+    Ok(prepared)
 }
 
 #[derive(Debug)]

--- a/datafusion/core/src/datasource/listing/metadata.rs
+++ b/datafusion/core/src/datasource/listing/metadata.rs
@@ -57,6 +57,7 @@ impl fmt::Display for MetadataColumn {
 }
 
 impl MetadataColumn {
+    /// The name of the metadata column (one of `location`, `last_modified`, or `size`)
     pub fn name(&self) -> &str {
         match self {
             MetadataColumn::Location => "location",

--- a/datafusion/core/src/datasource/listing/metadata.rs
+++ b/datafusion/core/src/datasource/listing/metadata.rs
@@ -1,0 +1,185 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Functions that support extracting metadata from files.
+
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use super::PartitionedFile;
+use crate::datasource::listing::helpers::apply_filters;
+use datafusion_common::plan_err;
+use datafusion_common::Result;
+
+use arrow::{
+    array::{Array, StringBuilder, TimestampMicrosecondBuilder, UInt64Builder},
+    datatypes::{DataType, Field, Schema, TimeUnit},
+    record_batch::RecordBatch,
+};
+use arrow_schema::Fields;
+use datafusion_common::ScalarValue;
+use datafusion_expr::execution_props::ExecutionProps;
+
+use datafusion_common::DataFusionError;
+use datafusion_expr::Expr;
+use object_store::ObjectMeta;
+
+pub(crate) enum MetadataColumn {
+    Location,
+    LastModified,
+    Size,
+}
+
+impl fmt::Display for MetadataColumn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MetadataColumn::Location => write!(f, "location"),
+            MetadataColumn::LastModified => write!(f, "last_modified"),
+            MetadataColumn::Size => write!(f, "size"),
+        }
+    }
+}
+
+pub(crate) enum MetadataBuilder {
+    Location(StringBuilder),
+    LastModified(TimestampMicrosecondBuilder),
+    Size(UInt64Builder),
+}
+
+impl MetadataBuilder {
+    pub fn append(&mut self, meta: &ObjectMeta) {
+        match self {
+            Self::Location(builder) => builder.append_value(&meta.location),
+            Self::LastModified(builder) => {
+                builder.append_value(meta.last_modified.timestamp_micros())
+            }
+            Self::Size(builder) => builder.append_value(meta.size as u64),
+        }
+    }
+
+    pub fn finish(self) -> Arc<dyn Array> {
+        match self {
+            MetadataBuilder::Location(mut builder) => Arc::new(builder.finish()),
+            MetadataBuilder::LastModified(mut builder) => Arc::new(builder.finish()),
+            MetadataBuilder::Size(mut builder) => Arc::new(builder.finish()),
+        }
+    }
+}
+
+impl MetadataColumn {
+    pub fn arrow_type(&self) -> DataType {
+        match self {
+            MetadataColumn::Location => DataType::Utf8,
+            MetadataColumn::LastModified => {
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+            }
+            MetadataColumn::Size => DataType::UInt64,
+        }
+    }
+
+    pub fn builder(&self, capacity: usize) -> MetadataBuilder {
+        match self {
+            MetadataColumn::Location => MetadataBuilder::Location(
+                StringBuilder::with_capacity(capacity, capacity * 10),
+            ),
+            MetadataColumn::LastModified => MetadataBuilder::LastModified(
+                TimestampMicrosecondBuilder::with_capacity(capacity).with_data_type(
+                    DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                ),
+            ),
+            MetadataColumn::Size => {
+                MetadataBuilder::Size(UInt64Builder::with_capacity(capacity))
+            }
+        }
+    }
+
+    pub fn to_scalar_value(&self, meta: &ObjectMeta) -> ScalarValue {
+        match self {
+            MetadataColumn::Location => {
+                ScalarValue::Utf8(Some(meta.location.to_string()))
+            }
+            MetadataColumn::LastModified => ScalarValue::TimestampMicrosecond(
+                Some(meta.last_modified.timestamp_micros()),
+                Some("UTC".into()),
+            ),
+            MetadataColumn::Size => ScalarValue::UInt64(Some(meta.size as u64)),
+        }
+    }
+}
+
+impl FromStr for MetadataColumn {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "location" => Ok(MetadataColumn::Location),
+            "last_modified" => Ok(MetadataColumn::LastModified),
+            "size" => Ok(MetadataColumn::Size),
+            _ => plan_err!(
+                "Invalid metadata column: {}, expected: location, last_modified, or size",
+                s
+            ),
+        }
+    }
+}
+
+/// Determine if the given file matches the input metadata filters.
+/// `filters` should only contain expressions that can be evaluated
+/// using only the metadata columns.
+pub(crate) fn apply_metadata_filters(
+    file: PartitionedFile,
+    filters: &[Expr],
+    metadata_cols: &[MetadataColumn],
+) -> Result<Option<PartitionedFile>> {
+    // if no metadata col => simply return all the files
+    if metadata_cols.is_empty() {
+        return Ok(Some(file));
+    }
+
+    let mut builders: Vec<_> = metadata_cols.iter().map(|col| col.builder(1)).collect();
+
+    for builder in builders.iter_mut() {
+        builder.append(&file.object_meta);
+    }
+
+    let arrays = builders
+        .into_iter()
+        .map(|builder| builder.finish())
+        .collect::<Vec<_>>();
+
+    let fields: Fields = metadata_cols
+        .iter()
+        .map(|col| Field::new(col.to_string(), col.arrow_type(), true))
+        .collect();
+    let schema = Arc::new(Schema::new(fields));
+
+    let batch = RecordBatch::try_new(schema, arrays)?;
+
+    // TODO: Plumb this down
+    let props = ExecutionProps::new();
+
+    // Don't retain rows that evaluated to null
+    let prepared = apply_filters(&batch, filters, &props)?;
+
+    // If the filter evaluates to true, return the file
+    if prepared.true_count() == 1 {
+        return Ok(Some(file));
+    }
+
+    Ok(None)
+}

--- a/datafusion/core/src/datasource/listing/metadata.rs
+++ b/datafusion/core/src/datasource/listing/metadata.rs
@@ -52,15 +52,19 @@ pub enum MetadataColumn {
 
 impl fmt::Display for MetadataColumn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MetadataColumn::Location => write!(f, "location"),
-            MetadataColumn::LastModified => write!(f, "last_modified"),
-            MetadataColumn::Size => write!(f, "size"),
-        }
+        write!(f, "{}", self.name())
     }
 }
 
 impl MetadataColumn {
+    pub fn name(&self) -> &str {
+        match self {
+            MetadataColumn::Location => "location",
+            MetadataColumn::LastModified => "last_modified",
+            MetadataColumn::Size => "size",
+        }
+    }
+
     /// Returns the arrow type of this metadata column
     pub fn arrow_type(&self) -> DataType {
         match self {

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -19,6 +19,7 @@
 //! to get the list of files to process.
 
 mod helpers;
+mod metadata;
 mod table;
 mod url;
 

--- a/datafusion/core/src/datasource/listing/mod.rs
+++ b/datafusion/core/src/datasource/listing/mod.rs
@@ -32,6 +32,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 pub use self::url::ListingTableUrl;
+pub use metadata::MetadataColumn;
 pub use table::{ListingOptions, ListingTable, ListingTableConfig};
 
 /// Stream of files get listed from object store

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -999,6 +999,11 @@ impl TableProvider for ListingTable {
             .cloned()
             .collect();
 
+        let metadata_cols = self
+            .metadata_column_names()
+            .filter_map(|c| MetadataColumn::from_str(c).ok())
+            .collect::<Vec<_>>();
+
         // create the execution plan
         self.options
             .format
@@ -1010,7 +1015,8 @@ impl TableProvider for ListingTable {
                     .with_projection(projection.cloned())
                     .with_limit(limit)
                     .with_output_ordering(output_ordering)
-                    .with_table_partition_cols(table_partition_cols),
+                    .with_table_partition_cols(table_partition_cols)
+                    .with_metadata_cols(metadata_cols),
                 filters.as_ref(),
             )
             .await

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -862,9 +862,7 @@ impl ListingTable {
         self.options
             .table_partition_cols
             .iter()
-            .map(|col| &col.0)
-            .chain(self.options.metadata_cols.iter())
-            .map(|col| Ok(self.table_schema.field_with_name(col)?))
+            .map(|col| Ok(self.table_schema.field_with_name(&col.0)?))
             .collect::<Result<Vec<_>>>()
     }
 

--- a/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_scan_config.rs
@@ -434,6 +434,7 @@ impl ExtendedColumnProjector {
     // Create a projector to insert the partitioning/metadata columns into batches read from files
     // - `projected_schema`: the target schema with file, partitioning and metadata columns
     // - `table_partition_cols`: all the partitioning column names
+    // - `metadata_cols`: all the metadata column names
     pub fn new(
         projected_schema: SchemaRef,
         table_partition_cols: &[String],
@@ -455,8 +456,6 @@ impl ExtendedColumnProjector {
                 projected_metadata_indexes.push(schema_idx);
             }
         }
-
-        projected_metadata_indexes.sort_by(|a, b| a.cmp(b));
 
         Self {
             key_buffer_cache: Default::default(),
@@ -876,7 +875,7 @@ mod tests {
                     wrap_partition_value_in_dict(ScalarValue::from("10")),
                     wrap_partition_value_in_dict(ScalarValue::from("26")),
                 ],
-                &ObjectMeta::default(),
+                &test_object_meta(),
             )
             .expect("Projection of partition columns into record batch failed");
         let expected = [

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -27,7 +27,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::datasource::listing::PartitionedFile;
-use crate::datasource::physical_plan::file_scan_config::PartitionColumnProjector;
+use crate::datasource::physical_plan::file_scan_config::ExtendedColumnProjector;
 use crate::datasource::physical_plan::{FileMeta, FileScanConfig};
 use crate::error::Result;
 use crate::physical_plan::metrics::{
@@ -44,8 +44,7 @@ use datafusion_common::ScalarValue;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{ready, FutureExt, Stream, StreamExt};
-
-use super::file_scan_config::ExtendedColumnProjector;
+use object_store::ObjectMeta;
 
 /// A fallible future that resolves to a stream of [`RecordBatch`]
 pub type FileOpenFuture =
@@ -87,8 +86,8 @@ pub struct FileStream<F: FileOpener> {
     /// A generic [`FileOpener`]. Calling `open()` returns a [`FileOpenFuture`],
     /// which can be resolved to a stream of `RecordBatch`.
     file_opener: F,
-    /// The partition column projector
-    pc_projector: PartitionColumnProjector,
+    /// The extended (partitioning + metadata) column projector
+    col_projector: ExtendedColumnProjector,
     /// The stream state
     state: FileStreamState,
     /// File stream specific metrics
@@ -117,19 +116,23 @@ enum FileStreamState {
         future: FileOpenFuture,
         /// The partition values for this file
         partition_values: Vec<ScalarValue>,
+        /// The object metadata for this file
+        object_meta: ObjectMeta,
     },
     /// Scanning the [`BoxStream`] returned by the completion of a [`FileOpenFuture`]
     /// returned by [`FileOpener::open`]
     Scan {
         /// Partitioning column values for the current batch_iter
         partition_values: Vec<ScalarValue>,
+        /// The object metadata for the current file
+        object_meta: ObjectMeta,
         /// The reader instance
         reader: BoxStream<'static, Result<RecordBatch, ArrowError>>,
         /// A [`FileOpenFuture`] for the next file to be processed,
         /// and its corresponding partition column values, if any.
         /// This allows the next file to be opened in parallel while the
         /// current file is read.
-        next: Option<(NextOpen, Vec<ScalarValue>)>,
+        next: Option<(NextOpen, Vec<ScalarValue>, ObjectMeta)>,
     },
     /// Encountered an error
     Error,
@@ -253,13 +256,14 @@ impl<F: FileOpener> FileStream<F> {
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Self> {
         let (projected_schema, ..) = config.project();
-        let pc_projector = ExtendedColumnProjector::new(
+        let col_projector = ExtendedColumnProjector::new(
             projected_schema.clone(),
             &config
                 .table_partition_cols
                 .iter()
                 .map(|x| x.name().clone())
                 .collect::<Vec<_>>(),
+            &config.metadata_cols,
         );
 
         let files = config.file_groups[partition].clone();
@@ -269,7 +273,7 @@ impl<F: FileOpener> FileStream<F> {
             projected_schema,
             remain: config.limit,
             file_opener,
-            pc_projector,
+            col_projector,
             state: FileStreamState::Idle,
             file_stream_metrics: FileStreamMetrics::new(metrics, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -290,19 +294,21 @@ impl<F: FileOpener> FileStream<F> {
     ///
     /// Since file opening is mostly IO (and may involve a
     /// bunch of sequential IO), it can be parallelized with decoding.
-    fn start_next_file(&mut self) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>)>> {
+    fn start_next_file(
+        &mut self,
+    ) -> Option<Result<(FileOpenFuture, Vec<ScalarValue>, ObjectMeta)>> {
         let part_file = self.file_iter.pop_front()?;
 
         let file_meta = FileMeta {
-            object_meta: part_file.object_meta,
+            object_meta: part_file.object_meta.clone(),
             range: part_file.range,
             extensions: part_file.extensions,
         };
 
         Some(
-            self.file_opener
-                .open(file_meta)
-                .map(|future| (future, part_file.partition_values)),
+            self.file_opener.open(file_meta).map(|future| {
+                (future, part_file.partition_values, part_file.object_meta)
+            }),
         )
     }
 
@@ -313,10 +319,11 @@ impl<F: FileOpener> FileStream<F> {
                     self.file_stream_metrics.time_opening.start();
 
                     match self.start_next_file().transpose() {
-                        Ok(Some((future, partition_values))) => {
+                        Ok(Some((future, partition_values, object_meta))) => {
                             self.state = FileStreamState::Open {
                                 future,
                                 partition_values,
+                                object_meta,
                             }
                         }
                         Ok(None) => return Poll::Ready(None),
@@ -329,9 +336,11 @@ impl<F: FileOpener> FileStream<F> {
                 FileStreamState::Open {
                     future,
                     partition_values,
+                    object_meta,
                 } => match ready!(future.poll_unpin(cx)) {
                     Ok(reader) => {
                         let partition_values = mem::take(partition_values);
+                        let object_meta = object_meta.clone();
 
                         // include time needed to start opening in `start_next_file`
                         self.file_stream_metrics.time_opening.stop();
@@ -340,13 +349,19 @@ impl<F: FileOpener> FileStream<F> {
                         self.file_stream_metrics.time_scanning_total.start();
 
                         match next {
-                            Ok(Some((next_future, next_partition_values))) => {
+                            Ok(Some((
+                                next_future,
+                                next_partition_values,
+                                next_object_meta,
+                            ))) => {
                                 self.state = FileStreamState::Scan {
                                     partition_values,
+                                    object_meta,
                                     reader,
                                     next: Some((
                                         NextOpen::Pending(next_future),
                                         next_partition_values,
+                                        next_object_meta,
                                     )),
                                 };
                             }
@@ -354,6 +369,7 @@ impl<F: FileOpener> FileStream<F> {
                                 self.state = FileStreamState::Scan {
                                     reader,
                                     partition_values,
+                                    object_meta,
                                     next: None,
                                 };
                             }
@@ -381,9 +397,10 @@ impl<F: FileOpener> FileStream<F> {
                     reader,
                     partition_values,
                     next,
+                    object_meta,
                 } => {
                     // We need to poll the next `FileOpenFuture` here to drive it forward
-                    if let Some((next_open_future, _)) = next {
+                    if let Some((next_open_future, _, _)) = next {
                         if let NextOpen::Pending(f) = next_open_future {
                             if let Poll::Ready(reader) = f.as_mut().poll(cx) {
                                 *next_open_future = NextOpen::Ready(reader);
@@ -395,8 +412,8 @@ impl<F: FileOpener> FileStream<F> {
                             self.file_stream_metrics.time_scanning_until_data.stop();
                             self.file_stream_metrics.time_scanning_total.stop();
                             let result = self
-                                .pc_projector
-                                .project(batch, partition_values)
+                                .col_projector
+                                .project(batch, partition_values, object_meta)
                                 .map_err(|e| ArrowError::ExternalError(e.into()))
                                 .map(|batch| match &mut self.remain {
                                     Some(remain) => {
@@ -429,7 +446,7 @@ impl<F: FileOpener> FileStream<F> {
                             match self.on_error {
                                 // If `OnError::Skip` we skip the file as soon as we hit the first error
                                 OnError::Skip => match mem::take(next) {
-                                    Some((future, partition_values)) => {
+                                    Some((future, partition_values, object_meta)) => {
                                         self.file_stream_metrics.time_opening.start();
 
                                         match future {
@@ -437,6 +454,7 @@ impl<F: FileOpener> FileStream<F> {
                                                 self.state = FileStreamState::Open {
                                                     future,
                                                     partition_values,
+                                                    object_meta,
                                                 }
                                             }
                                             NextOpen::Ready(reader) => {
@@ -445,6 +463,7 @@ impl<F: FileOpener> FileStream<F> {
                                                         reader,
                                                     )),
                                                     partition_values,
+                                                    object_meta,
                                                 }
                                             }
                                         }
@@ -462,7 +481,7 @@ impl<F: FileOpener> FileStream<F> {
                             self.file_stream_metrics.time_scanning_total.stop();
 
                             match mem::take(next) {
-                                Some((future, partition_values)) => {
+                                Some((future, partition_values, object_meta)) => {
                                     self.file_stream_metrics.time_opening.start();
 
                                     match future {
@@ -470,6 +489,7 @@ impl<F: FileOpener> FileStream<F> {
                                             self.state = FileStreamState::Open {
                                                 future,
                                                 partition_values,
+                                                object_meta,
                                             }
                                         }
                                         NextOpen::Ready(reader) => {
@@ -478,6 +498,7 @@ impl<F: FileOpener> FileStream<F> {
                                                     reader,
                                                 )),
                                                 partition_values,
+                                                object_meta,
                                             }
                                         }
                                     }

--- a/datafusion/core/src/datasource/physical_plan/file_stream.rs
+++ b/datafusion/core/src/datasource/physical_plan/file_stream.rs
@@ -45,6 +45,8 @@ use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{ready, FutureExt, Stream, StreamExt};
 
+use super::file_scan_config::ExtendedColumnProjector;
+
 /// A fallible future that resolves to a stream of [`RecordBatch`]
 pub type FileOpenFuture =
     BoxFuture<'static, Result<BoxStream<'static, Result<RecordBatch, ArrowError>>>>;
@@ -251,7 +253,7 @@ impl<F: FileOpener> FileStream<F> {
         metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Self> {
         let (projected_schema, ..) = config.project();
-        let pc_projector = PartitionColumnProjector::new(
+        let pc_projector = ExtendedColumnProjector::new(
             projected_schema.clone(),
             &config
                 .table_partition_cols

--- a/datafusion/core/tests/sql/path_partition.rs
+++ b/datafusion/core/tests/sql/path_partition.rs
@@ -24,7 +24,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use arrow::datatypes::DataType;
-use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::datasource::listing::{ListingTableUrl, MetadataColumn};
 use datafusion::datasource::physical_plan::ParquetExec;
 use datafusion::{
     assert_batches_sorted_eq,
@@ -72,6 +72,7 @@ async fn parquet_partition_pruning_filter() -> Result<()> {
             ("month", DataType::Int32),
             ("day", DataType::Int32),
         ],
+        &[],
         "mirror:///",
         "alltypes_plain.parquet",
     )
@@ -574,6 +575,134 @@ async fn parquet_overlapping_columns() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_metadata_columns() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let table = create_partitioned_alltypes_parquet_table(
+        &ctx,
+        &[
+            "year=2021/month=09/day=09/file.parquet",
+            "year=2021/month=10/day=09/file.parquet",
+            "year=2021/month=10/day=28/file.parquet",
+        ],
+        &[
+            ("year", DataType::Int32),
+            ("month", DataType::Int32),
+            ("day", DataType::Int32),
+        ],
+        &[
+            MetadataColumn::Location,
+            MetadataColumn::Size,
+            MetadataColumn::LastModified,
+        ],
+        "mirror:///",
+        "alltypes_plain.parquet",
+    )
+    .await;
+
+    ctx.register_table("t", table).unwrap();
+
+    let result = ctx
+        .sql("SELECT id, size, location, last_modified FROM t WHERE size > 1500 ORDER BY id LIMIT 10")
+        .await?
+        .collect()
+        .await?;
+
+    let expected = [
+        "+----+------+----------------------------------------+----------------------+",
+        "| id | size | location                               | last_modified        |",
+        "+----+------+----------------------------------------+----------------------+",
+        "| 0  | 1851 | year=2021/month=09/day=09/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 0  | 1851 | year=2021/month=10/day=09/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 0  | 1851 | year=2021/month=10/day=28/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 1  | 1851 | year=2021/month=09/day=09/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 1  | 1851 | year=2021/month=10/day=09/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 1  | 1851 | year=2021/month=10/day=28/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 2  | 1851 | year=2021/month=09/day=09/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 2  | 1851 | year=2021/month=10/day=09/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 2  | 1851 | year=2021/month=10/day=28/file.parquet | 1970-01-01T00:00:00Z |",
+        "| 3  | 1851 | year=2021/month=10/day=28/file.parquet | 1970-01-01T00:00:00Z |",
+        "+----+------+----------------------------------------+----------------------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_metadata_columns_pushdown() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let table = create_partitioned_alltypes_parquet_table(
+        &ctx,
+        &[
+            "year=2021/month=09/day=09/file.parquet",
+            "year=2021/month=10/day=09/file.parquet",
+            "year=2021/month=10/day=28/file.parquet",
+        ],
+        &[
+            ("year", DataType::Int32),
+            ("month", DataType::Int32),
+            ("day", DataType::Int32),
+        ],
+        &[
+            MetadataColumn::Location,
+            MetadataColumn::Size,
+            MetadataColumn::LastModified,
+        ],
+        "mirror:///",
+        "alltypes_plain.parquet",
+    )
+    .await;
+
+    // The metadata filters can be resolved using only the metadata columns.
+    let filters = [
+        Expr::eq(
+            col("location"),
+            lit("year=2021/month=09/day=09/file.parquet"),
+        ),
+        Expr::gt(col("size"), lit(400u64)),
+        Expr::gt_eq(
+            col("last_modified"),
+            lit(ScalarValue::TimestampMicrosecond(
+                Some(0),
+                Some("UTC".into()),
+            )),
+        ),
+        Expr::gt(col("id"), lit(1)),
+    ];
+    let exec = table.scan(&ctx.state(), None, &filters, None).await?;
+    let parquet_exec = exec.as_any().downcast_ref::<ParquetExec>().unwrap();
+    let pred = parquet_exec.predicate().unwrap();
+    // Only the last filter should be pushdown to TableScan
+    let expected = Arc::new(BinaryExpr::new(
+        Arc::new(Column::new_with_schema("id", &exec.schema()).unwrap()),
+        Operator::Gt,
+        Arc::new(Literal::new(ScalarValue::Int32(Some(1)))),
+    ));
+
+    assert!(pred.as_any().is::<BinaryExpr>());
+    let pred = pred.as_any().downcast_ref::<BinaryExpr>().unwrap();
+
+    assert_eq!(pred, expected.as_any());
+
+    // Only the first file should be scanned
+    let scan_files = parquet_exec
+        .base_config()
+        .file_groups
+        .iter()
+        .flat_map(|x| x.iter().map(|y| y.path()).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    assert_eq!(scan_files.len(), 1);
+    assert_eq!(
+        scan_files[0].to_string(),
+        "year=2021/month=09/day=09/file.parquet"
+    );
+
+    Ok(())
+}
+
 fn register_partitioned_aggregate_csv(
     ctx: &SessionContext,
     store_paths: &[&str],
@@ -618,6 +747,7 @@ async fn register_partitioned_alltypes_parquet(
         ctx,
         store_paths,
         partition_cols,
+        &[],
         table_path,
         source_file,
     )
@@ -630,6 +760,7 @@ async fn create_partitioned_alltypes_parquet_table(
     ctx: &SessionContext,
     store_paths: &[&str],
     partition_cols: &[(&str, DataType)],
+    metadata_cols: &[MetadataColumn],
     table_path: &str,
     source_file: &str,
 ) -> Arc<dyn TableProvider> {
@@ -647,7 +778,8 @@ async fn create_partitioned_alltypes_parquet_table(
                 .iter()
                 .map(|x| (x.0.to_owned(), x.1.clone()))
                 .collect::<Vec<_>>(),
-        );
+        )
+        .with_metadata_cols(metadata_cols.to_vec());
 
     let table_path = ListingTableUrl::parse(table_path).unwrap();
     let store_path =


### PR DESCRIPTION
## Which issue does this PR close?

TBD

## Rationale for this change

This enables another way to prune files that don't need to be read, similar to partitioning, but based on the metadata of the file itself. This can be used to efficiently find all data that are in files that have changed since I last did a query, for example: `SELECT * FROM test WHERE last_modified > {last_check_time}`.

## What changes are included in this PR?

Adds a new option to the `ListingOptions` for specifying certain metadata properties. The metadata properties that are supported are `location`, `size` and `last_modified`. When those properties are included, then they are added to the table schema (similar to partition columns) and the value is filled in by looking at the `ObjectMeta` for the file.

## Are these changes tested?

Yes, added tests to `path_partition.rs`.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
