### PR TITLE
fix: Fix BigQuery timestamp literal format in SQL unparsing

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -623,6 +623,18 @@ impl Dialect for BigQueryDialect {
     fn unnest_as_table_factor(&self) -> bool {
         true
     }
+
+    fn timestamp_with_tz_to_string(&self, dt: DateTime<Tz>, unit: TimeUnit) -> String {
+        // https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
+        let format = match unit {
+            TimeUnit::Second => "%Y-%m-%d %H:%M:%S%:z",
+            TimeUnit::Millisecond => "%Y-%m-%d %H:%M:%S%.3f%:z",
+            TimeUnit::Microsecond => "%Y-%m-%d %H:%M:%S%.6f%:z",
+            TimeUnit::Nanosecond => "%Y-%m-%d %H:%M:%S%.9f%:z",
+        };
+
+        dt.format(format).to_string()
+    }
 }
 
 impl BigQueryDialect {


### PR DESCRIPTION
## Which issue does this PR close?

The default `Dialect::timestamp_with_tz_to_string` uses `dt.to_string()` which produces timestamps with a space before the TimeZone offset:

>2016-08-06 20:05:00 +00:00 <- invalid for BigQuery: 
invalid timestamp: '2016-08-06 20:05:00 +00:00'; while executing the filter on column 'startTime' (query) (sqlstate: [0, 0, 0, 0, 0], vendor_code: -2147483648)

BigQuery rejects this format. Per the [BigQuery timestamp docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type), the offset must be attached directly to the time:

>2016-08-06 20:05:00+00:00 <- valid

This causes filter pushdown to fail when unparsing timestamp predicates for BigQuery.

### Changes

Override `timestamp_with_tz_to_string` in `BigQueryDialect` using chrono's `%:z` format specifier, which produces the offset without a leading space.

**Before (default `dt.to_string()`):**

```sql
CAST('2016-08-06 20:05:00 +00:00' AS TIMESTAMP)  -- BigQuery error
```
After (%:z format):

```sql
CAST('2016-08-06 20:05:00+00:00' AS TIMESTAMP)  -- valid BigQuery timestamp
```

Similar to DuckDB recent fix: https://github.com/apache/datafusion/pull/17653