### PR TITLE
Use UDTF name in logical plan table scan

### DIFF
--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -66,7 +66,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         .get_table_function_source(&tbl_func_name, args)?;
                     let plan = LogicalPlanBuilder::scan(
                         TableReference::Bare {
-                            table: "tmp_table".into(),
+                            table: format!("{tbl_func_name}()").into(),
                         },
                         provider,
                         None,


### PR DESCRIPTION
## Rationale for this change
Currently, the logical plan for all UDTFs is a table scan with fixed table name `tmp_table`. For example:
```
+---------------+----------------------------------------------------------------+
| plan_type     | plan                                                           |
+---------------+----------------------------------------------------------------+
| logical_plan  | Limit: skip=0, fetch=4                                         |
|               |   BytesProcessedNode                                           |
|               |     TableScan: tmp_table projection=[location, score], fetch=4 |
+---------------+----------------------------------------------------------------+
```

This hinders the ability to define `AnalyzerRule`s via the tree node API that look for a given UDTF. This PR changes the static name `tmp_table` to the UDTF's name. 

```
+---------------+----------------------------------------------------------------+
| plan_type     | plan                                                           |
+---------------+----------------------------------------------------------------+
| logical_plan  | Limit: skip=0, fetch=4                                         |
|               |   BytesProcessedNode                                           |
|               |     TableScan: my_udtf() projection=[location, score], fetch=4 |
+---------------+----------------------------------------------------------------+
```

The reasoning for the `()` suffix is to distinguish UDTFs from table with the same name.