### PR TITLE
Fix panic in `try_swapping_with_projection` when metadata columns are projected

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -785,6 +785,29 @@ impl DataSource for FileScanConfig {
     ) -> Result<Option<Arc<dyn DataSource>>> {
         // This process can be moved into CsvExec, but it would be an overlap of their responsibility.
 
+        // Metadata columns (e.g. `location`, `size`, `last_modified`) are
+        // inserted at designated output positions by ExtendedColumnProjector
+        // and are NOT part of the file source's projection. If the incoming
+        // projection references any metadata column we cannot push it down
+        // into the file source — bail out and keep the ProjectionExec above.
+        if !self.projected_metadata_positions.is_empty() {
+            let has_metadata_refs = projection.iter().any(|proj_expr| {
+                proj_expr
+                    .expr
+                    .as_any()
+                    .downcast_ref::<Column>()
+                    .map(|c| {
+                        self.projected_metadata_positions
+                            .iter()
+                            .any(|(output_pos, _)| c.index() == *output_pos)
+                    })
+                    .unwrap_or(false)
+            });
+            if has_metadata_refs {
+                return Ok(None);
+            }
+        }
+
         // Must be all column references, with no table partition columns (which can not be projected)
         let partitioned_columns_in_proj = projection.iter().any(|proj_expr| {
             proj_expr


### PR DESCRIPTION
## Which issue does this PR close?

Backport similar improvement from spiceai-52 branch, adapted for v51 API differences.

`FileScanConfig::try_swapping_with_projection` does not account for metadata columns (`location`, `last_modified`, `size`) inserted into the output schema by `ExtendedColumnProjector`. These columns occupy output positions in the `DataSourceExec` schema but have no corresponding entries in the file source's internal projection array.

During optimization, there are scenarios where `remove_unnecessary_projections` attempts to fold a `ProjectionExec` into its child `DataSourceExec`. In these cases, `new_projections_for_columns` uses column output indices to index into the source projection array. Metadata column indices exceed the array length, causing an out-of-bounds panic.

**Fix:** Before attempting the projection swap, check whether any column in the incoming projection references a metadata column output position. If so, skip the swap and keep the `ProjectionExec` above. Non-metadata projections still benefit from the optimization.
