### PR TITLE
Implement `ExecutionPlan::fetch` and `ExecutionPlan::with_fetch` for `ProjectionExec`

### DIFF
--- a/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
@@ -1093,3 +1093,34 @@ fn test_sort_pushdown_exact_preserves_fetch() {
     "
     );
 }
+
+#[test]
+fn test_sort_pushdown_exact_preserves_fetch_through_projection() {
+    // Regression test: in the Exact pushdown path, SortExec is removed and
+    // fetch must be propagated through ProjectionExec to the source via with_fetch().
+    let schema = schema();
+    let source = exact_test_scan(schema.clone());
+
+    // Projection reorders columns: SELECT b, a
+    let projection = simple_projection_exec(source, vec![1, 0]);
+
+    // Sort on projected column b with LIMIT.
+    let b_expr_at_0 = sort_expr_named("b", 0);
+    let ordering = LexOrdering::new(vec![b_expr_at_0]).unwrap();
+    let plan = sort_exec_with_fetch(ordering, Some(10), projection);
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, PushdownSort::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - SortExec: TopK(fetch=10), expr=[b@0 ASC], preserve_partitioning=[false]
+        -   ProjectionExec: expr=[b@1 as b, a@0 as a]
+        -     ExactTestScan
+      output:
+        Ok:
+          - ProjectionExec: expr=[b@1 as b, a@0 as a]
+          -   ExactTestScan: ordered=[b@1 ASC], fetch=10
+    "
+    );
+}

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -324,6 +324,17 @@ impl ExecutionPlan for ProjectionExec {
         true
     }
 
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let child_with_fetch = self.input().with_fetch(limit)?;
+        ProjectionExec::try_new(self.expr().to_vec(), child_with_fetch)
+            .ok()
+            .map(|projection| Arc::new(projection) as Arc<dyn ExecutionPlan>)
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.input().fetch()
+    }
+
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::Equal
     }


### PR DESCRIPTION
 ### Summary
This fixes limit pushdown for queries where `ProjectionExec` where required.

 ### Repro

 ```sql
   -- LIMIT is pushed down
   SELECT quantity_ordered, msrp FROM sales ORDER BY msrp LIMIT 8;

   -- LIMIT is NOT pushed down (before this fix)
   SELECT msrp, quantity_ordered FROM sales ORDER BY msrp LIMIT 8;
 ```
`PushdownSort` exact path attempts to preserve fetch using `inner.with_fetch(...)`.
`ProjectionExec` reported `supports_limit_pushdown = true`, but did not implement `with_fetch` / `fetch`.  `fetch` propagation stopped at the `ProjectionExec`.
