### PR TITLE
fix: unparsing left/ right semi/mark join

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run tests (excluding doctests)
         env:
           RUST_BACKTRACE: 1
-        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests
+        run: cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests,recursive_protection
       - name: Verify Working Directory Clean
         run: git diff --exit-code
       - name: Cleanup

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use core::fmt;
+use std::ops::ControlFlow;
 
-use sqlparser::ast;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
+use sqlparser::ast::{self, visit_expressions_mut};
 
 #[derive(Clone)]
 pub struct QueryBuilder {
@@ -192,6 +193,37 @@ impl SelectBuilder {
         self.lateral_views = value;
         self
     }
+
+    /// Replaces the selection with a new value.
+    ///
+    /// This function is used to replace a specific expression within the selection.
+    /// Unlike the `selection` method which combines existing and new selections with AND,
+    /// this method searches for and replaces occurrences of a specific expression.
+    ///
+    /// This method is primarily used to modify LEFT MARK JOIN expressions.
+    /// When processing a LEFT MARK JOIN, we need to replace the placeholder expression
+    /// with the actual join condition in the selection clause.
+    ///
+    /// # Arguments
+    ///
+    /// * `existing_expr` - The expression to replace
+    /// * `value` - The new expression to set as the selection
+    pub fn replace_mark(
+        &mut self,
+        existing_expr: &ast::Expr,
+        value: &ast::Expr,
+    ) -> &mut Self {
+        if let Some(selection) = &mut self.selection {
+            visit_expressions_mut(selection, |expr| {
+                if expr == existing_expr {
+                    *expr = value.clone();
+                }
+                ControlFlow::<()>::Continue(())
+            });
+        }
+        self
+    }
+
     pub fn selection(&mut self, value: Option<ast::Expr>) -> &mut Self {
         // With filter pushdown optimization, the LogicalPlan can have filters defined as part of `TableScan` and `Filter` nodes.
         // To avoid overwriting one of the filters, we combine the existing filter with the additional filter.

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -94,6 +94,7 @@ impl Unparser<'_> {
         Ok(root_expr)
     }
 
+    #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
     fn expr_to_sql_inner(&self, expr: &Expr) -> Result<ast::Expr> {
         match expr {
             Expr::InList(InList {
@@ -693,7 +694,7 @@ impl Unparser<'_> {
         }
     }
 
-    fn col_to_sql(&self, col: &Column) -> Result<ast::Expr> {
+    pub fn col_to_sql(&self, col: &Column) -> Result<ast::Expr> {
         if let Some(table_ref) = &col.relation {
             let mut id = if self.dialect.full_qualified_col() {
                 table_ref.to_vec()

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -381,6 +381,7 @@ impl Unparser<'_> {
         }
     }
 
+    #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
     fn select_to_sql_recursively(
         &self,
         plan: &LogicalPlan,
@@ -642,14 +643,20 @@ impl Unparser<'_> {
             }
             LogicalPlan::Join(join) => {
                 let mut table_scan_filters = vec![];
+                let (left_plan, right_plan) = match join.join_type {
+                    JoinType::RightSemi | JoinType::RightAnti => {
+                        (&join.right, &join.left)
+                    }
+                    _ => (&join.left, &join.right),
+                };
 
                 let left_plan =
-                    match try_transform_to_simple_table_scan_with_filters(&join.left)? {
+                    match try_transform_to_simple_table_scan_with_filters(left_plan)? {
                         Some((plan, filters)) => {
                             table_scan_filters.extend(filters);
                             Arc::new(plan)
                         }
-                        None => Arc::clone(&join.left),
+                        None => Arc::clone(left_plan),
                     };
 
                 self.select_to_sql_recursively(
@@ -660,12 +667,12 @@ impl Unparser<'_> {
                 )?;
 
                 let right_plan =
-                    match try_transform_to_simple_table_scan_with_filters(&join.right)? {
+                    match try_transform_to_simple_table_scan_with_filters(right_plan)? {
                         Some((plan, filters)) => {
                             table_scan_filters.extend(filters);
                             Arc::new(plan)
                         }
-                        None => Arc::clone(&join.right),
+                        None => Arc::clone(right_plan),
                     };
 
                 let mut right_relation = RelationBuilder::default();
@@ -717,19 +724,70 @@ impl Unparser<'_> {
                     &mut right_relation,
                 )?;
 
-                let Ok(Some(relation)) = right_relation.build() else {
-                    return internal_err!("Failed to build right relation");
-                };
+                match join.join_type {
+                    JoinType::LeftSemi
+                    | JoinType::LeftAnti
+                    | JoinType::LeftMark
+                    | JoinType::RightSemi
+                    | JoinType::RightAnti => {
+                        let mut query_builder = QueryBuilder::default();
+                        let mut from = TableWithJoinsBuilder::default();
+                        let mut exists_select: SelectBuilder = SelectBuilder::default();
+                        from.relation(right_relation);
+                        exists_select.push_from(from);
+                        if let Some(filter) = &join.filter {
+                            exists_select.selection(Some(self.expr_to_sql(filter)?));
+                        }
+                        for (left, right) in &join.on {
+                            exists_select.selection(Some(
+                                self.expr_to_sql(&left.clone().eq(right.clone()))?,
+                            ));
+                        }
+                        exists_select.projection(vec![ast::SelectItem::UnnamedExpr(
+                            ast::Expr::Value(ast::Value::Number("1".to_string(), false)),
+                        )]);
+                        query_builder.body(Box::new(SetExpr::Select(Box::new(
+                            exists_select.build()?,
+                        ))));
 
-                let ast_join = ast::Join {
-                    relation,
-                    global: false,
-                    join_operator: self
-                        .join_operator_to_sql(join.join_type, join_constraint)?,
+                        let negated = match join.join_type {
+                            JoinType::LeftSemi
+                            | JoinType::RightSemi
+                            | JoinType::LeftMark => false,
+                            JoinType::LeftAnti | JoinType::RightAnti => true,
+                            _ => unreachable!(),
+                        };
+                        let exists_expr = ast::Expr::Exists {
+                            subquery: Box::new(query_builder.build()?),
+                            negated,
+                        };
+                        if join.join_type == JoinType::LeftMark {
+                            let (table_ref, _) = right_plan.schema().qualified_field(0);
+                            let column = self
+                                .col_to_sql(&Column::new(table_ref.cloned(), "mark"))?;
+                            select.replace_mark(&column, &exists_expr);
+                        } else {
+                            select.selection(Some(exists_expr));
+                        }
+                    }
+                    JoinType::Inner
+                    | JoinType::Left
+                    | JoinType::Right
+                    | JoinType::Full => {
+                        let Ok(Some(relation)) = right_relation.build() else {
+                            return internal_err!("Failed to build right relation");
+                        };
+                        let ast_join = ast::Join {
+                            relation,
+                            global: false,
+                            join_operator: self
+                                .join_operator_to_sql(join.join_type, join_constraint)?,
+                        };
+                        let mut from = select.pop_from().unwrap();
+                        from.push_join(ast_join);
+                        select.push_from(from);
+                    }
                 };
-                let mut from = select.pop_from().unwrap();
-                from.push_join(ast_join);
-                select.push_from(from);
 
                 Ok(())
             }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -16,7 +16,9 @@
 // under the License.
 
 use arrow::datatypes::{DataType, Field, Schema};
-use datafusion_common::{assert_contains, DFSchema, DFSchemaRef, Result, TableReference};
+use datafusion_common::{
+    assert_contains, Column, DFSchema, DFSchemaRef, Result, TableReference,
+};
 use datafusion_expr::test::function_stub::{
     count_udaf, max_udaf, min_udaf, sum, sum_udaf,
 };
@@ -32,7 +34,8 @@ use datafusion_functions_window::rank::rank_udwf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     CustomDialectBuilder, DefaultDialect as UnparserDefaultDialect, DefaultDialect,
-    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect, SqliteDialect,
+    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect,
+    PostgreSqlDialect as UnparserPostgreSqlDialect, SqliteDialect,
 };
 use datafusion_sql::unparser::{expr_to_sql, plan_to_sql, Unparser};
 use sqlparser::ast::Statement;
@@ -42,7 +45,7 @@ use std::{fmt, vec};
 
 use crate::common::{MockContextProvider, MockSessionState};
 use datafusion_expr::builder::{
-    project, table_scan_with_filter_and_fetch, table_scan_with_filters,
+    project, subquery_alias, table_scan_with_filter_and_fetch, table_scan_with_filters,
 };
 use datafusion_functions::core::planner::CoreFunctionPlanner;
 use datafusion_functions_nested::extract::array_element_udf;
@@ -1811,5 +1814,232 @@ fn test_unparse_optimized_multi_union() -> Result<()> {
         panic!("Expected error")
     }
 
+    Ok(())
+}
+
+/// Test unparse the optimized plan from the following SQL:
+/// ```
+/// SELECT
+///   customer_view.c_custkey,
+///   customer_view.c_name,
+///   customer_view.custkey_plus
+/// FROM
+///   (
+///     SELECT
+///       customer.c_custkey,
+///       customer.c_name,
+///       customer.custkey_plus
+///     FROM
+///       (
+///         SELECT
+///           customer.c_custkey,
+///           CAST(customer.c_custkey AS BIGINT) + 1 AS custkey_plus,
+///           customer.c_name
+///         FROM
+///           (
+///             SELECT
+///               customer.c_custkey AS c_custkey,
+///               customer.c_name AS c_name
+///             FROM
+///               customer
+///           ) AS customer
+///       ) AS customer
+///   ) AS customer_view
+/// ```
+#[test]
+fn test_unparse_subquery_alias_with_table_pushdown() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("c_custkey", DataType::Int32, false),
+        Field::new("c_name", DataType::Utf8, false),
+    ]);
+
+    let table_scan = table_scan(Some("customer"), &schema, Some(vec![0, 1]))?.build()?;
+
+    let plan = LogicalPlanBuilder::from(table_scan)
+        .alias("customer")?
+        .project(vec![
+            col("customer.c_custkey"),
+            cast(col("customer.c_custkey"), DataType::Int64)
+                .add(lit(1))
+                .alias("custkey_plus"),
+            col("customer.c_name"),
+        ])?
+        .alias("customer")?
+        .project(vec![
+            col("customer.c_custkey"),
+            col("customer.c_name"),
+            col("customer.custkey_plus"),
+        ])?
+        .alias("customer_view")?
+        .build()?;
+
+    let unparser = Unparser::default();
+    let sql = unparser.plan_to_sql(&plan)?;
+    let expected = "SELECT customer_view.c_custkey, customer_view.c_name, customer_view.custkey_plus FROM (SELECT customer.c_custkey, (CAST(customer.c_custkey AS BIGINT) + 1) AS custkey_plus, customer.c_name FROM (SELECT customer.c_custkey, customer.c_name FROM customer AS customer) AS customer) AS customer_view";
+    assert_eq!(sql.to_string(), expected);
+    Ok(())
+}
+
+#[test]
+fn test_unparse_left_anti_join() -> Result<()> {
+    // select t1.d from t1 where c not in (select c from t2)
+    let schema = Schema::new(vec![
+        Field::new("c", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ]);
+
+    // LeftAnti Join: t1.c = __correlated_sq_1.c
+    //   TableScan: t1 projection=[c]
+    //   SubqueryAlias: __correlated_sq_1
+    //     TableScan: t2 projection=[c]
+
+    let table_scan1 = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let table_scan2 = table_scan(Some("t2"), &schema, Some(vec![0]))?.build()?;
+    let subquery = subquery_alias(table_scan2, "__correlated_sq_1")?;
+    let plan = LogicalPlanBuilder::from(table_scan1)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            subquery,
+            datafusion_expr::JoinType::LeftAnti,
+            vec![col("t1.c").eq(col("__correlated_sq_1.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?;
+    assert_eq!("SELECT \"t1\".\"d\" FROM \"t1\" WHERE NOT EXISTS (SELECT 1 FROM \"t2\" AS \"__correlated_sq_1\" WHERE (\"t1\".\"c\" = \"__correlated_sq_1\".\"c\"))", sql.to_string());
+    Ok(())
+}
+
+#[test]
+fn test_unparse_left_semi_join() -> Result<()> {
+    // select t1.d from t1 where c in (select c from t2)
+    let schema = Schema::new(vec![
+        Field::new("c", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ]);
+
+    // LeftSemi Join: t1.c = __correlated_sq_1.c
+    //   TableScan: t1 projection=[c]
+    //   SubqueryAlias: __correlated_sq_1
+    //     TableScan: t2 projection=[c]
+
+    let table_scan1 = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let table_scan2 = table_scan(Some("t2"), &schema, Some(vec![0]))?.build()?;
+    let subquery = subquery_alias(table_scan2, "__correlated_sq_1")?;
+    let plan = LogicalPlanBuilder::from(table_scan1)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            subquery,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("__correlated_sq_1.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?;
+    assert_eq!("SELECT \"t1\".\"d\" FROM \"t1\" WHERE EXISTS (SELECT 1 FROM \"t2\" AS \"__correlated_sq_1\" WHERE (\"t1\".\"c\" = \"__correlated_sq_1\".\"c\"))", sql.to_string());
+    Ok(())
+}
+
+#[test]
+fn test_unparse_left_mark_join() -> Result<()> {
+    // select t1.d from t1 where t1.d < 0 OR exists (select 1 from t2 where t1.c = t2.c)
+    let schema = Schema::new(vec![
+        Field::new("c", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ]);
+    // Filter: __correlated_sq_1.mark OR t1.d < Int32(0)
+    //   Projection: t1.d
+    //     LeftMark Join:  Filter: t1.c = __correlated_sq_1.c
+    //       TableScan: t1 projection=[c, d]
+    //       SubqueryAlias: __correlated_sq_1
+    //         TableScan: t2 projection=[c]
+    let table_scan1 = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let table_scan2 = table_scan(Some("t2"), &schema, Some(vec![0]))?.build()?;
+    let subquery = subquery_alias(table_scan2, "__correlated_sq_1")?;
+    let plan = LogicalPlanBuilder::from(table_scan1)
+        .join_on(
+            subquery,
+            datafusion_expr::JoinType::LeftMark,
+            vec![col("t1.c").eq(col("__correlated_sq_1.c"))],
+        )?
+        .project(vec![col("t1.d")])?
+        .filter(col("mark").or(col("t1.d").lt(lit(0))))?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?;
+    assert_eq!("SELECT \"t1\".\"d\" FROM \"t1\" WHERE (EXISTS (SELECT 1 FROM \"t2\" AS \"__correlated_sq_1\" WHERE (\"t1\".\"c\" = \"__correlated_sq_1\".\"c\")) OR (\"t1\".\"d\" < 0))", sql.to_string());
+    Ok(())
+}
+
+#[test]
+fn test_unparse_right_semi_join() -> Result<()> {
+    // select t2.c, t2.d from t1 right semi join t2 on t1.c = t2.c where t2.c <= 1
+    let schema = Schema::new(vec![
+        Field::new("c", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ]);
+    // Filter: t2.c <= Int64(1)
+    //   RightSemi Join: t1.c = t2.c
+    //     TableScan: t1 projection=[c, d]
+    //     Projection: t2.c, t2.d
+    //       TableScan: t2 projection=[c, d]
+    let left = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let right_table_scan = table_scan(Some("t2"), &schema, Some(vec![0, 1]))?.build()?;
+    let right = LogicalPlanBuilder::from(right_table_scan)
+        .project(vec![col("c"), col("d")])?
+        .build()?;
+    let plan = LogicalPlanBuilder::from(left)
+        .join(
+            right,
+            datafusion_expr::JoinType::RightSemi,
+            (
+                vec![Column::from_qualified_name("t1.c")],
+                vec![Column::from_qualified_name("t2.c")],
+            ),
+            None,
+        )?
+        .filter(col("t2.c").lt_eq(lit(1i64)))?
+        .build()?;
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?;
+    assert_eq!("SELECT \"t2\".\"c\", \"t2\".\"d\" FROM \"t2\" WHERE (\"t2\".\"c\" <= 1) AND EXISTS (SELECT 1 FROM \"t1\" WHERE (\"t1\".\"c\" = \"t2\".\"c\"))", sql.to_string());
+    Ok(())
+}
+
+#[test]
+fn test_unparse_right_anti_join() -> Result<()> {
+    // select t2.c, t2.d from t1 right anti join t2 on t1.c = t2.c where t2.c <= 1
+    let schema = Schema::new(vec![
+        Field::new("c", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ]);
+    // Filter: t2.c <= Int64(1)
+    //   RightAnti Join: t1.c = t2.c
+    //     TableScan: t1 projection=[c, d]
+    //     Projection: t2.c, t2.d
+    //       TableScan: t2 projection=[c, d]
+    let left = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let right_table_scan = table_scan(Some("t2"), &schema, Some(vec![0, 1]))?.build()?;
+    let right = LogicalPlanBuilder::from(right_table_scan)
+        .project(vec![col("c"), col("d")])?
+        .build()?;
+    let plan = LogicalPlanBuilder::from(left)
+        .join(
+            right,
+            datafusion_expr::JoinType::RightAnti,
+            (
+                vec![Column::from_qualified_name("t1.c")],
+                vec![Column::from_qualified_name("t2.c")],
+            ),
+            None,
+        )?
+        .filter(col("t2.c").lt_eq(lit(1i64)))?
+        .build()?;
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?;
+    assert_eq!("SELECT \"t2\".\"c\", \"t2\".\"d\" FROM \"t2\" WHERE (\"t2\".\"c\" <= 1) AND NOT EXISTS (SELECT 1 FROM \"t1\" WHERE (\"t1\".\"c\" = \"t2\".\"c\"))", sql.to_string());
     Ok(())
 }


### PR DESCRIPTION
Cherry pick https://github.com/apache/datafusion/pull/15212. This PR fixes the unparse of left / right semi/mark join and unlock tpcds q8 / q38/ q87 for federated database. However the unparsed query for q38 / q87 still remains wrong and I'll address that in an incremental pr.

## Which issue does this PR close?

- Part of: https://github.com/spiceai/spiceai/issues/4668
- Part of: https://github.com/spiceai/spiceai/issues/4667

- Note: To fully enable q8 / q38/ q87 for federated engine, it requires another datafusion federation change: https://github.com/spiceai/datafusion-federation/pull/47

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
