### PR TITLE
Support `table_partition_cols` in `CreateMemoryTable` and associated SQL parsing

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -869,6 +869,7 @@ impl SessionContext {
             constraints,
             column_defaults,
             temporary,
+            ..
         } = cmd;
 
         let input = Arc::unwrap_or_clone(input);

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -480,6 +480,57 @@ pub struct CreateMemoryTable {
     pub table_partition_cols: Vec<String>,
 }
 
+impl CreateMemoryTable {
+    /// Create a new [`CreateMemoryTable`] without specifying partition columns.
+    ///
+    /// This constructor is intended as a stable, forward-compatible API for
+    /// constructing [`CreateMemoryTable`]. Future fields can be added with
+    /// sensible defaults without requiring downstream code to change.
+    pub fn new(
+        name: TableReference,
+        constraints: Constraints,
+        input: Arc<LogicalPlan>,
+        if_not_exists: bool,
+        or_replace: bool,
+        column_defaults: Vec<(String, Expr)>,
+        temporary: bool,
+    ) -> Self {
+        Self {
+            name,
+            constraints,
+            input,
+            if_not_exists,
+            or_replace,
+            column_defaults,
+            temporary,
+            table_partition_cols: Vec::new(),
+        }
+    }
+
+    /// Create a new [`CreateMemoryTable`] with explicitly specified partition columns.
+    pub fn new_with_partition_cols(
+        name: TableReference,
+        constraints: Constraints,
+        input: Arc<LogicalPlan>,
+        if_not_exists: bool,
+        or_replace: bool,
+        column_defaults: Vec<(String, Expr)>,
+        temporary: bool,
+        table_partition_cols: Vec<String>,
+    ) -> Self {
+        Self {
+            name,
+            constraints,
+            input,
+            if_not_exists,
+            or_replace,
+            column_defaults,
+            temporary,
+            table_partition_cols,
+        }
+    }
+}
+
 /// Creates a view.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash)]
 pub struct CreateView {

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -476,6 +476,8 @@ pub struct CreateMemoryTable {
     pub column_defaults: Vec<(String, Expr)>,
     /// Whether the table is `TableType::Temporary`
     pub temporary: bool,
+    /// Partition Columns
+    pub table_partition_cols: Vec<String>,
 }
 
 /// Creates a view.

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -508,6 +508,7 @@ impl CreateMemoryTable {
     }
 
     /// Create a new [`CreateMemoryTable`] with explicitly specified partition columns.
+    #[expect(clippy::too_many_arguments)]
     pub fn new_with_partition_cols(
         name: TableReference,
         constraints: Constraints,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -989,6 +989,7 @@ impl LogicalPlan {
                 or_replace,
                 column_defaults,
                 temporary,
+                table_partition_cols,
                 ..
             })) => {
                 self.assert_no_expressions(expr)?;
@@ -1002,6 +1003,7 @@ impl LogicalPlan {
                         or_replace: *or_replace,
                         column_defaults: column_defaults.clone(),
                         temporary: *temporary,
+                        table_partition_cols: table_partition_cols.clone(),
                     },
                 )))
             }

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -990,6 +990,7 @@ impl LogicalPlan {
                 column_defaults,
                 temporary,
                 table_partition_cols,
+                constraints,
                 ..
             })) => {
                 self.assert_no_expressions(expr)?;
@@ -997,7 +998,7 @@ impl LogicalPlan {
                 Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
                     CreateMemoryTable {
                         input: Arc::new(input),
-                        constraints: Constraints::default(),
+                        constraints: constraints.clone(),
                         name: name.clone(),
                         if_not_exists: *if_not_exists,
                         or_replace: *or_replace,

--- a/datafusion/expr/src/logical_plan/tree_node.rs
+++ b/datafusion/expr/src/logical_plan/tree_node.rs
@@ -264,6 +264,7 @@ impl TreeNode for LogicalPlan {
                         or_replace,
                         column_defaults,
                         temporary,
+                        table_partition_cols,
                     }) => input.map_elements(f)?.update_data(|input| {
                         DdlStatement::CreateMemoryTable(CreateMemoryTable {
                             name,
@@ -273,6 +274,7 @@ impl TreeNode for LogicalPlan {
                             or_replace,
                             column_defaults,
                             temporary,
+                            table_partition_cols,
                         })
                     }),
                     DdlStatement::CreateView(CreateView {

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -372,6 +372,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     or_replace: false,
                     temporary: false,
                     column_defaults: vec![],
+                    table_partition_cols: vec![],
                 },
             ))),
             _ => Ok(plan),

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -517,6 +517,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                             plan
                         };
 
