### PR TITLE
fix: Use iterative BinaryExpr evaluation for large nested chains

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -187,6 +187,16 @@ impl PhysicalExpr for BinaryExpr {
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
         use arrow::compute::kernels::numeric::*;
 
+        // For AND/OR operators with deeply nested chains, use iterative evaluation
+        // to avoid stack overflow. We only check depth for AND/OR since other
+        // operators don't typically form deep chains.
+        if matches!(self.op, Operator::And | Operator::Or) {
+            let depth = self.estimate_and_or_chain_depth();
+            if depth > ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD {
+                return self.evaluate_and_or_chain(batch);
+            }
+        }
+
         // Evaluate left-hand side expression.
         let lhs = self.left.evaluate(batch)?;
 
@@ -652,7 +662,137 @@ impl BinaryExpr {
             }
         }
     }
+
+    /// Estimates the depth of a homogeneous AND/OR chain.
+    ///
+    /// Uses iterative stack-based traversal to avoid recursion.
+    /// Only counts depth for chains where all BinaryExpr have the same operator.
+    fn estimate_and_or_chain_depth(&self) -> usize {
+        if !matches!(self.op, Operator::And | Operator::Or) {
+            return 1;
+        }
+
+        let target_op = self.op;
+        let mut max_depth = 0;
+        // Stack holds (expression, current_depth)
+        let mut stack: Vec<(&Arc<dyn PhysicalExpr>, usize)> =
+            vec![(&self.left, 1), (&self.right, 1)];
+
+        while let Some((expr, depth)) = stack.pop() {
+            max_depth = max_depth.max(depth);
+
+            if let Some(binary) = expr.as_any().downcast_ref::<BinaryExpr>() {
+                if binary.op == target_op {
+                    stack.push((&binary.left, depth + 1));
+                    stack.push((&binary.right, depth + 1));
+                }
+            }
+        }
+
+        max_depth
+    }
+
+    /// Collects all operands from a homogeneous AND/OR chain iteratively.
+    ///
+    /// For example, `(a AND b) AND (c AND d)` returns `[a, b, c, d]`.
+    /// Stops descending when encountering a non-BinaryExpr or a BinaryExpr with a different operator.
+    fn collect_boolean_chain_operands(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        debug_assert!(matches!(self.op, Operator::And | Operator::Or));
+
+        let target_op = self.op;
+        let mut operands = Vec::new();
+        let mut stack: Vec<Arc<dyn PhysicalExpr>> =
+            vec![Arc::clone(&self.right), Arc::clone(&self.left)];
+
+        while let Some(expr) = stack.pop() {
+            if let Some(binary) = expr.as_any().downcast_ref::<BinaryExpr>() {
+                if binary.op == target_op {
+                    // Push right first so left is processed first (preserves order)
+                    stack.push(Arc::clone(&binary.right));
+                    stack.push(Arc::clone(&binary.left));
+                    continue;
+                }
+            }
+            // Not a matching BinaryExpr, so it's a leaf operand
+            operands.push(expr);
+        }
+
+        operands
+    }
+
+    /// Evaluates an AND/OR chain iteratively with short-circuit semantics.
+    ///
+    /// This avoids deep recursion for chains like `a AND b AND c AND ... AND z`.
+    fn evaluate_and_or_chain(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        debug_assert!(matches!(self.op, Operator::And | Operator::Or));
+
+        let is_and = self.op == Operator::And;
+        let operands = self.collect_boolean_chain_operands();
+        let num_rows = batch.num_rows();
+
+        // Start with identity value for the operation
+        // AND: start with all true, OR: start with all false
+        let mut result: Option<ColumnarValue> = None;
+
+        for operand in operands {
+            // Evaluate this operand
+            let value = operand.evaluate(batch)?;
+
+            // Check for short-circuit opportunity
+            match check_short_circuit(&value, &self.op) {
+                ShortCircuitStrategy::ReturnLeft => {
+                    // For AND: all false means result is false
+                    // For OR: all true means result is true
+                    return Ok(value);
+                }
+                ShortCircuitStrategy::ReturnRight => {
+                    // For AND: all true means continue (identity)
+                    // For OR: all false means continue (identity)
+                    // Skip this operand as it doesn't affect result
+                    continue;
+                }
+                ShortCircuitStrategy::PreSelection(_) | ShortCircuitStrategy::None => {
+                    // Can't short-circuit, need to combine with accumulated result
+                }
+            }
+
+            // Combine with accumulated result
+            result = Some(match result {
+                None => value,
+                Some(acc) => {
+                    // Combine acc and value using the appropriate boolean kernel
+                    let acc_array = acc.into_array(num_rows)?;
+                    let value_array = value.into_array(num_rows)?;
+                    let combined = if is_and {
+                        boolean_op(&acc_array, &value_array, and_kleene)?
+                    } else {
+                        boolean_op(&acc_array, &value_array, or_kleene)?
+                    };
+                    ColumnarValue::Array(combined)
+                }
+            });
+
+            // After combining, check if we can short-circuit based on result
+            if let Some(ref res) = result {
+                match check_short_circuit(res, &self.op) {
+                    ShortCircuitStrategy::ReturnLeft => {
+                        return Ok(result.unwrap());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Return result or identity value if all operands were skipped
+        Ok(result
+            .unwrap_or_else(|| ColumnarValue::Scalar(ScalarValue::Boolean(Some(is_and)))))
+    }
 }
+
+/// Threshold for switching to iterative evaluation for AND/OR chains.
+/// When the chain depth exceeds this value, we use iterative evaluation
+/// to avoid stack overflow.
+const ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD: usize = 10;
 
 enum ShortCircuitStrategy<'a> {
     None,
@@ -5312,5 +5452,260 @@ mod tests {
         let expected =
             BooleanArray::from_iter(vec![Some(true), Some(true), Some(true), Some(true)]);
         assert_eq!(eq_result.into_array(4).unwrap().as_boolean(), &expected);
+    }
+
+    #[test]
+    fn test_estimate_and_or_chain_depth() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+            Field::new("c", DataType::Boolean, false),
+        ]);
+
+        let col_a = col("a", &schema).unwrap();
+        let col_b = col("b", &schema).unwrap();
+        let col_c = col("c", &schema).unwrap();
+
+        // Single binary expression: depth = 1
+        let expr = BinaryExpr::new(col_a.clone(), Operator::And, col_b.clone());
+        assert_eq!(expr.estimate_and_or_chain_depth(), 1);
+
+        // (a AND b) AND c: depth = 2
+        let left = Arc::new(BinaryExpr::new(col_a.clone(), Operator::And, col_b.clone()));
+        let expr = BinaryExpr::new(left, Operator::And, col_c.clone());
+        assert_eq!(expr.estimate_and_or_chain_depth(), 2);
+
+        // a AND (b AND c): depth = 2
+        let right =
+            Arc::new(BinaryExpr::new(col_b.clone(), Operator::And, col_c.clone()));
+        let expr = BinaryExpr::new(col_a.clone(), Operator::And, right);
+        assert_eq!(expr.estimate_and_or_chain_depth(), 2);
+
+        // Mixed operators don't increase depth: (a AND b) OR c has depth 1 for OR
+        let left = Arc::new(BinaryExpr::new(col_a.clone(), Operator::And, col_b.clone()));
+        let expr = BinaryExpr::new(left, Operator::Or, col_c.clone());
+        assert_eq!(expr.estimate_and_or_chain_depth(), 1);
+
+        // Non-AND/OR operator: depth = 1
+        let expr = BinaryExpr::new(col_a.clone(), Operator::Eq, col_b.clone());
+        assert_eq!(expr.estimate_and_or_chain_depth(), 1);
+    }
+
+    #[test]
+    fn test_collect_boolean_chain_operands() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+            Field::new("c", DataType::Boolean, false),
+            Field::new("d", DataType::Boolean, false),
+        ]);
+
+        let col_a = col("a", &schema).unwrap();
+        let col_b = col("b", &schema).unwrap();
+        let col_c = col("c", &schema).unwrap();
+        let col_d = col("d", &schema).unwrap();
+
+        // Simple: a AND b -> [a, b]
+        let expr = BinaryExpr::new(col_a.clone(), Operator::And, col_b.clone());
+        let operands = expr.collect_boolean_chain_operands();
+        assert_eq!(operands.len(), 2);
+
+        // Nested: (a AND b) AND (c AND d) -> [a, b, c, d]
+        let left = Arc::new(BinaryExpr::new(col_a.clone(), Operator::And, col_b.clone()));
+        let right =
+            Arc::new(BinaryExpr::new(col_c.clone(), Operator::And, col_d.clone()));
+        let expr = BinaryExpr::new(left, Operator::And, right);
+        let operands = expr.collect_boolean_chain_operands();
+        assert_eq!(operands.len(), 4);
+
+        // Mixed: (a AND b) OR c -> [(a AND b), c] (stops at different operator)
+        let left = Arc::new(BinaryExpr::new(col_a.clone(), Operator::And, col_b.clone()));
+        let expr = BinaryExpr::new(left, Operator::Or, col_c.clone());
+        let operands = expr.collect_boolean_chain_operands();
+        assert_eq!(operands.len(), 2);
+    }
+
+    #[test]
+    fn test_deep_and_chain_iterative() -> Result<()> {
+        // Create a chain deeper than the threshold to trigger iterative evaluation
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Boolean, false)]));
+
+        // Create test data
+        let a = BooleanArray::from(vec![true, true, false, true]);
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(a)])?;
+
+        let col_a = col("a", &schema)?;
+
+        // Build a deep chain: a AND a AND a AND ... (depth > threshold)
+        let depth = ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD + 5;
+        let mut expr: Arc<dyn PhysicalExpr> = col_a.clone();
+        for _ in 0..depth {
+            expr = Arc::new(BinaryExpr::new(expr, Operator::And, col_a.clone()));
+        }
+
+        // This should use the iterative path and not stack overflow
+        let result = expr.evaluate(&batch)?;
+        let result_array = result.into_array(batch.num_rows())?;
+        let bool_array = result_array.as_boolean();
+
+        // a AND a AND ... AND a = a
+        assert_eq!(bool_array.value(0), true);
+        assert_eq!(bool_array.value(1), true);
+        assert_eq!(bool_array.value(2), false);
+        assert_eq!(bool_array.value(3), true);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deep_or_chain_iterative() -> Result<()> {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Boolean, false)]));
+
+        let a = BooleanArray::from(vec![true, false, false, true]);
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(a)])?;
+
+        let col_a = col("a", &schema)?;
+
+        // Build a deep OR chain
+        let depth = ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD + 5;
+        let mut expr: Arc<dyn PhysicalExpr> = col_a.clone();
+        for _ in 0..depth {
+            expr = Arc::new(BinaryExpr::new(expr, Operator::Or, col_a.clone()));
+        }
+
+        let result = expr.evaluate(&batch)?;
+        let result_array = result.into_array(batch.num_rows())?;
+        let bool_array = result_array.as_boolean();
+
+        // a OR a OR ... OR a = a
+        assert_eq!(bool_array.value(0), true);
+        assert_eq!(bool_array.value(1), false);
+        assert_eq!(bool_array.value(2), false);
+        assert_eq!(bool_array.value(3), true);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_iterative_and_short_circuit_all_false() -> Result<()> {
+        // Test that short-circuit works: if any operand is all false, AND returns false
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+        ]));
+
+        let a = BooleanArray::from(vec![true, true, true, true]);
+        let b = BooleanArray::from(vec![false, false, false, false]); // all false
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(a), Arc::new(b)])?;
+
+        let col_a = col("a", &schema)?;
+        let col_b = col("b", &schema)?;
+
+        // Build deep chain: a AND a AND ... AND b AND a AND ...
+        // The b (all false) should short-circuit
+        let depth = ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD + 5;
+        let mut expr: Arc<dyn PhysicalExpr> = col_a.clone();
+        for i in 0..depth {
+            if i == depth / 2 {
+                expr = Arc::new(BinaryExpr::new(expr, Operator::And, col_b.clone()));
+            } else {
+                expr = Arc::new(BinaryExpr::new(expr, Operator::And, col_a.clone()));
+            }
+        }
+
+        let result = expr.evaluate(&batch)?;
+        let result_array = result.into_array(batch.num_rows())?;
+        let bool_array = result_array.as_boolean();
+
+        // Result should be all false due to short-circuit
+        assert_eq!(bool_array.value(0), false);
+        assert_eq!(bool_array.value(1), false);
+        assert_eq!(bool_array.value(2), false);
+        assert_eq!(bool_array.value(3), false);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_iterative_or_short_circuit_all_true() -> Result<()> {
+        // Test that short-circuit works: if any operand is all true, OR returns true
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+        ]));
+
+        let a = BooleanArray::from(vec![false, false, false, false]);
+        let b = BooleanArray::from(vec![true, true, true, true]); // all true
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(a), Arc::new(b)])?;
+
+        let col_a = col("a", &schema)?;
+        let col_b = col("b", &schema)?;
+
+        // Build deep chain: a OR a OR ... OR b OR a OR ...
+        let depth = ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD + 5;
+        let mut expr: Arc<dyn PhysicalExpr> = col_a.clone();
+        for i in 0..depth {
+            if i == depth / 2 {
+                expr = Arc::new(BinaryExpr::new(expr, Operator::Or, col_b.clone()));
+            } else {
+                expr = Arc::new(BinaryExpr::new(expr, Operator::Or, col_a.clone()));
+            }
+        }
+
+        let result = expr.evaluate(&batch)?;
+        let result_array = result.into_array(batch.num_rows())?;
+        let bool_array = result_array.as_boolean();
+
+        // Result should be all true due to short-circuit
+        assert_eq!(bool_array.value(0), true);
+        assert_eq!(bool_array.value(1), true);
+        assert_eq!(bool_array.value(2), true);
+        assert_eq!(bool_array.value(3), true);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_iterative_mixed_values() -> Result<()> {
+        // Test with mixed boolean values
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+            Field::new("c", DataType::Boolean, false),
+        ]));
+
+        let a = BooleanArray::from(vec![true, true, false, false]);
+        let b = BooleanArray::from(vec![true, false, true, false]);
+        let c = BooleanArray::from(vec![true, true, true, true]);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(a), Arc::new(b), Arc::new(c)],
+        )?;
+
+        let col_a = col("a", &schema)?;
+        let col_b = col("b", &schema)?;
+        let col_c = col("c", &schema)?;
+
+        // Build: a AND b AND c AND a AND b AND ... (deep chain)
+        let depth = ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD + 3;
+        let cols = vec![col_a.clone(), col_b.clone(), col_c.clone()];
+        let mut expr: Arc<dyn PhysicalExpr> = cols[0].clone();
+        for i in 1..depth {
+            expr = Arc::new(BinaryExpr::new(expr, Operator::And, cols[i % 3].clone()));
+        }
+
+        let result = expr.evaluate(&batch)?;
+        let result_array = result.into_array(batch.num_rows())?;
+        let bool_array = result_array.as_boolean();
+
+        // a AND b AND c = [true, false, false, false]
+        assert_eq!(bool_array.value(0), true);
+        assert_eq!(bool_array.value(1), false);
+        assert_eq!(bool_array.value(2), false);
+        assert_eq!(bool_array.value(3), false);
+
+        Ok(())
     }
 }

