### PR TITLE
Custom timestamp format for DuckDB

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -207,16 +207,6 @@ pub trait Dialect: Send + Sync {
             TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f %:z",
         }
     }
-
-    /// The format string to use for unparsing naive timestamps (without time zone information).
-    fn naive_timestamp_format_for_unit(&self, unit: TimeUnit) -> &str {
-        match unit {
-            TimeUnit::Second => "%Y-%m-%d %H:%M:%S",
-            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f",
-            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f",
-            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f",
-        }
-    }
 }
 
 /// `IntervalStyle` to use for unparsing

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -197,6 +197,28 @@ pub trait Dialect: Send + Sync {
     fn unnest_as_table_factor(&self) -> bool {
         false
     }
+
+    /// The format string to use for unparsing timestamps with time zone information.
+    /// Most dialects use "%Y-%m-%d %H:%M:%S %:z" to represent timestamps with time zone offset.
+    fn timestamp_with_tz_format_for_unit(&self, unit: TimeUnit) -> &str {
+        match unit {
+            TimeUnit::Second => "%Y-%m-%d %H:%M:%S %:z",
+            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f %:z",
+            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f %:z",
+            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f %:z",
+        }
+    }
+
+    /// The format string to use for unparsing naive timestamps (without time zone information).
+    /// Most dialects use "%Y-%m-%d %H:%M:%S" to represent timestamps without time zone.
+    fn naive_timestamp_format_for_unit(&self, unit: TimeUnit) -> &str {
+        match unit {
+            TimeUnit::Second => "%Y-%m-%d %H:%M:%S",
+            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f",
+            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f",
+            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f",
+        }
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -393,6 +415,15 @@ impl Dialect for DuckDBDialect {
         }
 
         Ok(None)
+    }
+
+    fn timestamp_with_tz_format_for_unit(&self, unit: TimeUnit) -> &str {
+        match unit {
+            TimeUnit::Second => "%Y-%m-%d %H:%M:%S%:z",
+            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f%:z",
+            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f%:z",
+            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f%:z",
+        }
     }
 }
 

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -199,7 +199,6 @@ pub trait Dialect: Send + Sync {
     }
 
     /// The format string to use for unparsing timestamps with time zone information.
-    /// Most dialects use "%Y-%m-%d %H:%M:%S %:z" to represent timestamps with time zone offset.
     fn timestamp_with_tz_format_for_unit(&self, unit: TimeUnit) -> &str {
         match unit {
             TimeUnit::Second => "%Y-%m-%d %H:%M:%S %:z",
@@ -210,7 +209,6 @@ pub trait Dialect: Send + Sync {
     }
 
     /// The format string to use for unparsing naive timestamps (without time zone information).
-    /// Most dialects use "%Y-%m-%d %H:%M:%S" to represent timestamps without time zone.
     fn naive_timestamp_format_for_unit(&self, unit: TimeUnit) -> &str {
         match unit {
             TimeUnit::Second => "%Y-%m-%d %H:%M:%S",

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -3155,17 +3155,17 @@ mod tests {
                 Arc::clone(&default_dialect),
                 ScalarValue::TimestampMillisecond(
                     Some(1757934000123),
-                    Some("+00:00".into()),
+                    Some("+01:00".into()),
                 ),
-                "CAST('2025-09-15 11:00:00.123 +00:00' AS TIMESTAMP)",
+                "CAST('2025-09-15 12:00:00.123 +01:00' AS TIMESTAMP)",
             ),
             (
                 Arc::clone(&default_dialect),
                 ScalarValue::TimestampMicrosecond(
                     Some(1757934000123456),
-                    Some("+00:00".into()),
+                    Some("-01:00".into()),
                 ),
-                "CAST('2025-09-15 11:00:00.123456 +00:00' AS TIMESTAMP)",
+                "CAST('2025-09-15 10:00:00.123456 -01:00' AS TIMESTAMP)",
             ),
             (
                 Arc::clone(&default_dialect),
@@ -3187,17 +3187,17 @@ mod tests {
                 Arc::clone(&duckdb_dialect),
                 ScalarValue::TimestampMillisecond(
                     Some(1757934000123),
-                    Some("+00:00".into()),
+                    Some("+01:00".into()),
                 ),
-                "CAST('2025-09-15 11:00:00.123+00:00' AS TIMESTAMP)",
+                "CAST('2025-09-15 12:00:00.123+01:00' AS TIMESTAMP)",
             ),
             (
                 Arc::clone(&duckdb_dialect),
                 ScalarValue::TimestampMicrosecond(
                     Some(1757934000123456),
-                    Some("+00:00".into()),
+                    Some("-01:00".into()),
                 ),
-                "CAST('2025-09-15 11:00:00.123456+00:00' AS TIMESTAMP)",
+                "CAST('2025-09-15 10:00:00.123456-01:00' AS TIMESTAMP)",
             ),
             (
                 Arc::clone(&duckdb_dialect),

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -3140,27 +3140,77 @@ mod tests {
         let default_dialect: Arc<dyn Dialect> =
             Arc::new(CustomDialectBuilder::new().build());
 
-        let duckdb_default: Arc<dyn Dialect> = Arc::new(DuckDBDialect::new());
+        let duckdb_dialect: Arc<dyn Dialect> = Arc::new(DuckDBDialect::new());
 
-        for (dialect, expected) in [
+        for (dialect, scalar, expected) in [
             (
-                default_dialect,
-                "CAST('2025-09-15 11:00:00.000 +00:00' AS TIMESTAMP)",
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampSecond(
+                    Some(1757934000),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00 +00:00' AS TIMESTAMP)",
             ),
             (
-                duckdb_default,
-                "CAST('2025-09-15 11:00:00.000+00:00' AS TIMESTAMP)",
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampMillisecond(
+                    Some(1757934000123),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123 +00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampMicrosecond(
+                    Some(1757934000123456),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123456 +00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampNanosecond(
+                    Some(1757934000123456789),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123456789 +00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampSecond(
+                    Some(1757934000),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00+00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampMillisecond(
+                    Some(1757934000123),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123+00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampMicrosecond(
+                    Some(1757934000123456),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123456+00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampNanosecond(
+                    Some(1757934000123456789),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123456789+00:00' AS TIMESTAMP)",
             ),
         ] {
             let unparser = Unparser::new(dialect.as_ref());
 
-            let expr = Expr::Literal(
-                ScalarValue::TimestampMillisecond(
-                    Some(1757934000000),
-                    Some("+00:00".into()),
-                ),
-                None,
-            );
+            let expr = Expr::Literal(scalar, None);
 
             let actual = format!("{}", unparser.expr_to_sql(&expr)?);
             assert_eq!(actual, expected);

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1056,7 +1056,6 @@ impl Unparser<'_> {
                 .ok_or(internal_datafusion_err!(
                     "Unable to convert {v:?} to DateTime"
                 ))?
-                .format(self.dialect.naive_timestamp_format_for_unit(unit))
                 .to_string()
         };
 


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change

Most databases use following format for timestamps : `2025-09-15 11:00:00 +00:00`
But duckdb fails due to extra space:


<img width="1156" height="211" alt="Screenshot 2025-09-16 at 2 22 51 PM" src="https://github.com/user-attachments/assets/d87f4a6a-d89a-41b6-bd36-481fa94047e1" />


## What changes are included in this PR?

* Extended `Dialect` with `timestamp_with_tz_format_for_unit` and default implementation
* Custom `timestamp_with_tz_format_for_unit` implementation for `DuckDBDialect`
* Tests

## Are these changes tested?
Manually + unit tests

## Are there any user-facing changes?
No
