### PR TITLE
fix(unparser): Use FLOAT64 instead of DOUBLE in BigQueryDialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -620,6 +620,10 @@ impl Dialect for BigQueryDialect {
         }
     }
 
+    fn float64_ast_dtype(&self) -> ast::DataType {
+        ast::DataType::Float64
+    }
+
     fn date_field_extract_style(&self) -> DateFieldExtractStyle {
         DateFieldExtractStyle::Extract
     }


### PR DESCRIPTION
## Which issue does this PR close?

BigQuery does not support the `DOUBLE` type keyword. Queries containing `CAST(... AS DOUBLE)` fail with `Type not found: DOUBLE`. BigQuery uses `FLOAT64 `instead.