+                        // Validate partition columns exist in the schema
+                        for col_name in &table_partition_cols {
+                            if !plan.schema().has_column_with_unqualified_name(col_name) {
+                                return plan_err!(
+                                    "PARTITION BY column '{col_name}' not found in table schema"
+                                );
+                            }
+                        }
+
                         let constraints = self.new_constraint_from_table_constraints(
                             &all_constraints,
                             plan.schema(),
@@ -537,6 +546,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     }
 
                     None => {
+                        // Validate partition columns exist in the schema
+                        for col_name in &table_partition_cols {
+                            if !schema.has_column_with_unqualified_name(col_name) {
+                                return plan_err!(
+                                    "PARTITION BY column '{col_name}' not found in table schema"
+                                );
+                            }
+                        }
+
                         let plan = EmptyRelation {
                             produce_one_row: false,
                             schema,

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -517,14 +517,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                             plan
                         };
 
-                        // Validate partition columns exist in the schema
-                        for col_name in &table_partition_cols {
-                            if !plan.schema().has_column_with_unqualified_name(col_name) {
-                                return plan_err!(
-                                    "PARTITION BY column '{col_name}' not found in table schema"
-                                );
-                            }
-                        }
+                        Self::validate_partition_columns(plan.schema(), &table_partition_cols)?;
 
                         let constraints = self.new_constraint_from_table_constraints(
                             &all_constraints,
@@ -546,14 +539,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     }
 
                     None => {
-                        // Validate partition columns exist in the schema
-                        for col_name in &table_partition_cols {
-                            if !schema.has_column_with_unqualified_name(col_name) {
-                                return plan_err!(
-                                    "PARTITION BY column '{col_name}' not found in table schema"
-                                );
-                            }
-                        }
+                        Self::validate_partition_columns(&schema, &table_partition_cols)?;
 
                         let plan = EmptyRelation {
                             produce_one_row: false,
@@ -1698,6 +1684,21 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
 
     /// Convert a `PARTITION BY` expression into a list of column name strings.
     ///
+    /// Validate that all partition column names exist in the given schema.
+    fn validate_partition_columns(
+        schema: &DFSchema,
+        partition_cols: &[String],
+    ) -> Result<()> {
+        for col_name in partition_cols {
+            if !schema.has_column_with_unqualified_name(col_name) {
+                return plan_err!(
+                    "PARTITION BY column '{col_name}' not found in table schema"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Supports the following forms:
     /// - `PARTITION BY col` — a single identifier
     /// - `PARTITION BY (col1, col2, ...)` — a tuple of identifiers

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -540,7 +540,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 or_replace,
                                 column_defaults,
                                 temporary,
-                                table_partition_cols: table_partition_cols.clone(),
+                                table_partition_cols,
                             },
                         )))
                     }

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -384,9 +384,11 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 if order_by.is_some() {
                     return not_impl_err!("Order by not supported")?;
                 }
-                if partition_by.is_some() {
-                    return not_impl_err!("Partition by not supported")?;
-                }
+                let table_partition_cols = if let Some(partition_by) = partition_by {
+                    Self::partition_by_to_col_names(*partition_by)?
+                } else {
+                    vec![]
+                };
                 if cluster_by.is_some() {
                     return not_impl_err!("Cluster by not supported")?;
                 }
@@ -529,6 +531,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 or_replace,
                                 column_defaults,
                                 temporary,
+                                table_partition_cols: table_partition_cols.clone(),
                             },
                         )))
                     }
@@ -552,6 +555,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 or_replace,
                                 column_defaults,
                                 temporary,
+                                table_partition_cols,
                             },
                         )))
                     }
@@ -1672,6 +1676,31 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 .with_column_defaults(column_defaults)
                 .build(),
         )))
+    }
+
+    /// Convert a `PARTITION BY` expression into a list of column name strings.
+    ///
+    /// Supports the following forms:
+    /// - `PARTITION BY col` — a single identifier
+    /// - `PARTITION BY (col1, col2, ...)` — a tuple of identifiers
+    fn partition_by_to_col_names(expr: SQLExpr) -> Result<Vec<String>> {
+        match expr {
+            SQLExpr::Identifier(ident) => Ok(vec![normalize_ident(ident)]),
+            // PARTITION BY (col) is parsed as Nested(Identifier)
+            SQLExpr::Nested(inner) => Self::partition_by_to_col_names(*inner),
+            SQLExpr::Tuple(exprs) => exprs
+                .into_iter()
+                .map(|e| match e {
+                    SQLExpr::Identifier(ident) => Ok(normalize_ident(ident)),
+                    other => plan_err!(
+                        "Expected column name identifier in PARTITION BY, found: {other}"
+                    ),
+                })
+                .collect(),
+            other => plan_err!(
+                "Expected column name(s) in PARTITION BY, found: {other}"
+            ),
+        }
     }
 
     /// Get the indices of the constraint columns in the schema.

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -529,6 +529,23 @@ fn plan_create_table_check_constraint() {
 }
 
 #[test]
