### PR TITLE
Lazily initialize BatchCoalescer in RepartitionExec to avoid schema type mismatch

### DIFF
--- a/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
@@ -134,9 +134,19 @@ impl ExecutionPlan for CustomPlan {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        let schema_captured = self.schema().clone();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
-            futures::stream::iter(self.batches.clone().into_iter().map(Ok)),
+            futures::stream::iter(self.batches.clone().into_iter().map(move |batch| {
+                let projection: Vec<usize> = schema_captured
+                    .fields()
+                    .iter()
+                    .filter_map(|field| batch.schema().index_of(field.name()).ok())
+                    .collect();
+                batch
+                    .project(&projection)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+            })),
         )))
     }
 

--- a/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
+++ b/datafusion/core/tests/custom_sources_cases/provider_filter_pushdown.rs
@@ -134,19 +134,9 @@ impl ExecutionPlan for CustomPlan {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let schema_captured = self.schema().clone();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
-            futures::stream::iter(self.batches.clone().into_iter().map(move |batch| {
-                let projection: Vec<usize> = schema_captured
-                    .fields()
-                    .iter()
-                    .filter_map(|field| batch.schema().index_of(field.name()).ok())
-                    .collect();
-                batch
-                    .project(&projection)
-                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
-            })),
+            futures::stream::iter(self.batches.clone().into_iter().map(Ok)),
         )))
     }
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -30,7 +30,6 @@ use super::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use super::{
     DisplayAs, ExecutionPlanProperties, RecordBatchStream, SendableRecordBatchStream,
 };
-use crate::coalesce::LimitedBatchCoalescer;
 use crate::execution_plan::{CardinalityEffect, EvaluationType, SchedulingType};
 use crate::hash_utils::create_hashes;
 use crate::metrics::{BaselineMetrics, SpillMetrics};
@@ -999,7 +998,6 @@ impl ExecutionPlan for RepartitionExec {
                             spill_stream,
                             1, // Each receiver handles one input partition
                             BaselineMetrics::new(&metrics, partition),
-                            None, // subsequent merge sort already does batching https://github.com/apache/datafusion/blob/e4dcf0c85611ad0bd291f03a8e03fe56d773eb16/datafusion/physical-plan/src/sorts/merge.rs#L286
                         )) as SendableRecordBatchStream
                     })
                     .collect::<Vec<_>>();
@@ -1038,7 +1036,6 @@ impl ExecutionPlan for RepartitionExec {
                     spill_stream,
                     num_input_partitions,
                     BaselineMetrics::new(&metrics, partition),
-                    Some(context.session_config().batch_size()),
                 )) as SendableRecordBatchStream)
             }
         })
