### PR TITLE
Custom timestamp format for DuckDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ version = "49.0.2"
 dependencies = [
  "arrow",
  "bigdecimal",
+ "chrono",
  "ctor",
  "datafusion-common",
  "datafusion-expr",

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -50,6 +50,7 @@ recursive_protection = ["dep:recursive"]
 [dependencies]
 arrow = { workspace = true }
 bigdecimal = { workspace = true }
+chrono = { workspace = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 indexmap = { workspace = true }

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -204,6 +204,16 @@ pub trait Dialect: Send + Sync {
     fn col_alias_overrides(&self, _alias: &str) -> Result<Option<String>> {
         Ok(None)
     }
+
+    /// The format string to use for unparsing timestamps with time zone information.
+    fn timestamp_with_tz_format_for_unit(&self, unit: TimeUnit) -> &str {
+        match unit {
+            TimeUnit::Second => "%Y-%m-%d %H:%M:%S %:z",
+            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f %:z",
+            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f %:z",
+            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f %:z",
+        }
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -400,6 +410,15 @@ impl Dialect for DuckDBDialect {
         }
 
         Ok(None)
+    }
+
+    fn timestamp_with_tz_format_for_unit(&self, unit: TimeUnit) -> &str {
+        match unit {
+            TimeUnit::Second => "%Y-%m-%d %H:%M:%S%:z",
+            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f%:z",
+            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f%:z",
+            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f%:z",
+        }
     }
 }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -34,7 +34,9 @@ use arrow::array::{
     },
     ArrayRef, Date32Array, Date64Array, PrimitiveArray,
 };
-use arrow::datatypes::{DataType, Decimal128Type, Decimal256Type, DecimalType};
+use arrow::datatypes::{
+    ArrowTimestampType, DataType, Decimal128Type, Decimal256Type, DecimalType,
+};
 use arrow::util::display::array_value_to_string;
 use datafusion_common::{
     internal_datafusion_err, internal_err, not_impl_err, plan_err, Column, Result,
@@ -1043,7 +1045,7 @@ impl Unparser<'_> {
         }
     }
 
-    fn handle_timestamp<T: ArrowTemporalType>(
+    fn handle_timestamp<T: ArrowTimestampType>(
         &self,
         v: &ScalarValue,
         tz: &Option<Arc<str>>,
@@ -1051,6 +1053,8 @@ impl Unparser<'_> {
     where
         i64: From<T::Native>,
     {
+        let unit = T::UNIT;
+
         let ts = if let Some(tz) = tz {
             v.to_array()?
                 .as_any()
@@ -1062,6 +1066,7 @@ impl Unparser<'_> {
                 .ok_or(internal_datafusion_err!(
                     "Unable to convert {v:?} to DateTime"
                 ))?
+                .format(self.dialect.timestamp_with_tz_format_for_unit(unit))
                 .to_string()
         } else {
             v.to_array()?
@@ -3174,6 +3179,89 @@ mod tests {
             let actual = ast.to_string();
             let expected = expected.to_string();
 
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_timestamp_with_tz_format() -> Result<()> {
+        let default_dialect: Arc<dyn Dialect> =
+            Arc::new(CustomDialectBuilder::new().build());
+
+        let duckdb_dialect: Arc<dyn Dialect> = Arc::new(DuckDBDialect::new());
+
+        for (dialect, scalar, expected) in [
+            (
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampSecond(
+                    Some(1757934000),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00 +00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampMillisecond(
+                    Some(1757934000123),
+                    Some("+01:00".into()),
+                ),
+                "CAST('2025-09-15 12:00:00.123 +01:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampMicrosecond(
+                    Some(1757934000123456),
+                    Some("-01:00".into()),
+                ),
+                "CAST('2025-09-15 10:00:00.123456 -01:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&default_dialect),
+                ScalarValue::TimestampNanosecond(
+                    Some(1757934000123456789),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123456789 +00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampSecond(
+                    Some(1757934000),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00+00:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampMillisecond(
+                    Some(1757934000123),
+                    Some("+01:00".into()),
+                ),
+                "CAST('2025-09-15 12:00:00.123+01:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampMicrosecond(
+                    Some(1757934000123456),
+                    Some("-01:00".into()),
+                ),
+                "CAST('2025-09-15 10:00:00.123456-01:00' AS TIMESTAMP)",
+            ),
+            (
+                Arc::clone(&duckdb_dialect),
+                ScalarValue::TimestampNanosecond(
+                    Some(1757934000123456789),
+                    Some("+00:00".into()),
+                ),
+                "CAST('2025-09-15 11:00:00.123456789+00:00' AS TIMESTAMP)",
+            ),
+        ] {
+            let unparser = Unparser::new(dialect.as_ref());
+
+            let expr = Expr::Literal(scalar, None);
+
+            let actual = format!("{}", unparser.expr_to_sql(&expr)?);
             assert_eq!(actual, expected);
         }
         Ok(())

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -34,9 +34,7 @@ use arrow::array::{
     },
     ArrayRef, Date32Array, Date64Array, PrimitiveArray,
 };
-use arrow::datatypes::{
-    ArrowTimestampType, DataType, Decimal128Type, Decimal256Type, DecimalType,
-};
+use arrow::datatypes::{DataType, Decimal128Type, Decimal256Type, DecimalType};
 use arrow::util::display::array_value_to_string;
 use datafusion_common::{
     internal_datafusion_err, internal_err, not_impl_err, plan_err, Column, Result,

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -3158,11 +3158,16 @@ mod tests {
     fn test_cast_timestamp_sqlite() -> Result<()> {
         let sqlite_dialect: Arc<dyn Dialect> = Arc::new(SqliteDialect {});
 
-        for (dialect, expected) in [(sqlite_dialect, "CAST(`a` AS TEXT)")] {
+        for (dialect, expected) in [
+            (sqlite_dialect, "CAST(`a` AS TEXT)"),
+        ] {
             let unparser = Unparser::new(dialect.as_ref());
             let expr = Expr::Cast(Cast {
                 expr: Box::new(col("a")),
-                data_type: DataType::Timestamp(TimeUnit::Nanosecond, None),
+                data_type: DataType::Timestamp(
+                    TimeUnit::Nanosecond,
+                    None,
+                ),
             });
 
             let ast = unparser.expr_to_sql(&expr)?;


### PR DESCRIPTION
## Which issue does this PR close?
Required for https://github.com/spiceai/spiceai/pull/7055

## Rationale for this change

Most databases use following format for timestamps : `2025-09-15 11:00:00 +00:00`
But duckdb fails due to extra space:


<img width="1156" height="211" alt="Screenshot 2025-09-16 at 2 22 51 PM" src="https://github.com/user-attachments/assets/d87f4a6a-d89a-41b6-bd36-481fa94047e1" />


## What changes are included in this PR?

* Extended `Dialect` with `timestamp_with_tz_format_for_unit` and default implementation
* Custom `timestamp_with_tz_format_for_unit` implementation for `DuckDBDialect`
* Tests

## Are these changes tested?
Manually + unit tests

## Are there any user-facing changes?
No
