### PR TITLE
fix(unparser): Disable column alias in table alias for BigQueryDialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -649,6 +649,10 @@ impl Dialect for BigQueryDialect {
         true
     }
 
+    fn supports_column_alias_in_table_alias(&self) -> bool {
+        false
+    }
+
     fn timestamp_with_tz_to_string(&self, dt: DateTime<Tz>, unit: TimeUnit) -> String {
         // https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
         let format = match unit {


### PR DESCRIPTION
BigQuery does not support column aliases in table alias definitions (e.g. `AS c(key)`), failing with `Expected ")" but got "("`.

Override `supports_column_alias_in_table_alias()` to return `false` in `BigQueryDialect`. The unparser will inline column aliases into the subquery projection instead.

**Before:** `SELECT c.key FROM (SELECT o_orderkey FROM orders) AS c(key)`
**After:** `SELECT c.key FROM (SELECT o_orderkey AS key FROM orders) AS c`

## Are these changes tested?

Verified against BigQuery.