@@ -1531,13 +1528,9 @@ struct PerPartitionStream {
 
     /// Execution metrics
     baseline_metrics: BaselineMetrics,
-
-    /// None for sort preserving variant (merge sort already does coalescing)
-    batch_coalescer: Option<LimitedBatchCoalescer>,
 }
 
 impl PerPartitionStream {
-    #[expect(clippy::too_many_arguments)]
     fn new(
         schema: SchemaRef,
         receiver: DistributionReceiver<MaybeBatch>,
@@ -1546,10 +1539,7 @@ impl PerPartitionStream {
         spill_stream: SendableRecordBatchStream,
         num_input_partitions: usize,
         baseline_metrics: BaselineMetrics,
-        batch_size: Option<usize>,
     ) -> Self {
-        let batch_coalescer =
-            batch_size.map(|s| LimitedBatchCoalescer::new(Arc::clone(&schema), s, None));
         Self {
             schema,
             receiver,
@@ -1559,7 +1549,6 @@ impl PerPartitionStream {
             state: StreamState::ReadingMemory,
             remaining_partitions: num_input_partitions,
             baseline_metrics,
-            batch_coalescer,
         }
     }
 
@@ -1643,43 +1632,6 @@ impl PerPartitionStream {
             }
         }
     }
-
-    fn poll_next_and_coalesce(
-        self: &mut Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        coalescer: &mut LimitedBatchCoalescer,
-    ) -> Poll<Option<Result<RecordBatch>>> {
-        let cloned_time = self.baseline_metrics.elapsed_compute().clone();
-        let mut completed = false;
-
-        loop {
-            if let Some(batch) = coalescer.next_completed_batch() {
-                return Poll::Ready(Some(Ok(batch)));
-            }
-            if completed {
-                return Poll::Ready(None);
-            }
-
-            match ready!(self.poll_next_inner(cx)) {
-                Some(Ok(batch)) => {
-                    let _timer = cloned_time.timer();
-                    if let Err(err) = coalescer.push_batch(batch) {
-                        return Poll::Ready(Some(Err(err)));
-                    }
-                }
-                Some(err) => {
-                    return Poll::Ready(Some(err));
-                }
-                None => {
-                    completed = true;
-                    let _timer = cloned_time.timer();
-                    if let Err(err) = coalescer.finish() {
-                        return Poll::Ready(Some(Err(err)));
-                    }
-                }
-            }
-        }
-    }
 }
 
 impl Stream for PerPartitionStream {
@@ -1689,13 +1641,7 @@ impl Stream for PerPartitionStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let poll;
-        if let Some(mut coalescer) = self.batch_coalescer.take() {
-            poll = self.poll_next_and_coalesce(cx, &mut coalescer);
-            self.batch_coalescer = Some(coalescer);
-        } else {
-            poll = self.poll_next_inner(cx);
-        }
+        let poll = self.poll_next_inner(cx);
         self.baseline_metrics.record_poll(poll)
     }
 }
@@ -1730,9 +1676,9 @@ mod tests {
     use datafusion_common::exec_err;
     use datafusion_common::test_util::batches_to_sort_string;
     use datafusion_common_runtime::JoinSet;
-    use datafusion_execution::config::SessionConfig;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use insta::assert_snapshot;
+    use itertools::Itertools;
 
     #[tokio::test]
     async fn one_to_many_round_robin() -> Result<()> {
@@ -1746,13 +1692,10 @@ mod tests {
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(4)).await?;
 
         assert_eq!(4, output_partitions.len());
-        for partition in &output_partitions {
-            assert_eq!(1, partition.len());
-        }
-        assert_eq!(13 * 8, output_partitions[0][0].num_rows());
-        assert_eq!(13 * 8, output_partitions[1][0].num_rows());
-        assert_eq!(12 * 8, output_partitions[2][0].num_rows());
-        assert_eq!(12 * 8, output_partitions[3][0].num_rows());
+        assert_eq!(13, output_partitions[0].len());
+        assert_eq!(13, output_partitions[1].len());
+        assert_eq!(12, output_partitions[2].len());
+        assert_eq!(12, output_partitions[3].len());
 
         Ok(())
     }
@@ -1769,7 +1712,7 @@ mod tests {
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(1)).await?;
 
         assert_eq!(1, output_partitions.len());
-        assert_eq!(150 * 8, output_partitions[0][0].num_rows());
+        assert_eq!(150, output_partitions[0].len());
 
         Ok(())
     }
@@ -1785,12 +1728,12 @@ mod tests {
         let output_partitions =
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(5)).await?;
 
-        let total_rows_per_partition = 8 * 50 * 3 / 5;
         assert_eq!(5, output_partitions.len());
-        for partition in output_partitions {
-            assert_eq!(1, partition.len());
-            assert_eq!(total_rows_per_partition, partition[0].num_rows());
-        }
+        assert_eq!(30, output_partitions[0].len());
+        assert_eq!(30, output_partitions[1].len());
+        assert_eq!(30, output_partitions[2].len());
+        assert_eq!(30, output_partitions[3].len());
+        assert_eq!(30, output_partitions[4].len());
 
         Ok(())
     }
