### PR TITLE
Resolve `ListingScan` projection against table schema including partition columns

### DIFF
--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -378,16 +378,6 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlanType::ListingScan(scan) => {
                 let schema: Schema = convert_required!(scan.schema)?;
 
-                let mut projection = None;
-                if let Some(columns) = &scan.projection {
-                    let column_indices = columns
-                        .columns
-                        .iter()
-                        .map(|name| schema.index_of(name))
-                        .collect::<Result<Vec<usize>, _>>()?;
-                    projection = Some(column_indices);
-                }
-
                 let filters =
                     from_proto::parse_exprs(&scan.filters, ctx, extension_codec)?;
 
@@ -491,6 +481,16 @@ impl AsLogicalPlan for LogicalPlanNode {
 
                 let table_name =
                     from_table_reference(scan.table_name.as_ref(), "ListingTableScan")?;
+
+                let mut projection = None;
+                if let Some(columns) = &scan.projection {
+                    let column_indices = columns
+                        .columns
+                        .iter()
+                        .map(|name| provider.schema().index_of(name))
+                        .collect::<Result<Vec<usize>, _>>()?;
+                    projection = Some(column_indices);
+                }
 
                 LogicalPlanBuilder::scan_with_filters(
                     table_name,

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -44,6 +44,7 @@ use datafusion::datasource::file_format::arrow::ArrowFormatFactory;
 use datafusion::datasource::file_format::csv::CsvFormatFactory;
 use datafusion::datasource::file_format::parquet::ParquetFormatFactory;
 use datafusion::datasource::file_format::{format_as_file_type, DefaultFileType};
+use datafusion::datasource::DefaultTableSource;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::execution::FunctionRegistry;
 use datafusion::functions_aggregate::count::count_udaf;
@@ -75,9 +76,9 @@ use datafusion_expr::expr::{
 use datafusion_expr::logical_plan::{Extension, UserDefinedLogicalNodeCore};
 use datafusion_expr::{
     Accumulator, AggregateUDF, ColumnarValue, ExprFunctionExt, ExprSchemable, Literal,
-    LogicalPlan, Operator, PartitionEvaluator, ScalarUDF, Signature, TryCast, Volatility,
-    WindowFrame, WindowFrameBound, WindowFrameUnits, WindowFunctionDefinition, WindowUDF,
-    WindowUDFImpl,
+    LogicalPlan, LogicalPlanBuilder, Operator, PartitionEvaluator, ScalarUDF, Signature,
+    TryCast, Volatility, WindowFrame, WindowFrameBound, WindowFrameUnits,
+    WindowFunctionDefinition, WindowUDF, WindowUDFImpl,
 };
 use datafusion_functions_aggregate::average::avg_udaf;
 use datafusion_functions_aggregate::expr_fn::{
@@ -2643,16 +2644,24 @@ async fn roundtrip_custom_listing_tables_schema() -> Result<()> {
         .infer_schema(&ctx.state())
         .await?;
 
-    ctx.register_table("hive_style", Arc::new(ListingTable::try_new(config)?))?;
+    let listing_table: Arc<dyn TableProvider> = Arc::new(ListingTable::try_new(config)?);
 
-    let plan = ctx
-        .sql("SELECT part, value FROM hive_style LIMIT 1")
-        .await?
-        .logical_plan()
-        .clone();
+    let projection = ["part", "value"]
+        .iter()
+        .map(|field_name| listing_table.schema().index_of(field_name))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let plan = LogicalPlanBuilder::scan(
+        "hive_style",
+        Arc::new(DefaultTableSource::new(listing_table)),
+        Some(projection),
+    )?
+    .limit(0, Some(1))?
+    .build()?;
 
     let bytes = logical_plan_to_bytes(&plan)?;
     let new_plan = logical_plan_from_bytes(&bytes, &ctx)?;
+
     assert_eq!(plan, new_plan);
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

TBD

## Rationale for this change

Since table partition columns are serialized separately for ListingScan, https://github.com/apache/datafusion/pull/15737 made a change to remove them from the `TableScan` schema so they would not be duplicated. Unfortunately, queries with projections that reference the partition columns would fail to resolve here:

https://github.com/apache/datafusion/blob/daeb6597a0c7344735460bb2dce13879fd89d7bd/datafusion/proto/src/logical_plan/mod.rs#L382-L390

The round-trip test used a partition column in its `SELECT` to exercise this, however the unoptimized plan did not have projections decorated (so they would not get serialized, and there would be no lookup to fail). As in, `scan.projection` above would be `None`. 

## What changes are included in this PR?

- Do the projection name -> index binding using `ListingTable::schema`, at which point the partition columns are decorated
- Since we're testing the round-tripping of the plan, make a plan with `LogicalPlanBuilder` that explicitly specifies a projection to ensure we're testing this functionality
  - This test fails on `main`

---

Upstream https://github.com/apache/datafusion/pull/17911