--- a/datafusion/physical-expr/src/utils/mod.rs
+++ b/datafusion/physical-expr/src/utils/mod.rs
@@ -59,15 +59,60 @@ pub fn conjunction(
 /// If the input is empty or the return None.
 /// If the input contains a single predicate, return Some(predicate).
 /// Otherwise, return a Some(..) of a conjunction of the predicates (e.g. `Some(a AND b AND c)`).
+///
+/// The resulting expression tree is balanced to avoid deep recursion during evaluation.
+/// For example, `conjunction([a, b, c, d])` produces `((a AND b) AND (c AND d))` rather than
+/// `(((a AND b) AND c) AND d)`.
 pub fn conjunction_opt(
     predicates: impl IntoIterator<Item = Arc<dyn PhysicalExpr>>,
 ) -> Option<Arc<dyn PhysicalExpr>> {
-    predicates
-        .into_iter()
-        .fold(None, |acc, predicate| match acc {
-            None => Some(predicate),
-            Some(acc) => Some(Arc::new(BinaryExpr::new(acc, Operator::And, predicate))),
-        })
+    let predicates: Vec<_> = predicates.into_iter().collect();
+    build_balanced_binary_tree(Operator::And, predicates)
+}
+
+/// Build a balanced tree of binary expressions from an operator and a list of expressions.
+///
+/// For example, `build_balanced_binary_tree(AND, [a, b, c, d, e])` produces:
+/// `((a AND b) AND ((c AND d) AND e))` with tree depth O(log n) rather than O(n).
+///
+/// Returns `None` if the input is empty.
+/// Returns the single expression if the input contains only one element.
+pub fn build_balanced_binary_tree(
+    op: Operator,
+    exprs: Vec<Arc<dyn PhysicalExpr>>,
+) -> Option<Arc<dyn PhysicalExpr>> {
+    let n = exprs.len();
+    if n == 0 {
+        return None;
+    }
+    // Use an iterator approach to avoid ownership issues
+    let mut iter = exprs.into_iter();
+    Some(build_balanced_tree_inner(op, &mut iter, n))
+}
+
+/// Helper function for [`build_balanced_binary_tree`] implementation.
+///
+/// `take_len` represents the number of elements to take from `exprs`.
+/// Using `take_len` avoids building complex iterator types from recursive `take()` calls.
+fn build_balanced_tree_inner(
+    op: Operator,
+    exprs: &mut impl Iterator<Item = Arc<dyn PhysicalExpr>>,
+    take_len: usize,
+) -> Arc<dyn PhysicalExpr> {
+    debug_assert!(take_len > 0, "take_len must be greater than 0");
+
+    if take_len == 1 {
+        return exprs.next().expect("Expected one more element in iterator");
+    }
+
+    // Split the list in two balanced halves
+    let left_len = take_len / 2;
+    let right_len = take_len - left_len;
+
+    let left = build_balanced_tree_inner(op, exprs, left_len);
+    let right = build_balanced_tree_inner(op, exprs, right_len);
+
+    Arc::new(BinaryExpr::new(left, op, right))
 }
 
 /// Assume the predicate is in the form of DNF, split the predicate to a Vec of PhysicalExprs.
@@ -560,6 +605,201 @@ pub(crate) mod tests {
         expected.insert(Column::new("col1", 2));
         expected.insert(Column::new("col2", 5));
         assert_eq!(collect_columns(&expr3), expected);
+        Ok(())
+    }
+
+    /// Helper to calculate the depth of a binary expression tree
+    fn tree_depth(expr: &Arc<dyn PhysicalExpr>) -> usize {
+        if let Some(binary) = expr.as_any().downcast_ref::<BinaryExpr>() {
+            1 + std::cmp::max(tree_depth(binary.left()), tree_depth(binary.right()))
+        } else {
+            1
+        }
+    }
+
+    /// Helper to evaluate an expression with a boolean result
+    fn eval_bool(
+        expr: &Arc<dyn PhysicalExpr>,
+        batch: &arrow::record_batch::RecordBatch,
+    ) -> Result<Vec<bool>> {
+        use datafusion_expr::ColumnarValue;
+        let result = expr.evaluate(batch)?;
+        match result {
+            ColumnarValue::Array(arr) => {
+                let bool_arr = arr
+                    .as_any()
+                    .downcast_ref::<arrow::array::BooleanArray>()
+                    .unwrap();
+                Ok(bool_arr.iter().map(|v| v.unwrap_or(false)).collect())
+            }
+            ColumnarValue::Scalar(s) => {
+                if let ScalarValue::Boolean(Some(b)) = s {
+                    Ok(vec![b])
+                } else {
+                    Ok(vec![false])
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_balanced_binary_tree_empty() {
+        let result = build_balanced_binary_tree(Operator::And, vec![]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_build_balanced_binary_tree_single() {
+        let col_a: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let result = build_balanced_binary_tree(Operator::And, vec![col_a.clone()]);
+        assert!(result.is_some());
+        let result = result.unwrap();
+        // Single element should return the element itself
+        assert!(result.as_any().is::<Column>());
+    }
+
+    #[test]
+    fn test_build_balanced_binary_tree_depth() {
+        // Test that the tree depth is O(log n) not O(n)
+        // With 8 elements, balanced tree has depth 4, linear tree has depth 8
+        let exprs: Vec<Arc<dyn PhysicalExpr>> = (0..8)
+            .map(|i| Arc::new(Column::new(&format!("c{i}"), i)) as Arc<dyn PhysicalExpr>)
+            .collect();
+
+        let result = build_balanced_binary_tree(Operator::And, exprs).unwrap();
+        let depth = tree_depth(&result);
+
+        // Balanced tree of 8 elements should have depth 4 (log2(8) + 1)
+        // A linear tree would have depth 8
+        assert!(depth <= 4, "Expected depth <= 4, got {depth}");
+    }
+
+    #[test]
+    fn test_build_balanced_binary_tree_large() {
+        // Test with a larger number of elements to verify no stack overflow
+        // and proper depth
+        let n = 100;
+        let exprs: Vec<Arc<dyn PhysicalExpr>> = (0..n)
+            .map(|i| Arc::new(Column::new(&format!("c{i}"), i)) as Arc<dyn PhysicalExpr>)
+            .collect();
+
+        let result = build_balanced_binary_tree(Operator::Or, exprs).unwrap();
+        let depth = tree_depth(&result);
+
+        // log2(100) ≈ 6.6, so depth should be around 7-8
+        let expected_max_depth = (n as f64).log2().ceil() as usize + 1;
+        assert!(
+            depth <= expected_max_depth,
+            "Expected depth <= {expected_max_depth}, got {depth}"
+        );
+    }
+
+    #[test]
+    fn test_conjunction_opt_empty() {
+        let result = conjunction_opt(vec![]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_conjunction_opt_single() {
+        let col_a: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let result = conjunction_opt(vec![col_a.clone()]);
+        assert!(result.is_some());
+        assert!(result.unwrap().as_any().is::<Column>());
+    }
+
+    #[test]
+    fn test_conjunction_opt_balanced_depth() {
+        // Verify conjunction_opt produces a balanced tree
+        let exprs: Vec<Arc<dyn PhysicalExpr>> = (0..8)
+            .map(|i| Arc::new(Column::new(&format!("c{i}"), i)) as Arc<dyn PhysicalExpr>)
+            .collect();
+
+        let result = conjunction_opt(exprs).unwrap();
+        let depth = tree_depth(&result);
+
+        // Should be balanced, not linear
+        assert!(depth <= 4, "Expected depth <= 4, got {depth}");
+    }
+
+    #[test]
+    fn test_conjunction_logical_equivalence() -> Result<()> {
+        // Test that conjunction produces logically equivalent results
+        // Create boolean columns and verify AND behavior
+        use arrow::array::BooleanArray;
+        use arrow::record_batch::RecordBatch;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+            Field::new("c", DataType::Boolean, false),
+        ]));
+
+        let a = Arc::new(BooleanArray::from(vec![true, true, false, false]));
+        let b = Arc::new(BooleanArray::from(vec![true, false, true, false]));
+        let c = Arc::new(BooleanArray::from(vec![true, true, true, true]));
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![a, b, c])?;
+
+        let col_a: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let col_b: Arc<dyn PhysicalExpr> = Arc::new(Column::new("b", 1));
+        let col_c: Arc<dyn PhysicalExpr> = Arc::new(Column::new("c", 2));
+
+        // Test a AND b AND c using conjunction
+        let conj =
+            conjunction_opt(vec![col_a.clone(), col_b.clone(), col_c.clone()]).unwrap();
+        let result = eval_bool(&conj, &batch)?;
+
+        // Expected: true AND true AND true = true
+        //           true AND false AND true = false
+        //           false AND true AND true = false
+        //           false AND false AND true = false
+        assert_eq!(result, vec![true, false, false, false]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_conjunction_roundtrip() -> Result<()> {
+        // Test that split_conjunction and conjunction are inverses
+        let col_a: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let col_b: Arc<dyn PhysicalExpr> = Arc::new(Column::new("b", 1));
+        let col_c: Arc<dyn PhysicalExpr> = Arc::new(Column::new("c", 2));
+
+        // Build a conjunction
+        let conj = conjunction(vec![col_a.clone(), col_b.clone(), col_c.clone()]);
+
+        // Split it back
+        let split = split_conjunction(&conj);
+
+        // Should have 3 elements
+        assert_eq!(split.len(), 3);
+
+        // Rebuild and verify logical equivalence via evaluation
+        use arrow::array::BooleanArray;
+        use arrow::record_batch::RecordBatch;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Boolean, false),
+            Field::new("b", DataType::Boolean, false),
+            Field::new("c", DataType::Boolean, false),
+        ]));
+
+        let a = Arc::new(BooleanArray::from(vec![true, false, true, false]));
+        let b = Arc::new(BooleanArray::from(vec![true, true, false, false]));
+        let c = Arc::new(BooleanArray::from(vec![true, true, true, false]));
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![a, b, c])?;
+
+        // Evaluate original conjunction
+        let original_result = eval_bool(&conj, &batch)?;
+
+        // Rebuild conjunction from split parts
+        let rebuilt = conjunction(split.into_iter().cloned());
+        let rebuilt_result = eval_bool(&rebuilt, &batch)?;
+
+        assert_eq!(original_result, rebuilt_result);
+
         Ok(())
     }
 }

--- a/datafusion/pruning/src/pruning_predicate.rs
+++ b/datafusion/pruning/src/pruning_predicate.rs
@@ -1452,8 +1452,10 @@ fn build_predicate_expression(
                 })
                 .collect();
             // Build a balanced tree to avoid deep recursion during evaluation