@@ -1817,32 +1760,6 @@ mod tests {
         assert_eq!(8, output_partitions.len());
         assert_eq!(total_rows, 8 * 50 * 3);
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_repartition_with_coalescing() -> Result<()> {
-        let schema = test_schema();
-        // create 50 batches, each having 8 rows
-        let partition = create_vec_batches(50);
-        let partitions = vec![partition.clone(), partition.clone()];
-        let partitioning = Partitioning::RoundRobinBatch(1);
-
-        let session_config = SessionConfig::new().with_batch_size(200);
-        let task_ctx = TaskContext::default().with_session_config(session_config);
-        let task_ctx = Arc::new(task_ctx);
-
-        // create physical plan
-        let exec = TestMemoryExec::try_new_exec(&partitions, Arc::clone(&schema), None)?;
-        let exec = RepartitionExec::try_new(exec, partitioning)?;
-
-        for i in 0..exec.partitioning().partition_count() {
-            let mut stream = exec.execute(i, Arc::clone(&task_ctx))?;
-            while let Some(result) = stream.next().await {
-                let batch = result?;
-                assert_eq!(200, batch.num_rows());
-            }
-        }
         Ok(())
     }
 
@@ -1891,12 +1808,12 @@ mod tests {
 
         let output_partitions = handle.join().await.unwrap().unwrap();
 
-        let total_rows_per_partition = 8 * 50 * 3 / 5;
         assert_eq!(5, output_partitions.len());
-        for partition in output_partitions {
-            assert_eq!(1, partition.len());
-            assert_eq!(total_rows_per_partition, partition[0].num_rows());
-        }
+        assert_eq!(30, output_partitions[0].len());
+        assert_eq!(30, output_partitions[1].len());
+        assert_eq!(30, output_partitions[2].len());
+        assert_eq!(30, output_partitions[3].len());
+        assert_eq!(30, output_partitions[4].len());
 
         Ok(())
     }
@@ -2134,13 +2051,14 @@ mod tests {
         });
         let batches_with_drop = crate::common::collect(output_stream1).await.unwrap();
 
