### PR TITLE
Fix ILIKE expression support in SQL unparser

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -261,32 +261,20 @@ impl Unparser<'_> {
                     uses_odbc_syntax: false,
                 }))
             }
-            Expr::Like(Like {
+            Expr::SimilarTo(Like {
                 negated,
                 expr,
                 pattern,
                 escape_char,
-                case_insensitive,
-            }) => {
-                if *case_insensitive {
-                    Ok(ast::Expr::ILike {
-                        negated: *negated,
-                        expr: Box::new(self.expr_to_sql_inner(expr)?),
-                        pattern: Box::new(self.expr_to_sql_inner(pattern)?),
-                        escape_char: escape_char.map(|c| c.to_string()),
-                        any: false,
-                    })
-                } else {
-                    Ok(ast::Expr::Like {
-                        negated: *negated,
-                        expr: Box::new(self.expr_to_sql_inner(expr)?),
-                        pattern: Box::new(self.expr_to_sql_inner(pattern)?),
-                        escape_char: escape_char.map(|c| c.to_string()),
-                        any: false,
-                    })
-                }
-            }
-            Expr::SimilarTo(Like {
+                case_insensitive: _,
+            }) => Ok(ast::Expr::Like {
+                negated: *negated,
+                expr: Box::new(self.expr_to_sql_inner(expr)?),
+                pattern: Box::new(self.expr_to_sql_inner(pattern)?),
+                escape_char: escape_char.map(|c| c.to_string()),
+                any: false,
+            }),
+            Expr::Like(Like {
                 negated,
                 expr,
                 pattern,
@@ -1833,16 +1821,6 @@ mod tests {
                 r#"a NOT LIKE 'foo' ESCAPE 'o'"#,
             ),
             (
-                Expr::SimilarTo(Like {
-                    negated: false,
-                    expr: Box::new(col("a")),
-                    pattern: Box::new(lit("foo")),
-                    escape_char: Some('o'),
-                    case_insensitive: false,
-                }),
-                r#"a LIKE 'foo' ESCAPE 'o'"#,
-            ),
-            (
                 Expr::Like(Like {
                     negated: true,
                     expr: Box::new(col("a")),
@@ -1858,9 +1836,19 @@ mod tests {
                     expr: Box::new(col("a")),
                     pattern: Box::new(lit("foo")),
                     escape_char: Some('o'),
+                    case_insensitive: false,
+                }),
+                r#"a LIKE 'foo' ESCAPE 'o'"#,
+            ),
+            (
+                Expr::SimilarTo(Like {
+                    negated: false,
+                    expr: Box::new(col("a")),
+                    pattern: Box::new(lit("foo")),
+                    escape_char: Some('o'),
                     case_insensitive: true,
                 }),
-                r#"a ILIKE 'foo' ESCAPE 'o'"#,
+                r#"a LIKE 'foo' ESCAPE 'o'"#,
             ),
             (
                 Expr::Literal(ScalarValue::Date64(Some(0))),

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1558,6 +1558,24 @@ fn test_like_filters() {
         r#"SELECT * FROM person WHERE first_name NOT ILIKE 'a%'"#,
         r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'a%'"#,
     );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name LIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT * FROM person WHERE person.first_name LIKE 'A!_%' ESCAPE '!'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT LIKE 'A!_%' ESCAPE '!'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'A!_%' ESCAPE '!'"#,
+    );
 }
 
 #[test]

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1534,6 +1534,33 @@ fn test_unnest_to_sql() {
 }
 
 #[test]
+fn test_like_filters() {
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name LIKE '%John%'"#,
+        r#"SELECT * FROM person WHERE person.first_name LIKE '%John%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name ILIKE '%john%'"#,
+        r#"SELECT * FROM person WHERE person.first_name ILIKE '%john%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT LIKE 'A%'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT LIKE 'A%'"#,
+    );
+
+    sql_round_trip(
+        GenericDialect {},
+        r#"SELECT * FROM person WHERE first_name NOT ILIKE 'a%'"#,
+        r#"SELECT * FROM person WHERE person.first_name NOT ILIKE 'a%'"#,
+    );
+}
+
+#[test]
 fn test_join_with_no_conditions() {
     sql_round_trip(
         GenericDialect {},


### PR DESCRIPTION
## Which issue does this PR close?

SQL Unparser incorrectly handles `ILIKE` expressions, handling all as `LIKE`, ignoring `case_insensitive` flag.

## Rationale for this change

Case sensitivity shouldn't be ignored in `ILIKE` expressions, as it's a part of the SQL standard.

## What changes are included in this PR?

Added correct handling for `case_insensitive` flag in `ILIKE` expressions in SQL unparser

## Are these changes tested?

Yes, covered by additional SQL roundtrip test in plan_to_sql, fixed and extended expressions tests for LIKE/ILIKE.

## Are there any user-facing changes?

No
