### PR TITLE
fix(unparser): Add `date_field_extract_style` and `interval_style` overrides for `BigQueryDialect`

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -620,6 +620,27 @@ impl Dialect for BigQueryDialect {
         }
     }
 
+    fn date_field_extract_style(&self) -> DateFieldExtractStyle {
+        DateFieldExtractStyle::Extract
+    }
+
+    fn interval_style(&self) -> IntervalStyle {
+        IntervalStyle::SQLStandard
+    }
+
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        func_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        if func_name == "date_part" {
+            return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+        }
+
+        Ok(None)
+    }
+
     fn unnest_as_table_factor(&self) -> bool {
         true
     }


### PR DESCRIPTION
## Which issue does this PR close?

Fixes BigQuery SQL unparsing that generates incompatible `date_part()` function calls and PostgreSQL-style `INTERVAL` syntax, causing TPC-H query failures.

**Affected TPC-H queries:**
| Queries | Error |
|---------|-------|
| Q7, Q8, Q9 | `Function not found: date_part` |
| Q4, Q20 | `Syntax error: Unexpected ")"` (invalid `INTERVAL '3 MONS'` syntax) |

`BigQueryDialect` inherited default trait implementations producing PostgreSQL-style SQL that BigQuery does not support:
- `date_field_extract_style()` defaulted to `DatePart` → generates `date_part('YEAR', ...)` (BigQuery requires `EXTRACT`)
- `interval_style()` defaulted to `PostgresVerbose` → generates `INTERVAL '3 MONS'` (BigQuery requires SQL standard intervals)

## What changes are included in this PR?

Override `date_field_extract_style()` and `interval_style()` in `BigQueryDialect`.

### Before

```sql
-- Q7, Q8, Q9: date_part not supported in BigQuery
date_part('YEAR', lineitem.l_shipdate)

-- Q4, Q20: INTERVAL with MONS abbreviation not supported
CAST('1993-07-01' AS DATE) + INTERVAL '3 MONS'
```

### After

```sql
-- Q7, Q8, Q9: EXTRACT is BigQuery-compatible
EXTRACT(YEAR FROM lineitem.l_shipdate)

-- Q4, Q20: SQL standard interval is BigQuery-compatible
CAST('1993-07-01' AS DATE) + INTERVAL '3' MONTH
```

## Are these changes tested?

Yes, tested manually using TPC-H