-        let items_vec_with_drop = str_batches_to_vec(&batches_with_drop);
-        let items_set_with_drop: HashSet<&str> =
-            items_vec_with_drop.iter().copied().collect();
-        assert_eq!(
-            items_set_with_drop.symmetric_difference(&items_set).count(),
-            0
-        );
+        fn sort(batch: Vec<RecordBatch>) -> Vec<RecordBatch> {
+            batch
+                .into_iter()
+                .sorted_by_key(|b| format!("{b:?}"))
+                .collect()
+        }
+
+        assert_eq!(sort(batches_without_drop), sort(batches_with_drop));
     }
 
     fn str_batches_to_vec(batches: &[RecordBatch]) -> Vec<&str> {

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -1534,6 +1534,12 @@ struct PerPartitionStream {
 
     /// None for sort preserving variant (merge sort already does coalescing)
     batch_coalescer: Option<LimitedBatchCoalescer>,
+
+    /// Target batch size for lazy coalescer initialization.
+    /// The coalescer is created on the first batch using the actual batch
+    /// schema rather than the declared schema to avoid type mismatches
+    /// (e.g., a child declares LargeUtf8 but produces Utf8).
+    target_batch_size: Option<usize>,
 }
 
 impl PerPartitionStream {
@@ -1548,8 +1554,6 @@ impl PerPartitionStream {
         baseline_metrics: BaselineMetrics,
         batch_size: Option<usize>,
     ) -> Self {
-        let batch_coalescer =
-            batch_size.map(|s| LimitedBatchCoalescer::new(Arc::clone(&schema), s, None));
         Self {
             schema,
             receiver,
@@ -1559,7 +1563,8 @@ impl PerPartitionStream {
             state: StreamState::ReadingMemory,
             remaining_partitions: num_input_partitions,
             baseline_metrics,
-            batch_coalescer,
+            batch_coalescer: None,
+            target_batch_size: batch_size,
         }
     }
 
@@ -1689,13 +1694,48 @@ impl Stream for PerPartitionStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let poll;
-        if let Some(mut coalescer) = self.batch_coalescer.take() {
-            poll = self.poll_next_and_coalesce(cx, &mut coalescer);
+        let poll = if let Some(mut coalescer) = self.batch_coalescer.take() {
+            // Coalescer already initialized — use it
+            let result = self.poll_next_and_coalesce(cx, &mut coalescer);
             self.batch_coalescer = Some(coalescer);
+            result
+        } else if let Some(target_batch_size) = self.target_batch_size.take() {
+            // Coalescer not yet initialized — lazily create it from the
+            // first batch's actual schema to avoid type mismatches
+            // (e.g. child declares LargeUtf8 but produces Utf8).
+            match self.poll_next_inner(cx) {
+                Poll::Pending => {
+                    // Restore target_batch_size so we retry on next poll
+                    self.target_batch_size = Some(target_batch_size);
+                    return self.baseline_metrics.record_poll(Poll::Pending);
+                }
+                Poll::Ready(Some(Ok(batch))) => {
+                    let mut coalescer = LimitedBatchCoalescer::new(
+                        batch.schema(),
+                        target_batch_size,
+                        None,
+                    );
+                    if let Err(err) = coalescer.push_batch(batch) {
+                        return self
+                            .baseline_metrics
+                            .record_poll(Poll::Ready(Some(Err(err))));
+                    }
+                    let result = self.poll_next_and_coalesce(cx, &mut coalescer);
+                    self.batch_coalescer = Some(coalescer);
+                    result
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    return self.baseline_metrics.record_poll(Poll::Ready(Some(Err(e))));
+                }
+                Poll::Ready(None) => {
+                    // Stream ended with no batches — nothing to coalesce
+                    return self.baseline_metrics.record_poll(Poll::Ready(None));
+                }
+            }
         } else {
-            poll = self.poll_next_inner(cx);
-        }
+            // No coalescing requested (sort-preserving variant)
+            self.poll_next_inner(cx)
+        };
         self.baseline_metrics.record_poll(poll)
     }
 }

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -30,6 +30,7 @@ use super::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use super::{
     DisplayAs, ExecutionPlanProperties, RecordBatchStream, SendableRecordBatchStream,
 };
+use crate::coalesce::LimitedBatchCoalescer;
 use crate::execution_plan::{CardinalityEffect, EvaluationType, SchedulingType};
 use crate::hash_utils::create_hashes;
 use crate::metrics::{BaselineMetrics, SpillMetrics};
@@ -998,6 +999,7 @@ impl ExecutionPlan for RepartitionExec {
                             spill_stream,
                             1, // Each receiver handles one input partition
                             BaselineMetrics::new(&metrics, partition),
+                            None, // subsequent merge sort already does batching https://github.com/apache/datafusion/blob/e4dcf0c85611ad0bd291f03a8e03fe56d773eb16/datafusion/physical-plan/src/sorts/merge.rs#L286
                         )) as SendableRecordBatchStream
                     })
                     .collect::<Vec<_>>();
@@ -1036,6 +1038,7 @@ impl ExecutionPlan for RepartitionExec {
                     spill_stream,
                     num_input_partitions,
                     BaselineMetrics::new(&metrics, partition),
+                    Some(context.session_config().batch_size()),
                 )) as SendableRecordBatchStream)
             }
         })
