### PR TITLE
Infer placeholder datatype for `Expr::InSubquery`

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1623,6 +1623,25 @@ impl Expr {
                 | Expr::SimilarTo(Like { expr, pattern, .. }) => {
                     rewrite_placeholder(pattern.as_mut(), expr.as_ref(), schema)?;
                 }
+                Expr::InSubquery(InSubquery {
+                    expr,
+                    subquery,
+                    negated: _,
+                }) => {
+                    let subquery_schema = subquery.subquery.schema();
+                    // using first field of subquery schema since `IN`
+                    // subqueries typically return a single column
+                    if let Some(first_field) = subquery_schema.fields().first() {
+                        rewrite_placeholder(
+                            expr.as_mut(),
+                            &Expr::Column(Column {
+                                relation: None,
+                                name: first_field.name().clone(),
+                            }),
+                            schema,
+                        )?;
+                    }
+                }
                 Expr::Placeholder(_) => {
                     has_placeholder = true;
                 }
@@ -2801,7 +2820,8 @@ mod test {
     use crate::expr_fn::col;
     use crate::{
         case, lit, qualified_wildcard, wildcard, wildcard_with_options, ColumnarValue,
-        ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Volatility,
+        LogicalPlan, LogicalTableSource, Projection, ScalarFunctionArgs, ScalarUDF,
+        ScalarUDFImpl, TableScan, Volatility,
     };
     use arrow::datatypes::{Field, Schema};
     use sqlparser::ast;
@@ -2861,6 +2881,82 @@ mod test {
             }
             _ => panic!("Expected InList expression"),
         }
+    }
+
+    #[test]
+    fn infer_placeholder_in_subquery() -> Result<()> {
+        // Schema for my_table: A (Int32), B (Int32)
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("A", DataType::Int32, true),
+            Field::new("B", DataType::Int32, true),
+        ]));
+
+        let source = Arc::new(LogicalTableSource::new(schema.clone()));
+
+        // Simulate: SELECT * FROM my_table WHERE $1 IN (SELECT A FROM my_table WHERE B > 3);
+        let placeholder = Expr::Placeholder(Placeholder {
+            id: "$1".to_string(),
+            data_type: None,
+        });
+
+        // Subquery: SELECT A FROM my_table WHERE B > 3
+        let subquery_filter = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(col("B")),
+            op: Operator::Gt,
+            right: Box::new(Expr::Literal(ScalarValue::Int32(Some(3)))),
+        });
+
+        let subquery_scan = LogicalPlan::TableScan(TableScan {
+            table_name: TableReference::from("my_table"),
+            source,
+            projected_schema: Arc::new(DFSchema::try_from(schema.clone())?),
+            projection: None,
+            filters: vec![subquery_filter.clone()],
+            fetch: None,
+        });
+
+        let subquery = Subquery {
+            subquery: Arc::new(LogicalPlan::Projection(Projection {
+                expr: vec![col("A")],
+                input: Arc::new(subquery_scan),
+                schema: Arc::new(DFSchema::try_from_qualified_schema(
+                    "my_table", &schema,
+                )?),
+            })),
+            outer_ref_columns: vec![],
+        };
+
+        let in_subquery = Expr::InSubquery(InSubquery {
+            expr: Box::new(placeholder),
+            subquery,
+            negated: false,
+        });
+
+        let df_schema = DFSchema::try_from(schema)?;
+
+        let (inferred_expr, contains_placeholder) =
+            in_subquery.infer_placeholder_types(&df_schema)?;
+
+        assert!(
+            contains_placeholder,
+            "Expression should contain a placeholder"
+        );
+
+        match inferred_expr {
+            Expr::InSubquery(in_subquery) => match *in_subquery.expr {
+                Expr::Placeholder(placeholder) => {
+                    assert_eq!(
+                        placeholder.data_type,
+                        Some(DataType::Int32),
+                        "Placeholder $1 should infer Int32"
+                    );
+                }
+                _ => panic!("Expected Placeholder expression in InSubquery"),
+            },
+            _ => panic!("Expected InSubquery expression"),
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1629,8 +1629,7 @@ impl Expr {
                     negated: _,
                 }) => {
                     let subquery_schema = subquery.subquery.schema();
-                    // using first field of subquery schema since `IN`
-                    // subqueries typically return a single column
+                    // Using the datatype of the first field in the subquery
                     if let Some(first_field) = subquery_schema.fields().first() {
                         rewrite_placeholder(
                             expr.as_mut(),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/spiceai/spiceai/issues/5671

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Cannot currently use prepared statements from certain Flight clients when placeholders are used with `$1 IN (<subquery>)`

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

You should be able to execute queries like, `SELECT * FROM my_table WHERE $1 IN (SELECT A FROM my_table WHERE B > 3);`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, users have additional ability to use placeholders in prepared statements.
