### PR TITLE
Infer placeholder datatype after `LIMIT` clause as `DataType::Int64`

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1482,6 +1482,16 @@ impl LogicalPlan {
         let mut param_types: HashMap<String, Option<DataType>> = HashMap::new();
 
         self.apply_with_subqueries(|plan| {
+            if let LogicalPlan::Limit(Limit { fetch: Some(e), .. }) = plan {
+                if let Expr::Placeholder(Placeholder { id, data_type }) = &**e {
+                    if data_type.is_none() {
+                        // Hardcode to Int64 for LIMIT placeholders
+                        param_types.insert(id.clone(), Some(DataType::Int64));
+                    } else {
+                        param_types.insert(id.clone(), data_type.clone());
+                    }
+                }
+            }
             plan.apply_expressions(|expr| {
                 expr.apply(|expr| {
                     if let Expr::Placeholder(Placeholder { id, data_type }) = expr {
@@ -1494,6 +1504,9 @@ impl LogicalPlan {
                             }
                             (_, Some(dt)) => {
                                 param_types.insert(id.clone(), Some(dt.clone()));
+                            }
+                            (Some(Some(_)), None) => {
+                                // we have already inferred the datatype
                             }
                             _ => {
                                 param_types.insert(id.clone(), None);
@@ -4468,5 +4481,38 @@ digraph {
 
         let parameter_type = params.clone().get(placeholder_value).unwrap().clone();
         assert_eq!(parameter_type, None);
+    }
+
+    #[test]
+    fn test_resolved_placeholder_limit() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("A", DataType::Int32, true)]));
+        let source = Arc::new(LogicalTableSource::new(schema.clone()));
+
+        let placeholder_value = "$1";
+
+        // SELECT * FROM my_table LIMIT $1
+        let plan = LogicalPlan::Limit(Limit {
+            skip: None,
+            fetch: Some(Box::new(Expr::Placeholder(Placeholder {
+                id: placeholder_value.to_string(),
+                data_type: None,
+            }))),
+            input: Arc::new(LogicalPlan::TableScan(TableScan {
+                table_name: TableReference::from("my_table"),
+                source,
+                projected_schema: Arc::new(DFSchema::try_from(schema.clone())?),
+                projection: None,
+                filters: vec![],
+                fetch: None,
+            })),
+        });
+
+        let params = plan.get_parameter_types().unwrap();
+        assert_eq!(params.len(), 1);
+
+        let parameter_type = params.clone().get(placeholder_value).unwrap().clone();
+        assert_eq!(parameter_type, Some(DataType::Int64));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Placeholders after the `LIMIT` clause in SQL queries are now inferred as `DataType::Int64`, which follows the SQL standard and conventions in [Postgres](https://www.postgresql.org/docs/current/sql-select.html#SQL-LIMIT).