@@ -1528,9 +1531,13 @@ struct PerPartitionStream {
 
     /// Execution metrics
     baseline_metrics: BaselineMetrics,
+
+    /// None for sort preserving variant (merge sort already does coalescing)
+    batch_coalescer: Option<LimitedBatchCoalescer>,
 }
 
 impl PerPartitionStream {
+    #[expect(clippy::too_many_arguments)]
     fn new(
         schema: SchemaRef,
         receiver: DistributionReceiver<MaybeBatch>,
@@ -1539,7 +1546,10 @@ impl PerPartitionStream {
         spill_stream: SendableRecordBatchStream,
         num_input_partitions: usize,
         baseline_metrics: BaselineMetrics,
+        batch_size: Option<usize>,
     ) -> Self {
+        let batch_coalescer =
+            batch_size.map(|s| LimitedBatchCoalescer::new(Arc::clone(&schema), s, None));
         Self {
             schema,
             receiver,
@@ -1549,6 +1559,7 @@ impl PerPartitionStream {
             state: StreamState::ReadingMemory,
             remaining_partitions: num_input_partitions,
             baseline_metrics,
+            batch_coalescer,
         }
     }
 
@@ -1632,6 +1643,43 @@ impl PerPartitionStream {
             }
         }
     }
+
+    fn poll_next_and_coalesce(
+        self: &mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        coalescer: &mut LimitedBatchCoalescer,
+    ) -> Poll<Option<Result<RecordBatch>>> {
+        let cloned_time = self.baseline_metrics.elapsed_compute().clone();
+        let mut completed = false;
+
+        loop {
+            if let Some(batch) = coalescer.next_completed_batch() {
+                return Poll::Ready(Some(Ok(batch)));
+            }
+            if completed {
+                return Poll::Ready(None);
+            }
+
+            match ready!(self.poll_next_inner(cx)) {
+                Some(Ok(batch)) => {
+                    let _timer = cloned_time.timer();
+                    if let Err(err) = coalescer.push_batch(batch) {
+                        return Poll::Ready(Some(Err(err)));
+                    }
+                }
+                Some(err) => {
+                    return Poll::Ready(Some(err));
+                }
+                None => {
+                    completed = true;
+                    let _timer = cloned_time.timer();
+                    if let Err(err) = coalescer.finish() {
+                        return Poll::Ready(Some(Err(err)));
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl Stream for PerPartitionStream {
@@ -1641,7 +1689,13 @@ impl Stream for PerPartitionStream {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        let poll = self.poll_next_inner(cx);
+        let poll;
+        if let Some(mut coalescer) = self.batch_coalescer.take() {
+            poll = self.poll_next_and_coalesce(cx, &mut coalescer);
+            self.batch_coalescer = Some(coalescer);
+        } else {
+            poll = self.poll_next_inner(cx);
+        }
         self.baseline_metrics.record_poll(poll)
     }
 }
@@ -1676,9 +1730,9 @@ mod tests {
     use datafusion_common::exec_err;
     use datafusion_common::test_util::batches_to_sort_string;
     use datafusion_common_runtime::JoinSet;
+    use datafusion_execution::config::SessionConfig;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use insta::assert_snapshot;
-    use itertools::Itertools;
 
     #[tokio::test]
     async fn one_to_many_round_robin() -> Result<()> {
@@ -1692,10 +1746,13 @@ mod tests {
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(4)).await?;
 
         assert_eq!(4, output_partitions.len());
-        assert_eq!(13, output_partitions[0].len());
-        assert_eq!(13, output_partitions[1].len());
-        assert_eq!(12, output_partitions[2].len());
-        assert_eq!(12, output_partitions[3].len());
+        for partition in &output_partitions {
+            assert_eq!(1, partition.len());
+        }
+        assert_eq!(13 * 8, output_partitions[0][0].num_rows());
+        assert_eq!(13 * 8, output_partitions[1][0].num_rows());
+        assert_eq!(12 * 8, output_partitions[2][0].num_rows());
+        assert_eq!(12 * 8, output_partitions[3][0].num_rows());
 
         Ok(())
     }
@@ -1712,7 +1769,7 @@ mod tests {
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(1)).await?;
 
         assert_eq!(1, output_partitions.len());
-        assert_eq!(150, output_partitions[0].len());
+        assert_eq!(150 * 8, output_partitions[0][0].num_rows());
 
         Ok(())
     }
@@ -1728,12 +1785,12 @@ mod tests {
         let output_partitions =
             repartition(&schema, partitions, Partitioning::RoundRobinBatch(5)).await?;
 
+        let total_rows_per_partition = 8 * 50 * 3 / 5;
         assert_eq!(5, output_partitions.len());
-        assert_eq!(30, output_partitions[0].len());
-        assert_eq!(30, output_partitions[1].len());
-        assert_eq!(30, output_partitions[2].len());
-        assert_eq!(30, output_partitions[3].len());
-        assert_eq!(30, output_partitions[4].len());
+        for partition in output_partitions {
+            assert_eq!(1, partition.len());
+            assert_eq!(total_rows_per_partition, partition[0].num_rows());
+        }
 
         Ok(())
     }
@@ -1760,6 +1817,32 @@ mod tests {
         assert_eq!(8, output_partitions.len());
         assert_eq!(total_rows, 8 * 50 * 3);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_repartition_with_coalescing() -> Result<()> {
+        let schema = test_schema();
+        // create 50 batches, each having 8 rows
+        let partition = create_vec_batches(50);
+        let partitions = vec![partition.clone(), partition.clone()];
+        let partitioning = Partitioning::RoundRobinBatch(1);
+
+        let session_config = SessionConfig::new().with_batch_size(200);
+        let task_ctx = TaskContext::default().with_session_config(session_config);
+        let task_ctx = Arc::new(task_ctx);
+
+        // create physical plan
+        let exec = TestMemoryExec::try_new_exec(&partitions, Arc::clone(&schema), None)?;
+        let exec = RepartitionExec::try_new(exec, partitioning)?;
+
+        for i in 0..exec.partitioning().partition_count() {
+            let mut stream = exec.execute(i, Arc::clone(&task_ctx))?;
+            while let Some(result) = stream.next().await {
+                let batch = result?;
+                assert_eq!(200, batch.num_rows());
+            }
+        }
         Ok(())
     }
 
@@ -1808,12 +1891,12 @@ mod tests {
 
         let output_partitions = handle.join().await.unwrap().unwrap();
 
+        let total_rows_per_partition = 8 * 50 * 3 / 5;
         assert_eq!(5, output_partitions.len());
-        assert_eq!(30, output_partitions[0].len());
-        assert_eq!(30, output_partitions[1].len());
-        assert_eq!(30, output_partitions[2].len());
-        assert_eq!(30, output_partitions[3].len());
-        assert_eq!(30, output_partitions[4].len());
+        for partition in output_partitions {
+            assert_eq!(1, partition.len());
+            assert_eq!(total_rows_per_partition, partition[0].num_rows());
+        }
 
         Ok(())
     }
@@ -2051,14 +2134,13 @@ mod tests {
         });
         let batches_with_drop = crate::common::collect(output_stream1).await.unwrap();
 
-        fn sort(batch: Vec<RecordBatch>) -> Vec<RecordBatch> {
-            batch
-                .into_iter()
-                .sorted_by_key(|b| format!("{b:?}"))
-                .collect()
-        }
-
-        assert_eq!(sort(batches_without_drop), sort(batches_with_drop));
+        let items_vec_with_drop = str_batches_to_vec(&batches_with_drop);
+        let items_set_with_drop: HashSet<&str> =
+            items_vec_with_drop.iter().copied().collect();
+        assert_eq!(
+            items_set_with_drop.symmetric_difference(&items_set).count(),
+            0
+        );
     }
 
     fn str_batches_to_vec(batches: &[RecordBatch]) -> Vec<&str> {


### PR DESCRIPTION
## Which issue does this PR close?

Fix issues below related to the following DF52 change: 20870c18a418ec081d44ecf8a90a30a95aa53138. Fixes 
- https://github.com/spiceai/spiceai/issues/9621

The coalescer was created eagerly using the **declared** schema from the execution plan. When the child operator produced batches with different actual types, `BatchCoalescer` hit a `debug_assert_eq!` (debug) or `RecordBatch::try_new_impl` validation error (release).

`SchemaCastScanExec` already handles this mismatch by casting batch types to the declared schema, but it sits above `RepartitionExec` in the plan tree and runs too late.

**What changed**: In DF 52, `RepartitionExec` now internally uses `BatchCoalescer` (from arrow-rs) which validates that array types match the declared schema and also we use provided declared schema upfront. Since `RepartitionExec` inherits the declared schema (`LargeUtf8`) but receives actual `Utf8` data from DuckDB, the new BatchCoalescer fails

### Plan Structure (identical in DF 51 and DF 52)

```
SchemaCastScanExec              ← casts Utf8 → LargeUtf8 (but too late!)
  CooperativeExec
    BytesProcessedExec
      CooperativeExec
        RepartitionExec: RoundRobinBatch(16)   ← BatchCoalescer panics here (DF 52 only)
          CooperativeExec
            VirtualExecutionPlan (DuckDB)      ← declares LargeUtf8, produces Utf8
```

## Fix

Initialize the `LimitedBatchCoalescer` lazily on the first batch received, using `batch.schema()` (the **actual** types) instead of the declared plan schema. This ensures the coalescer's internal schema matches what the child operator actually produces.

`BatchCoalescer` is purely mechanical — it buffers small `RecordBatch`es and concatenates them into larger ones via `arrow::compute::concat_batches()`. It doesn't interpret or transform data. Previously it was initialized with the **declared** plan schema, which caused a `debug_assert_eq!` panic (debug) or schema mismatch error (release) when the actual batch column types differed from what was declared.

- All 41 existing repartition tests pass

>running 41 tests
test repartition::distributor_channels::tests::test_meta_poll_pending_waker ... ok
test repartition::distributor_channels::tests::test_poll_empty_channel_twice ... ok
test repartition::distributor_channels::tests::test_multi_sender ... ok
test repartition::distributor_channels::tests::test_close_channel_by_dropping_tx ... ok
test repartition::distributor_channels::tests::test_gate ... ok
test repartition::distributor_channels::tests::test_single_channel_no_gate ... ok
test repartition::distributor_channels::tests::test_close_channel_by_dropping_rx_on_closed_gate ... ok
test repartition::distributor_channels::tests::test_drop_rx_three_channels ... ok
test repartition::distributor_channels::tests::test_close_channel_by_dropping_rx_on_open_gate ... ok
test repartition::distributor_channels::tests::test_close_channel_by_dropping_rx_clears_data ... ok
test repartition::distributor_channels::tests::test_meta_poll_pending_wrong_state - should panic ... ok
test repartition::distributor_channels::tests::test_meta_poll_ready_wrong_state - should panic ... ok
test repartition::distributor_channels::tests::test_panic_poll_send_future_after_ready_err - should panic ... ok
test repartition::distributor_channels::tests::test_panic_poll_send_future_after_ready_ok - should panic ... ok
test repartition::distributor_channels::tests::test_panic_poll_recv_future_after_ready_some - should panic ... ok
test repartition::distributor_channels::tests::test_panic_poll_recv_future_after_ready_none - should panic ... ok
test repartition::tests::error_for_input_exec ... ok
test repartition::tests::oom ... ok
test repartition::tests::repartition_with_error_in_stream ... ok
test repartition::tests::hash_repartition_avoid_empty_batch ... ok
test repartition::tests::one_to_many_round_robin ... ok
test repartition::tests::many_to_many_round_robin ... ok
test repartition::tests::many_to_many_round_robin_within_tokio_task ... ok
test repartition::tests::many_to_one_round_robin ... ok
test repartition::tests::repartition_without_spilling ... ok
test repartition::tests::unsupported_partitioning ... ok
test repartition::tests::hash_repartition_with_dropping_output_stream ... ok
test repartition::tests::test_repartition_with_coalescing ... ok
test repartition::test::test_hash_partitioning_with_spilling ... ok
test repartition::tests::many_to_many_hash_partition ... ok
test repartition::test::test_preserve_order_with_spilling ... ok
test repartition::tests::test_repartition_ordering_with_spilling ... ok
test repartition::tests::repartition_with_partial_spilling ... ok
test repartition::tests::repartition_with_spilling ... ok
test repartition::tests::test_drop_cancel ... ok
test repartition::test::test_preserve_order_one_partition ... ok
test repartition::test::test_preserve_order_input_not_sorted ... ok
test repartition::test::test_repartition ... ok
test repartition::test::test_preserve_order ... ok
test repartition::tests::robin_repartition_with_dropping_output_stream ... ok
test repartition::tests::repartition_with_delayed_stream ... ok
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 988 filtered out; finished in 0.07s