### PR TITLE
Guard `ProjectionExec::try_pushdown_sort` against stale name/index metadata

### DIFF
--- a/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
@@ -747,6 +747,43 @@ fn test_sort_pushdown_through_projection_with_alias() {
 }
 
 #[test]
+fn test_no_sort_pushdown_for_projection_name_index_mismatch() {
+    // Regression: if a sort column's index points into a projection output but
+    // its name does not match the projected alias, do not rewrite by index only.
+    let schema = schema();
+
+    // Source has [a ASC] ordering
+    let a = sort_expr("a", &schema);
+    let source_ordering = LexOrdering::new(vec![a.clone()]).unwrap();
+    let source = parquet_exec_with_sort(schema.clone(), vec![source_ordering]);
+
+    // Projection: SELECT a, b
+    let projection = simple_projection_exec(source, vec![0, 1]);
+
+    // Mismatched column metadata: name "_score" at index 0.
+    // Even though index 0 maps to projected column `a`, this must not push down.
+    let mismatched = sort_expr_named("_score", 0);
+    let ordering = LexOrdering::new(vec![mismatched.reverse()]).unwrap();
+    let plan = sort_exec(ordering, projection);
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, PushdownSort::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - SortExec: expr=[_score@0 DESC NULLS LAST], preserve_partitioning=[false]
+        -   ProjectionExec: expr=[a@0 as a, b@1 as b]
+        -     DataSourceExec: file_groups={1 group: [[x]]}, projection=[a, b, c, d, e], output_ordering=[a@0 ASC], file_type=parquet
+      output:
+        Ok:
+          - SortExec: expr=[_score@0 DESC NULLS LAST], preserve_partitioning=[false]
+          -   ProjectionExec: expr=[a@0 as a, b@1 as b]
+          -     DataSourceExec: file_groups={1 group: [[x]]}, projection=[a, b, c, d, e], output_ordering=[a@0 ASC], file_type=parquet
+    "
+    );
+}
+
+#[test]
 fn test_no_sort_pushdown_through_computed_projection() {
     use datafusion_expr::Operator;
 

--- a/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
@@ -1093,3 +1093,34 @@ fn test_sort_pushdown_exact_preserves_fetch() {
     "
     );
 }
+
+#[test]
+fn test_sort_pushdown_exact_preserves_fetch_through_projection() {
+    // Regression test: in the Exact pushdown path, SortExec is removed and
+    // fetch must be propagated through ProjectionExec to the source via with_fetch().
+    let schema = schema();
+    let source = exact_test_scan(schema.clone());
+
+    // Projection reorders columns: SELECT b, a
+    let projection = simple_projection_exec(source, vec![1, 0]);
+
+    // Sort on projected column b with LIMIT.
+    let b_expr_at_0 = sort_expr_named("b", 0);
+    let ordering = LexOrdering::new(vec![b_expr_at_0]).unwrap();
+    let plan = sort_exec_with_fetch(ordering, Some(10), projection);
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, PushdownSort::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - SortExec: TopK(fetch=10), expr=[b@0 ASC], preserve_partitioning=[false]
+        -   ProjectionExec: expr=[b@1 as b, a@0 as a]
+        -     ExactTestScan
+      output:
+        Ok:
+          - ProjectionExec: expr=[b@1 as b, a@0 as a]
+          -   ExactTestScan: ordered=[b@1 ASC], fetch=10
+    "
+    );
+}

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -324,6 +324,17 @@ impl ExecutionPlan for ProjectionExec {
         true
     }
 
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let child_with_fetch = self.input().with_fetch(limit)?;
+        ProjectionExec::try_new(self.expr().to_vec(), child_with_fetch)
+            .ok()
+            .map(|projection| Arc::new(projection) as Arc<dyn ExecutionPlan>)
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.input().fetch()
+    }
+
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::Equal
     }

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -395,7 +395,15 @@ impl ExecutionPlan for ProjectionExec {
 
                     let proj_expr = &self.expr()[col.index()];
 
-                    // Check if projection expression is a simple column
+                    // Guard against stale/mismatched column metadata (e.g. same index
+                    // but different field name). In that case we must not rewrite by
+                    // index only, as it can push down an order on a different column.
+                    if col.name() != proj_expr.alias {
+                        can_pushdown = false;
+                        return Ok(Transformed::no(expr));
+                    }
+
+                    // Check if projection expression is a simple column.
                     // We cannot push down order by clauses that depend on
                     // projected computations as they would have nothing to reference.
                     if let Some(child_col) =


### PR DESCRIPTION
 Adds a safety check in ProjectionExec::try_pushdown_sort to prevent incorrect sort pushdown when a sort column’s (name, index) metadata is stale or mismatched. `ProjectionExec` translated parent sort requirements to child columns using index-only mapping:
 - take sort column `col@i`
 - map through `projection.expr()[i]`

If optimizer rewrites left a stale pair (e.g. name `_score`, index `3`, but projection slot 3 is actually `picked_at`), pushdown could incorrectly rewrite `_score@3` into `picked_at@3`, causing invalid ordering assumptions and potential `SanityCheckPlan` failures.