### PR TITLE
fix: Restore with_file_size() call for Azure/ABFS compatibility

### DIFF
--- a/datafusion/datasource-parquet/src/reader.rs
+++ b/datafusion/datasource-parquet/src/reader.rs
@@ -156,7 +156,8 @@ impl ParquetFileReaderFactory for DefaultParquetFileReaderFactory {
             metrics,
         );
         let store = Arc::clone(&self.store);
-        let mut inner = ParquetObjectReader::new_with_meta(store, file_meta.object_meta)
+        let mut inner = ParquetObjectReader::new_with_meta(store, file_meta.object_meta.clone())
+            .with_file_size(file_meta.object_meta.size)
             .with_object_versioning_type(self.object_versioning_type.clone());
 
         if let Some(hint) = metadata_size_hint {
@@ -220,6 +221,7 @@ impl ParquetFileReaderFactory for CachedParquetFileReaderFactory {
 
         let mut inner =
             ParquetObjectReader::new_with_meta(store, file_meta.object_meta.clone())
+                .with_file_size(file_meta.object_meta.size)
                 .with_object_versioning_type(self.object_versioning_type.clone());
 
         if let Some(hint) = metadata_size_hint {


### PR DESCRIPTION
The with_file_size() call was removed in commit 251010e26 when adding object versioning support. Without file_size set on ParquetObjectReader, get_metadata() falls back to suffix range requests which Azure Blob Storage does not support, causing the error:
'Azure does not support suffix range requests'

This restores the with_file_size() call for both DefaultParquetFileReaderFactory and CachedParquetFileReaderFactory.