-            let change_expr = build_balanced_binary_tree(re_op, eq_exprs)
-                .expect("list is not empty, so this should always return Some");
+            let Some(change_expr) = build_balanced_binary_tree(re_op, eq_exprs) else {
+                unreachable!("list is not empty, so this should always return Some");
+            };
+
             return build_predicate_expression(
                 &change_expr,
                 schema,

--- a/datafusion/pruning/src/pruning_predicate.rs
+++ b/datafusion/pruning/src/pruning_predicate.rs
@@ -43,7 +43,9 @@ use datafusion_common::{
 };
 use datafusion_common::{Column, DFSchema};
 use datafusion_expr_common::operator::Operator;
-use datafusion_physical_expr::utils::{collect_columns, Guarantee, LiteralGuarantee};
+use datafusion_physical_expr::utils::{
+    build_balanced_binary_tree, collect_columns, Guarantee, LiteralGuarantee,
+};
 use datafusion_physical_expr::{expressions as phys_expr, PhysicalExprRef};
 use datafusion_physical_expr_common::physical_expr::snapshot_physical_expr;
 use datafusion_physical_plan::{ColumnarValue, PhysicalExpr};
@@ -1437,7 +1439,8 @@ fn build_predicate_expression(
             } else {
                 Operator::Or
             };
-            let change_expr = in_list
+            // Build individual equality/inequality expressions
+            let eq_exprs: Vec<Arc<dyn PhysicalExpr>> = in_list
                 .list()
                 .iter()
                 .map(|e| {
@@ -1447,8 +1450,10 @@ fn build_predicate_expression(
                         Arc::clone(e),
                     )) as _
                 })
