### PR TITLE
Add `supports_subquery_in_join_predicate` dialect flag to avoid subqueries in JOIN ON

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -248,6 +248,23 @@ pub trait Dialect: Send + Sync {
     fn supports_empty_select_list(&self) -> bool {
         false
     }
+
+    /// Whether the dialect supports subquery expressions (scalar subqueries,
+    /// `IN` subqueries, `EXISTS`) inside `JOIN ON` predicates.
+    ///
+    /// When `false` and the join is an inner join, subquery-containing filter
+    /// predicates are moved from the `ON` clause to the `WHERE` clause, which
+    /// is semantically equivalent for inner joins.
+    ///
+    /// For non-inner joins (LEFT, RIGHT, FULL) when this returns `false`, the
+    /// unparser returns an error (not currently supported)
+    ///
+    /// # Default
+    ///
+    /// Returns `true` — most SQL backends accept subqueries in `JOIN ON`.
+    fn supports_subquery_in_join_predicate(&self) -> bool {
+        true
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -653,6 +670,10 @@ impl Dialect for BigQueryDialect {
         false
     }
 
+    fn supports_subquery_in_join_predicate(&self) -> bool {
+        false
+    }
+
     fn timestamp_with_tz_to_string(&self, dt: DateTime<Tz>, unit: TimeUnit) -> String {
         // https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
         let format = match unit {
@@ -694,6 +715,7 @@ pub struct CustomDialect {
     window_func_support_window_frame: bool,
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
+    supports_subquery_in_join_predicate: bool,
 }
 
 impl Default for CustomDialect {
@@ -722,6 +744,7 @@ impl Default for CustomDialect {
             window_func_support_window_frame: true,
             full_qualified_col: false,
             unnest_as_table_factor: false,
+            supports_subquery_in_join_predicate: true,
         }
     }
 }
@@ -832,6 +855,10 @@ impl Dialect for CustomDialect {
     fn unnest_as_table_factor(&self) -> bool {
         self.unnest_as_table_factor
     }
+
+    fn supports_subquery_in_join_predicate(&self) -> bool {
+        self.supports_subquery_in_join_predicate
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -869,6 +896,7 @@ pub struct CustomDialectBuilder {
     window_func_support_window_frame: bool,
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
+    supports_subquery_in_join_predicate: bool,
 }
 
 impl Default for CustomDialectBuilder {
@@ -903,6 +931,7 @@ impl CustomDialectBuilder {
             window_func_support_window_frame: true,
             full_qualified_col: false,
             unnest_as_table_factor: false,
+            supports_subquery_in_join_predicate: true,
         }
     }
 
@@ -929,6 +958,8 @@ impl CustomDialectBuilder {
             window_func_support_window_frame: self.window_func_support_window_frame,
             full_qualified_col: self.full_qualified_col,
             unnest_as_table_factor: self.unnest_as_table_factor,
+            supports_subquery_in_join_predicate: self
+                .supports_subquery_in_join_predicate,
         }
     }
 
@@ -1067,6 +1098,17 @@ impl CustomDialectBuilder {
 
     pub fn with_unnest_as_table_factor(mut self, unnest_as_table_factor: bool) -> Self {
         self.unnest_as_table_factor = unnest_as_table_factor;
+        self
+    }
+
+    /// Customize whether the dialect supports subquery expressions inside
+    /// `JOIN ON` predicates.
+    pub fn with_supports_subquery_in_join_predicate(
+        mut self,
+        supports_subquery_in_join_predicate: bool,
+    ) -> Self {
+        self.supports_subquery_in_join_predicate =
+            supports_subquery_in_join_predicate;
         self
     }
 }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -28,7 +28,8 @@ use super::{
     },
     utils::{
         find_agg_node_within_select, find_unnest_node_within_select,
-        find_window_nodes_within_select, try_transform_to_simple_table_scan_with_filters,
+        find_window_nodes_within_select, partition_subquery_filters,
+        try_transform_to_simple_table_scan_with_filters,
         unproject_sort_expr, unproject_unnest_expr, unproject_window_exprs,
     },
 };
@@ -741,12 +742,42 @@ impl Unparser<'_> {
                     &mut right_relation,
                 )?;
 
-                let join_filters = if table_scan_filters.is_empty() {
+                // When the dialect does not support subqueries inside JOIN ON
+                // predicates, separate subquery-containing filters from simple
+                // ones. For inner joins, subquery filters move to WHERE
+                // (semantically equivalent). For non-inner joins, return an
+                // error since moving to WHERE would change join semantics.
+                let (on_filters, where_filters): (Vec<_>, Vec<_>) =
+                    if self.dialect.supports_subquery_in_join_predicate() {
+                        (table_scan_filters, vec![])
+                    } else {
+                        let (simple, subquery) =
+                            partition_subquery_filters(table_scan_filters);
+
+                        if !subquery.is_empty()
+                            && join.join_type != JoinType::Inner
+                        {
+                            return not_impl_err!(
+                                "Subqueries in JOIN ON predicates are not supported for {} joins by this dialect",
+                                join.join_type
+                            );
+                        }
+
+                        (simple, subquery)
+                    };
+
+                // Move subquery-containing filters to WHERE for inner joins
+                for filter in where_filters {
+                    let filter_expr = self.expr_to_sql(&filter)?;
+                    select.selection(Some(filter_expr));
+                }
+
+                let join_filters = if on_filters.is_empty() {
                     join.filter.clone()
                 } else {
-                    // Combine `table_scan_filters` into a single filter using `AND`
+                    // Combine `on_filters` into a single filter using `AND`
                     let Some(combined_filters) =
-                        table_scan_filters.into_iter().reduce(|acc, filter| {
+                        on_filters.into_iter().reduce(|acc, filter| {
                             Expr::BinaryExpr(BinaryExpr {
                                 left: Box::new(acc),
                                 op: Operator::And,

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -419,6 +419,27 @@ pub(crate) fn try_transform_to_simple_table_scan_with_filters(
     Ok(None)
 }
 
+/// Returns `true` if the expression contains a subquery (scalar, IN, or EXISTS).
+pub(crate) fn expr_contains_subquery(expr: &Expr) -> bool {
+    expr.exists(|e| {
+        Ok(matches!(
+            e,
+            Expr::ScalarSubquery(_) | Expr::InSubquery(_) | Expr::Exists(_)
+        ))
+    })
+    .unwrap_or(false)
+}
+
+/// Partitions filters into `(non_subquery, subquery)` based on whether
+/// each filter contains a subquery expression.
+pub(crate) fn partition_subquery_filters(
+    filters: Vec<Expr>,
+) -> (Vec<Expr>, Vec<Expr>) {
+    filters
+        .into_iter()
+        .partition(|f| !expr_contains_subquery(f))
+}
+
 /// Converts a date_part function to SQL, tailoring it to the supported date field extraction style.
 pub(crate) fn date_part_to_sql(
     unparser: &Unparser,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -28,7 +28,8 @@ use datafusion_expr::test::function_stub::{
 use datafusion_expr::{
     EmptyRelation, Expr, Extension, LogicalPlan, LogicalPlanBuilder, Union,
     UserDefinedLogicalNode, UserDefinedLogicalNodeCore, WindowFrame,
-    WindowFunctionDefinition, cast, col, lit, not_exists, table_scan, wildcard,
+    WindowFunctionDefinition, cast, col, lit, not_exists, scalar_subquery, table_scan,
+    wildcard,
 };
 use datafusion_functions::unicode;
 use datafusion_functions_aggregate::grouping::grouping_udaf;
@@ -3177,6 +3178,86 @@ fn test_filter_with_subquery_over_aliased_table_scan_pushdown() -> Result<()> {
     assert_snapshot!(
         sql,
         @"SELECT * FROM (SELECT customer.c_custkey, customer.c_acctbal FROM customer WHERE ((customer.c_acctbal > 0.0) AND NOT EXISTS (SELECT orders.o_orderkey, orders.o_custkey FROM orders WHERE (orders.o_custkey = customer.c_custkey))) AND (customer.c_acctbal > 0.0)) AS custsale"
+    );
+
+    Ok(())
+}
+
+/// Verifies that when `supports_subquery_in_join_predicate` returns false,
+/// subquery-containing filters extracted from `Filter -> TableScan` are moved
+/// to the WHERE clause instead of the JOIN ON clause for inner joins.
+#[test]
+fn test_inner_join_scalar_subquery_filter_moved_to_where() -> Result<()> {
+    let part_schema = Schema::new(vec![
+        Field::new("p_partkey", DataType::Int32, false),
+    ]);
+
+    let partsupp_schema = Schema::new(vec![
+        Field::new("ps_partkey", DataType::Int32, false),
+        Field::new("ps_supplycost", DataType::Float64, false),
+    ]);
+
+    // Build the scalar subquery:
+    //   SELECT min(ps_supplycost) FROM partsupp
+    //   WHERE p_partkey = ps_partkey
+    let subquery_scan =
+        table_scan(Some("partsupp"), &partsupp_schema, Some(vec![0, 1]))?.build()?;
+
+    let subquery_plan = LogicalPlanBuilder::from(subquery_scan)
+        .filter(
+            col("partsupp.ps_partkey").eq(Expr::OuterReferenceColumn(
+                Arc::new(Field::new("p_partkey", DataType::Int32, false)),
+                Column::new(Some("part"), "p_partkey"),
+            )),
+        )?
+        .aggregate(
+            Vec::<Expr>::new(),
+            vec![min_udaf()
+                .call(vec![col("partsupp.ps_supplycost")])
+                .alias("min_cost")],
+        )?
+        .project(vec![col("min_cost")])?
+        .build()?;
+
+    let subquery_expr = scalar_subquery(Arc::new(subquery_plan));
+
+    // Build: Filter(ps_supplycost = <subquery>, TableScan(partsupp))
+    let partsupp_scan =
+        table_scan(Some("partsupp"), &partsupp_schema, Some(vec![0, 1]))?.build()?;
+
+    let partsupp_filtered = LogicalPlanBuilder::from(partsupp_scan)
+        .filter(col("partsupp.ps_supplycost").eq(subquery_expr))?
+        .build()?;
+
+    // Build: part INNER JOIN (Filter -> partsupp) ON p_partkey = ps_partkey
+    let part_scan =
+        table_scan(Some("part"), &part_schema, Some(vec![0]))?.build()?;
+
+    let join_plan = LogicalPlanBuilder::from(part_scan)
+        .join(
+            partsupp_filtered,
+            datafusion_expr::JoinType::Inner,
+            (vec!["part.p_partkey"], vec!["partsupp.ps_partkey"]),
+            None,
+        )?
+        .build()?;
+
+    // Default dialect (supports_subquery_in_join_predicate = true):
+    // subquery stays in ON
+    let default_sql = plan_to_sql(&join_plan)?;
+    assert_snapshot!(
+        default_sql,
+        @r#"SELECT "part".p_partkey, partsupp.ps_partkey, partsupp.ps_supplycost FROM "part" INNER JOIN partsupp ON "part".p_partkey = partsupp.ps_partkey AND (partsupp.ps_supplycost = (SELECT min(partsupp.ps_supplycost) AS min_cost FROM partsupp WHERE (partsupp.ps_partkey = "part".p_partkey)))"#
+    );
+
+    // BigQuery dialect (supports_subquery_in_join_predicate = false):
+    // subquery moves to WHERE
+    let bigquery_dialect = BigQueryDialect::new();
+    let unparser = Unparser::new(&bigquery_dialect);
+    let bigquery_sql = unparser.plan_to_sql(&join_plan)?;
+    assert_snapshot!(
+        bigquery_sql,
+        @r#"SELECT `part`.`p_partkey`, `partsupp`.`ps_partkey`, `partsupp`.`ps_supplycost` FROM `part` INNER JOIN `partsupp` ON `part`.`p_partkey` = `partsupp`.`ps_partkey` WHERE (`partsupp`.`ps_supplycost` = (SELECT min(`partsupp`.`ps_supplycost`) AS `min_cost` FROM `partsupp` WHERE (`partsupp`.`ps_partkey` = `part`.`p_partkey`)))"#
     );
 
     Ok(())


### PR DESCRIPTION
### Which issue does this PR close?

Fixes failing TPC-H queries for BigQuery:
 - https://github.com/spiceai/spiceai/issues/9954

### What changes are included in this PR?

Some SQL backends (e.g. BigQuery) reject subquery expressions (scalar subqueries, `IN`, `EXISTS`) inside `JOIN ON` predicates. Currently, `try_transform_to_simple_table_scan_with_filters` extracts all `Filter -> TableScan` predicates and folds them into `ON`, including subquery-containing ones.

This PR adds a `supports_subquery_in_join_predicate` dialect flag (default `true`) that controls this behavior:

- When `false` and the join is `INNER`, subquery-containing filters are moved to `WHERE` instead of `ON` (semantically equivalent for inner joins). This covers most popular scenario including all TPC-H.
- When `false` and the join is non-inner (`LEFT`/`RIGHT`/`FULL`), returns an error since moving to `WHERE` would change join semantics.
- When `true` (default), no behavior change.

`BigQueryDialect` overrides the flag to `false`.

**Background**: 

Other scenario support (LEFT joins) is **significantly more complex** (requires full subquery) — as noted in [PR #13132](https://github.com/apache/datafusion/pull/13132): 

> The alternative approach considered was always unparsing join sub-nodes by adding a wildcard projection if needed. However, it requires introducing additional alias for a subquery (and updating corresponding upper nodes to match alias added) as not all engines support adding subquery with the same name as original table, for example `JOIN (SELECT * FROM "orders" WHERE "orders"."o_comment" not like '%special%requests%') as orders ..` - `as orders` needs to be replaced with new alias for most engines.

There was also an attempt to implement this some time ago  - PR [#13496](https://github.com/apache/datafusion/pull/13496) but PR attempted the fix but moving filters to `WHERE` always (which is NOT always correct) instead of subquery and was closed as stale 

### Potential simplification

For inner joins, `ON` and `WHERE` are semantically equivalent — all `table_scan_filters` (not just subquery ones) could be moved to `WHERE`. This would eliminate the need for `partition_subquery_filters` / `expr_contains_subquery`/`supports_subquery_in_join_predicate` entirely. The current approach is conservative: only subquery filters are moved, keeping simple filters in `ON` to minimize SQL output changes. I'll discuss this alternative approach when creating upstream PR.

### Are these changes tested?

Added `test_inner_join_scalar_subquery_filter_moved_to_where` that verifies:
- Default dialect: subquery stays in `ON`
- BigQuery dialect: subquery moves to `WHERE`

### Are there any user-facing changes?

No change for existing dialects (flag defaults to `true`). BigQuery dialect now avoids generating unsupported subqueries in `JOIN ON`.