+fn plan_create_table_partition_by_single_column_no_parens() {
+    let sql = "create table person (id int, name string) partition by name";
+    let plan = logical_plan(sql).unwrap();
+    match &plan {
+        LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+            datafusion_expr::CreateMemoryTable {
+                table_partition_cols,
+                ..
+            },
+        )) => {
+            assert_eq!(table_partition_cols, &vec!["name".to_string()]);
+        }
+        _ => panic!("Expected CreateMemoryTable, got {plan:?}"),
+    }
+}
+
+#[test]
 fn plan_create_table_partition_by_single_column() {
     let sql = "create table person (id int, name string) partition by (name)";
     let plan = logical_plan(sql).unwrap();

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -612,6 +612,28 @@ fn plan_create_table_partition_by_invalid_expr() {
 }
 
 #[test]
+fn plan_create_table_partition_by_unknown_column() {
+    let sql = "create table person (id int, name string) partition by (unknown_col)";
+    let result = logical_plan(sql);
+    assert!(result.is_err());
+    assert_contains!(
+        result.unwrap_err().strip_backtrace(),
+        "PARTITION BY column 'unknown_col' not found in table schema"
+    );
+}
+
+#[test]
+fn plan_create_table_as_select_partition_by_unknown_column() {
+    let sql = "create table person_copy partition by (unknown_col) as select * from person";
+    let result = logical_plan(sql);
+    assert!(result.is_err());
+    assert_contains!(
+        result.unwrap_err().strip_backtrace(),
+        "PARTITION BY column 'unknown_col' not found in table schema"
+    );
+}
+
+#[test]
 fn plan_start_transaction() {
     let sql = "start transaction";
     let plan = logical_plan(sql).unwrap();

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -529,6 +529,89 @@ fn plan_create_table_check_constraint() {
 }
 
 #[test]
+fn plan_create_table_partition_by_single_column() {
+    let sql = "create table person (id int, name string) partition by (name)";
+    let plan = logical_plan(sql).unwrap();
+    match &plan {
+        LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+            datafusion_expr::CreateMemoryTable {
+                table_partition_cols,
+                ..
+            },
+        )) => {
+            assert_eq!(table_partition_cols, &vec!["name".to_string()]);
+        }
+        _ => panic!("Expected CreateMemoryTable, got {plan:?}"),
+    }
+}
+
+#[test]
+fn plan_create_table_partition_by_multiple_columns() {
+    let sql = "create table person (id int, name string) partition by (id, name)";
+    let plan = logical_plan(sql).unwrap();
+    match &plan {
+        LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+            datafusion_expr::CreateMemoryTable {
+                table_partition_cols,
+                ..
+            },
+        )) => {
+            assert_eq!(
+                table_partition_cols,
+                &vec!["id".to_string(), "name".to_string()]
+            );
+        }
+        _ => panic!("Expected CreateMemoryTable, got {plan:?}"),
+    }
+}
+
+#[test]
+fn plan_create_table_partition_by_no_partition() {
+    let sql = "create table person (id int, name string)";
+    let plan = logical_plan(sql).unwrap();
+    match &plan {
+        LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+            datafusion_expr::CreateMemoryTable {
+                table_partition_cols,
+                ..
+            },
+        )) => {
+            assert!(table_partition_cols.is_empty());
+        }
+        _ => panic!("Expected CreateMemoryTable, got {plan:?}"),
+    }
+}
+
+#[test]
+fn plan_create_table_as_select_partition_by() {
+    let sql =
+        "create table person_copy partition by (id) as select * from person";
+    let plan = logical_plan(sql).unwrap();
+    match &plan {
+        LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+            datafusion_expr::CreateMemoryTable {
+                table_partition_cols,
+                ..
+            },
+        )) => {
+            assert_eq!(table_partition_cols, &vec!["id".to_string()]);
+        }
+        _ => panic!("Expected CreateMemoryTable, got {plan:?}"),
+    }
+}
+
+#[test]
+fn plan_create_table_partition_by_invalid_expr() {
+    let sql = "create table person (id int, name string) partition by (1 + 2)";
+    let result = logical_plan(sql);
+    assert!(result.is_err());
+    assert_contains!(
+        result.unwrap_err().strip_backtrace(),
+        "Expected column name(s) in PARTITION BY"
+    );
+}
+
+#[test]
 fn plan_start_transaction() {
     let sql = "start transaction";
     let plan = logical_plan(sql).unwrap();


### PR DESCRIPTION
## Which issue does this PR close?
Minimum changes required to support table creation DDL with `partition by`. e.g. 
```sql
 CREATE TABLE IF NOT EXISTS "customer" (
  "c_custkey" BIGINT, 
  "c_name" TEXT, 
  "c_address" TEXT, 
  "c_nationkey" BIGINT, 
 --  etc.
) PARTITION BY (c_nationkey)
```

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