-                .reduce(|a, b| Arc::new(phys_expr::BinaryExpr::new(a, re_op, b)) as _)
-                .unwrap();
+                .collect();
+            // Build a balanced tree to avoid deep recursion during evaluation
+            let change_expr = build_balanced_binary_tree(re_op, eq_exprs)
+                .expect("list is not empty, so this should always return Some");
             return build_predicate_expression(
                 &change_expr,
                 schema,
@@ -5173,5 +5178,95 @@ mod tests {
         let expected =
             "c1_null_count@2 != row_count@3 AND c1_min@0 <= a AND a <= c1_max@1";
         assert_eq!(res.to_string(), expected);
+    }
+
+    /// Helper to calculate the depth of a physical expression tree
+    fn expr_tree_depth(expr: &Arc<dyn PhysicalExpr>) -> usize {
+        if let Some(binary) = expr.as_any().downcast_ref::<phys_expr::BinaryExpr>() {
+            1 + std::cmp::max(
+                expr_tree_depth(binary.left()),
+                expr_tree_depth(binary.right()),
+            )
+        } else {
+            1
+        }
+    }
+
+    #[test]
+    fn test_in_list_balanced_tree_depth() {
+        // Test that InList expressions produce balanced trees with O(log n) depth
+        // rather than O(n) depth to avoid stack overflow during evaluation
+        let schema = Schema::new(vec![Field::new("c1", DataType::Int32, false)]);
+
+        // Test with MAX_LIST_VALUE_SIZE_REWRITE (20) elements
+        let expr = Expr::InList(InList::new(
+            Box::new(col("c1")),
+            (1..=20).map(lit).collect(),
+            false,
+        ));
+        let predicate_expr =
+            test_build_predicate_expression(&expr, &schema, &mut RequiredColumns::new());
+
+        let depth = expr_tree_depth(&predicate_expr);
+        // With 20 elements, balanced tree should have depth around log2(20) + some constants
+        // for the inner expressions. A linear tree would have depth proportional to 20.
+        // The actual depth depends on the structure of inner expressions too.
+        // For a balanced OR tree of 20 items, max depth should be around 5-6 for the OR nodes
+        // plus the depth of individual expressions.
+        // Let's verify it's not linear (which would be > 20)
+        assert!(
+            depth < 20,
+            "Expected balanced tree depth < 20, got {depth}. Tree may not be balanced."
+        );
+    }
+
+    #[test]
+    fn test_in_list_logical_equivalence() -> Result<()> {
+        // Verify that the balanced tree produces the same pruning results as expected
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::Int32, false)]));
+
+        // Test c1 IN (1, 2, 3, 4, 5)
+        let expr = col("c1").in_list(vec![lit(1), lit(2), lit(3), lit(4), lit(5)], false);
+
+        // Statistics where c1 is between 0 and 2 (should NOT be pruned - contains 1, 2)
+        let statistics1 = TestStatistics::new().with(
+            "c1",
+            ContainerStats::new_i32(vec![Some(0)], vec![Some(2)])
+                .with_null_counts(vec![Some(0)])
+                .with_row_counts(vec![Some(100)]),
+        );
+
+        // Statistics where c1 is between 10 and 20 (should be pruned - contains none of 1,2,3,4,5)
+        let statistics2 = TestStatistics::new().with(
+            "c1",
+            ContainerStats::new_i32(vec![Some(10)], vec![Some(20)])
+                .with_null_counts(vec![Some(0)])
+                .with_row_counts(vec![Some(100)]),
+        );
+
+        // Create the pruning predicate
+        let physical_expr = logical2physical(&expr, &schema);
+        let pruning_predicate = PruningPredicate::try_new(physical_expr, schema)?;
+
+        // Test pruning results
+        let result1 = pruning_predicate.prune(&statistics1)?;
+        let result2 = pruning_predicate.prune(&statistics2)?;
+
+        // First container should NOT be pruned (true = may contain matching rows)
+        assert_eq!(
+            result1,
+            vec![true],
+            "Container with values 0-2 should not be pruned for IN (1,2,3,4,5)"
+        );
+
+        // Second container SHOULD be pruned (false = definitely no matching rows)
+        assert_eq!(
+            result2,
+            vec![false],
+            "Container with values 10-20 should be pruned for IN (1,2,3,4,5)"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the evaluation of deeply nested AND/OR chains in the `BinaryExpr` implementation, ensuring stack safety and better performance. The main changes include switching to iterative evaluation for deep chains, balancing the construction of conjunction trees, and adding comprehensive tests to validate these enhancements.

**Improvements to AND/OR chain evaluation:**

* Added iterative evaluation for deeply nested AND/OR chains in `BinaryExpr::evaluate`, using a threshold to avoid stack overflow. (`datafusion/physical-expr/src/expressions/binary.rs`)
* Implemented `estimate_and_or_chain_depth`, `collect_boolean_chain_operands`, and `evaluate_and_or_chain` methods to support iterative evaluation and operand collection for homogeneous AND/OR chains. (`datafusion/physical-expr/src/expressions/binary.rs`)
* Defined a constant `ITERATIVE_AND_OR_CHAIN_DEPTH_THRESHOLD` to control when iterative evaluation is triggered. (`datafusion/physical-expr/src/expressions/binary.rs`)

**Enhancements to conjunction construction:**

* Modified `conjunction_opt` to build balanced binary trees for conjunctions, reducing tree depth to O(log n) and preventing deep recursion. Added supporting functions `build_balanced_binary_tree` and `build_balanced_tree_inner`. (`datafusion/physical-expr/src/utils/mod.rs`)

**Testing and validation:**

* Added extensive tests for chain depth estimation, operand collection, and iterative evaluation, including short-circuiting and correctness for various boolean value scenarios. (`datafusion/physical-expr/src/expressions/binary.rs`)
