### PR TITLE
feat(unparser): faithfully unparse AT TIME ZONE instead of dropping the timezone

### DIFF
--- a/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
@@ -747,6 +747,43 @@ fn test_sort_pushdown_through_projection_with_alias() {
 }
 
 #[test]
+fn test_no_sort_pushdown_for_projection_name_index_mismatch() {
+    // Regression: if a sort column's index points into a projection output but
+    // its name does not match the projected alias, do not rewrite by index only.
+    let schema = schema();
+
+    // Source has [a ASC] ordering
+    let a = sort_expr("a", &schema);
+    let source_ordering = LexOrdering::new(vec![a.clone()]).unwrap();
+    let source = parquet_exec_with_sort(schema.clone(), vec![source_ordering]);
+
+    // Projection: SELECT a, b
+    let projection = simple_projection_exec(source, vec![0, 1]);
+
+    // Mismatched column metadata: name "_score" at index 0.
+    // Even though index 0 maps to projected column `a`, this must not push down.
+    let mismatched = sort_expr_named("_score", 0);
+    let ordering = LexOrdering::new(vec![mismatched.reverse()]).unwrap();
+    let plan = sort_exec(ordering, projection);
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, PushdownSort::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - SortExec: expr=[_score@0 DESC NULLS LAST], preserve_partitioning=[false]
+        -   ProjectionExec: expr=[a@0 as a, b@1 as b]
+        -     DataSourceExec: file_groups={1 group: [[x]]}, projection=[a, b, c, d, e], output_ordering=[a@0 ASC], file_type=parquet
+      output:
+        Ok:
+          - SortExec: expr=[_score@0 DESC NULLS LAST], preserve_partitioning=[false]
+          -   ProjectionExec: expr=[a@0 as a, b@1 as b]
+          -     DataSourceExec: file_groups={1 group: [[x]]}, projection=[a, b, c, d, e], output_ordering=[a@0 ASC], file_type=parquet
+    "
+    );
+}
+
+#[test]
 fn test_no_sort_pushdown_through_computed_projection() {
     use datafusion_expr::Operator;
 

--- a/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
+++ b/datafusion/core/tests/physical_optimizer/pushdown_sort.rs
@@ -1093,3 +1093,34 @@ fn test_sort_pushdown_exact_preserves_fetch() {
     "
     );
 }
+
+#[test]
+fn test_sort_pushdown_exact_preserves_fetch_through_projection() {
+    // Regression test: in the Exact pushdown path, SortExec is removed and
+    // fetch must be propagated through ProjectionExec to the source via with_fetch().
+    let schema = schema();
+    let source = exact_test_scan(schema.clone());
+
+    // Projection reorders columns: SELECT b, a
+    let projection = simple_projection_exec(source, vec![1, 0]);
+
+    // Sort on projected column b with LIMIT.
+    let b_expr_at_0 = sort_expr_named("b", 0);
+    let ordering = LexOrdering::new(vec![b_expr_at_0]).unwrap();
+    let plan = sort_exec_with_fetch(ordering, Some(10), projection);
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, PushdownSort::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - SortExec: TopK(fetch=10), expr=[b@0 ASC], preserve_partitioning=[false]
+        -   ProjectionExec: expr=[b@1 as b, a@0 as a]
+        -     ExactTestScan
+      output:
+        Ok:
+          - ProjectionExec: expr=[b@1 as b, a@0 as a]
+          -   ExactTestScan: ordered=[b@1 ASC], fetch=10
+    "
+    );
+}

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -324,6 +324,17 @@ impl ExecutionPlan for ProjectionExec {
         true
     }
 
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let child_with_fetch = self.input().with_fetch(limit)?;
+        ProjectionExec::try_new(self.expr().to_vec(), child_with_fetch)
+            .ok()
+            .map(|projection| Arc::new(projection) as Arc<dyn ExecutionPlan>)
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.input().fetch()
+    }
+
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::Equal
     }

--- a/datafusion/physical-plan/src/projection.rs
+++ b/datafusion/physical-plan/src/projection.rs
@@ -395,7 +395,15 @@ impl ExecutionPlan for ProjectionExec {
 
                     let proj_expr = &self.expr()[col.index()];
 
-                    // Check if projection expression is a simple column
+                    // Guard against stale/mismatched column metadata (e.g. same index
+                    // but different field name). In that case we must not rewrite by
+                    // index only, as it can push down an order on a different column.
+                    if col.name() != proj_expr.alias {
+                        can_pushdown = false;
+                        return Ok(Transformed::no(expr));
+                    }
+
+                    // Check if projection expression is a simple column.
                     // We cannot push down order by clauses that depend on
                     // projected computations as they would have nothing to reference.
                     if let Some(child_col) =

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -337,7 +337,12 @@ pub enum CharacterLengthStyle {
 pub enum TimezoneCastStyle {
     /// SQL-standard `expr AT TIME ZONE 'tz'` (PostgreSQL, DuckDB).
     AtTimeZone,
-    /// `CONVERT_TIMEZONE('tz', expr)` (Snowflake, Amazon Redshift).
+    /// `CAST(CONVERT_TIMEZONE('tz', expr) AS TIMESTAMP_NTZ)` (Snowflake).
+    ///
+    /// Not Amazon Redshift: Redshift's 2-arg `CONVERT_TIMEZONE(source_tz, ts)`
+    /// reads the first argument as the *source* zone and converts to the session
+    /// zone, whereas this emits the target zone as the first argument (Snowflake
+    /// semantics), so the rendered SQL would mean something different on Redshift.
     ConvertTimezone,
     /// Legacy `CAST(expr AS <timestamp_tz_cast_dtype>)`, which drops the zone
     /// name. Preserves the pre-fix behavior for callers that opt out.

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -122,6 +122,28 @@ pub trait Dialect: Send + Sync {
         ast::DataType::Timestamp(None, tz_info)
     }
 
+    /// How to unparse a cast that attaches a specific timezone to a timestamp —
+    /// the logical-plan form `CAST(expr AS Timestamp(_, Some(tz)))` that
+    /// DataFusion produces for `expr AT TIME ZONE 'tz'`.
+    ///
+    /// `input` is the already-unparsed inner expression and `tz` is the
+    /// timezone name (e.g. `"America/Los_Angeles"`, `"UTC"`, `"+00:00"`).
+    ///
+    /// Returning `Some(_)` replaces the default cast rendering produced by
+    /// [`Self::timestamp_cast_dtype`], which collapses a named zone down to a
+    /// bare `TIMESTAMP WITH TIME ZONE` and silently drops the zone — yielding
+    /// SQL whose meaning depends on the remote engine's session timezone.
+    /// Returning `None` falls back to that legacy cast rendering.
+    ///
+    /// The default emits the SQL-standard `input AT TIME ZONE 'tz'`.
+    fn timestamp_at_time_zone_to_sql(
+        &self,
+        input: ast::Expr,
+        tz: &str,
+    ) -> Option<ast::Expr> {
+        Some(at_time_zone_to_ast(input, tz))
+    }
+
     /// The SQL type to use for Arrow Date32 unparsing
     /// Most dialects use Date, but some, like SQLite require TEXT
     fn date32_cast_dtype(&self) -> ast::DataType {
@@ -305,6 +327,79 @@ pub enum DateFieldExtractStyle {
 pub enum CharacterLengthStyle {
     Length,
     CharacterLength,
+}
+
+/// How a [`Dialect`] renders a cast that attaches a specific timezone to a
+/// timestamp. DataFusion lowers `expr AT TIME ZONE 'tz'` to
+/// `CAST(expr AS Timestamp(_, Some(tz)))`; this selects how that cast is
+/// unparsed back to SQL so the zone name is not silently dropped.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TimezoneCastStyle {
+    /// SQL-standard `expr AT TIME ZONE 'tz'` (PostgreSQL, DuckDB).
+    AtTimeZone,
+    /// `CONVERT_TIMEZONE('tz', expr)` (Snowflake, Amazon Redshift).
+    ConvertTimezone,
+    /// Legacy `CAST(expr AS <timestamp_tz_cast_dtype>)`, which drops the zone
+    /// name. Preserves the pre-fix behavior for callers that opt out.
+    Cast,
+}
+
+/// Build the AST for `input AT TIME ZONE 'tz'`.
+pub(crate) fn at_time_zone_to_ast(input: ast::Expr, tz: &str) -> ast::Expr {
+    ast::Expr::AtTimeZone {
+        timestamp: Box::new(input),
+        time_zone: Box::new(ast::Expr::value(ast::Value::SingleQuotedString(
+            tz.to_string(),
+        ))),
+    }
+}
+
+/// Build the AST for `CAST(CONVERT_TIMEZONE('tz', input) AS TIMESTAMP_NTZ)`
+/// (Snowflake).
+///
+/// The result is cast to a naive `TIMESTAMP_NTZ` (the wall-clock in `tz`) on
+/// purpose. DataFusion's `expr AT TIME ZONE 'tz'` is typically compared against
+/// a naive timestamp literal, and that comparison is wall-clock based. If this
+/// returned a `TIMESTAMP_TZ` instead, Snowflake would coerce the naive literal
+/// using the session `TIMEZONE`, reintroducing a session-dependent skew (the
+/// original bug). Keeping the result naive makes the comparison
+/// `TIMESTAMP_NTZ` vs `TIMESTAMP_NTZ`, i.e. wall-clock vs wall-clock.
+///
+/// For a nested chain (`x AT TIME ZONE 'A' AT TIME ZONE 'B'`) the inner result
+/// is already `TIMESTAMP_NTZ`; the outer `CONVERT_TIMEZONE` then interprets it
+/// as local time in the session zone, so the connection's session `TIMEZONE`
+/// must be pinned to `UTC` for the chain to compose to the intended instant.
+pub(crate) fn convert_timezone_to_ast(input: ast::Expr, tz: &str) -> ast::Expr {
+    let convert = ast::Expr::Function(Function {
+        name: ObjectName::from(vec![Ident::new("CONVERT_TIMEZONE")]),
+        args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+            duplicate_treatment: None,
+            args: vec![
+                ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(ast::Expr::value(
+                    ast::Value::SingleQuotedString(tz.to_string()),
+                ))),
+                ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(input)),
+            ],
+            clauses: vec![],
+        }),
+        filter: None,
+        null_treatment: None,
+        over: None,
+        within_group: vec![],
+        parameters: ast::FunctionArguments::None,
+        uses_odbc_syntax: false,
+    });
+    // Cast to naive TIMESTAMP_NTZ so a comparison against a naive literal stays
+    // wall-clock based and session-TIMEZONE independent for the value.
+    ast::Expr::Cast {
+        kind: ast::CastKind::Cast,
+        expr: Box::new(convert),
+        data_type: ast::DataType::Custom(
+            ObjectName::from(vec![Ident::new("TIMESTAMP_NTZ")]),
+            vec![],
+        ),
+        format: None,
+    }
 }
 
 pub struct DefaultDialect {}
@@ -533,6 +628,15 @@ impl Dialect for MySqlDialect {
         ast::DataType::Datetime(None)
     }
 
+    fn timestamp_at_time_zone_to_sql(
+        &self,
+        _input: ast::Expr,
+        _tz: &str,
+    ) -> Option<ast::Expr> {
+        // MySQL has no `AT TIME ZONE` operator; keep the legacy DATETIME cast.
+        None
+    }
+
     fn requires_derived_table_alias(&self) -> bool {
         true
     }
@@ -584,6 +688,15 @@ impl Dialect for SqliteDialect {
         _tz: &Option<Arc<str>>,
     ) -> ast::DataType {
         ast::DataType::Text
+    }
+
+    fn timestamp_at_time_zone_to_sql(
+        &self,
+        _input: ast::Expr,
+        _tz: &str,
+    ) -> Option<ast::Expr> {
+        // SQLite has no `AT TIME ZONE` operator; keep the legacy TEXT cast.
+        None
     }
 
     fn scalar_function_to_sql_overrides(
@@ -674,6 +787,15 @@ impl Dialect for BigQueryDialect {
         false
     }
 
+    fn timestamp_at_time_zone_to_sql(
+        &self,
+        _input: ast::Expr,
+        _tz: &str,
+    ) -> Option<ast::Expr> {
+        // BigQuery has no `AT TIME ZONE` operator; keep the legacy cast.
+        None
+    }
+
     fn timestamp_with_tz_to_string(&self, dt: DateTime<Tz>, unit: TimeUnit) -> String {
         // https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
         let format = match unit {
@@ -716,6 +838,7 @@ pub struct CustomDialect {
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
     supports_subquery_in_join_predicate: bool,
+    timezone_cast_style: TimezoneCastStyle,
 }
 
 impl Default for CustomDialect {
@@ -745,6 +868,7 @@ impl Default for CustomDialect {
             full_qualified_col: false,
             unnest_as_table_factor: false,
             supports_subquery_in_join_predicate: true,
+            timezone_cast_style: TimezoneCastStyle::Cast,
         }
     }
 }
@@ -803,6 +927,20 @@ impl Dialect for CustomDialect {
             self.timestamp_tz_cast_dtype.clone()
         } else {
             self.timestamp_cast_dtype.clone()
+        }
+    }
+
+    fn timestamp_at_time_zone_to_sql(
+        &self,
+        input: ast::Expr,
+        tz: &str,
+    ) -> Option<ast::Expr> {
+        match self.timezone_cast_style {
+            TimezoneCastStyle::AtTimeZone => Some(at_time_zone_to_ast(input, tz)),
+            TimezoneCastStyle::ConvertTimezone => {
+                Some(convert_timezone_to_ast(input, tz))
+            }
+            TimezoneCastStyle::Cast => None,
         }
     }
 
@@ -897,6 +1035,7 @@ pub struct CustomDialectBuilder {
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
     supports_subquery_in_join_predicate: bool,
+    timezone_cast_style: TimezoneCastStyle,
 }
 
 impl Default for CustomDialectBuilder {
@@ -932,6 +1071,7 @@ impl CustomDialectBuilder {
             full_qualified_col: false,
             unnest_as_table_factor: false,
             supports_subquery_in_join_predicate: true,
+            timezone_cast_style: TimezoneCastStyle::Cast,
         }
     }
 
@@ -960,6 +1100,7 @@ impl CustomDialectBuilder {
             unnest_as_table_factor: self.unnest_as_table_factor,
             supports_subquery_in_join_predicate: self
                 .supports_subquery_in_join_predicate,
+            timezone_cast_style: self.timezone_cast_style,
         }
     }
 
@@ -1052,6 +1193,15 @@ impl CustomDialectBuilder {
     ) -> Self {
         self.timestamp_cast_dtype = timestamp_cast_dtype;
         self.timestamp_tz_cast_dtype = timestamp_tz_cast_dtype;
+        self
+    }
+
+    /// Customize how a cast that attaches a timezone to a timestamp is rendered
+    /// (the lowering of `expr AT TIME ZONE 'tz'`). Defaults to
+    /// [`TimezoneCastStyle::Cast`], which preserves the legacy zone-dropping
+    /// `CAST(... AS TIMESTAMP WITH TIME ZONE)` behavior.
+    pub fn with_timezone_cast_style(mut self, style: TimezoneCastStyle) -> Self {
+        self.timezone_cast_style = style;
         self
     }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1148,6 +1148,18 @@ impl Unparser<'_> {
     // For example: CAST(Utf8("binary_value") AS Binary) and  CAST(Utf8("dictionary_value") AS Dictionary)
     fn cast_to_sql(&self, expr: &Expr, data_type: &DataType) -> Result<ast::Expr> {
         let inner_expr = self.expr_to_sql_inner(expr)?;
+        // `expr AT TIME ZONE 'tz'` is planned as CAST(expr AS Timestamp(_, Some(tz))).
+        // Render it faithfully (e.g. `AT TIME ZONE` or `CONVERT_TIMEZONE`) so the zone
+        // name survives, instead of a bare `CAST(... AS TIMESTAMP WITH TIME ZONE)` that
+        // silently drops it and changes the meaning on the remote engine.
+        if let DataType::Timestamp(_, Some(tz)) = data_type {
+            if let Some(at_tz) = self
+                .dialect
+                .timestamp_at_time_zone_to_sql(inner_expr.clone(), tz.as_ref())
+            {
+                return Ok(at_tz);
+            }
+        }
         match inner_expr {
             ast::Expr::Value(_) => match data_type {
                 DataType::Dictionary(_, _) | DataType::Binary | DataType::BinaryView => {
@@ -1823,6 +1835,7 @@ mod tests {
     use crate::unparser::dialect::{
         CharacterLengthStyle, CustomDialect, CustomDialectBuilder, DateFieldExtractStyle,
         DefaultDialect, Dialect, DuckDBDialect, PostgreSqlDialect, ScalarFnToSqlHandler,
+        TimezoneCastStyle,
     };
 
     use super::*;
@@ -1917,7 +1930,7 @@ mod tests {
                         Some("+08:00".into()),
                     ),
                 }),
-                r#"CAST(a AS TIMESTAMP WITH TIME ZONE)"#,
+                r#"a AT TIME ZONE '+08:00'"#,
             ),
             (
                 Expr::Cast(Cast {
@@ -2341,6 +2354,135 @@ mod tests {
             assert_eq!(actual, expected);
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn cast_to_timestamp_with_timezone_unparses_at_time_zone() -> Result<()> {
+        // `expr AT TIME ZONE 'tz'` is planned as CAST(expr AS Timestamp(_, Some(tz))).
+        // The unparser must round-trip it as `AT TIME ZONE`, preserving the zone name,
+        // rather than collapsing it to a zone-dropping `CAST(... AS TIMESTAMP WITH TIME ZONE)`.
+        let expr = Expr::Cast(Cast {
+            expr: Box::new(col("a")),
+            data_type: DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("America/Los_Angeles".into()),
+            ),
+        });
+        let ast = expr_to_sql(&expr)?;
+        assert_eq!(format!("{ast}"), "a AT TIME ZONE 'America/Los_Angeles'");
+        Ok(())
+    }
+
+    #[test]
+    fn nested_at_time_zone_casts_preserve_each_zone() -> Result<()> {
+        // The exact shape produced by
+        // `MQL_AT AT TIME ZONE 'UTC' AT TIME ZONE 'America/Los_Angeles'`.
+        // Both zone names must survive unparsing; previously both were dropped.
+        let inner = Expr::Cast(Cast {
+            expr: Box::new(col("mql_at")),
+            data_type: DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+        });
+        let outer = Expr::Cast(Cast {
+            expr: Box::new(inner),
+            data_type: DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("America/Los_Angeles".into()),
+            ),
+        });
+        let ast = expr_to_sql(&outer)?;
+        assert_eq!(
+            format!("{ast}"),
+            "mql_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Los_Angeles'"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_at_time_zone_style_renders_at_time_zone() -> Result<()> {
+        let dialect = CustomDialectBuilder::new()
+            .with_timezone_cast_style(TimezoneCastStyle::AtTimeZone)
+            .build();
+        let unparser = Unparser::new(&dialect);
+        let expr = Expr::Cast(Cast {
+            expr: Box::new(col("a")),
+            data_type: DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("America/Los_Angeles".into()),
+            ),
+        });
+        let ast = unparser.expr_to_sql(&expr)?;
+        assert_eq!(format!("{ast}"), "a AT TIME ZONE 'America/Los_Angeles'");
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_convert_timezone_style_renders_function() -> Result<()> {
+        // Snowflake expresses the conversion as a function call rather than the
+        // `AT TIME ZONE` operator (which it does not support). The result is cast
+        // to naive TIMESTAMP_NTZ so comparisons against naive literals stay
+        // wall-clock based (session-TIMEZONE independent).
+        let dialect = CustomDialectBuilder::new()
+            .with_timezone_cast_style(TimezoneCastStyle::ConvertTimezone)
+            .build();
+        let unparser = Unparser::new(&dialect);
+        let expr = Expr::Cast(Cast {
+            expr: Box::new(col("a")),
+            data_type: DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("America/Los_Angeles".into()),
+            ),
+        });
+        let ast = unparser.expr_to_sql(&expr)?;
+        assert_eq!(
+            format!("{ast}"),
+            "CAST(CONVERT_TIMEZONE('America/Los_Angeles', a) AS TIMESTAMP_NTZ)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_convert_timezone_style_nested_chain() -> Result<()> {
+        // The reported bug shape: `MQL_AT AT TIME ZONE 'UTC' AT TIME ZONE 'LA'`.
+        // Composes to nested CONVERT_TIMEZONE calls; correct on Snowflake when the
+        // session TIMEZONE is pinned to UTC (see convert_timezone_to_ast docs).
+        let dialect = CustomDialectBuilder::new()
+            .with_timezone_cast_style(TimezoneCastStyle::ConvertTimezone)
+            .build();
+        let unparser = Unparser::new(&dialect);
+        let inner = Expr::Cast(Cast {
+            expr: Box::new(col("mql_at")),
+            data_type: DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+        });
+        let outer = Expr::Cast(Cast {
+            expr: Box::new(inner),
+            data_type: DataType::Timestamp(
+                TimeUnit::Nanosecond,
+                Some("America/Los_Angeles".into()),
+            ),
+        });
+        let ast = unparser.expr_to_sql(&outer)?;
+        assert_eq!(
+            format!("{ast}"),
+            "CAST(CONVERT_TIMEZONE('America/Los_Angeles', \
+             CAST(CONVERT_TIMEZONE('UTC', mql_at) AS TIMESTAMP_NTZ)) AS TIMESTAMP_NTZ)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn custom_dialect_default_timezone_cast_is_legacy() -> Result<()> {
+        // The default style is `Cast`: it preserves the pre-fix (zone-dropping)
+        // behavior so existing CustomDialect-based connectors are unaffected
+        // until they explicitly opt in.
+        let dialect = CustomDialectBuilder::new().build();
+        let unparser = Unparser::new(&dialect);
+        let expr = Expr::Cast(Cast {
+            expr: Box::new(col("a")),
+            data_type: DataType::Timestamp(TimeUnit::Nanosecond, Some("+08:00".into())),
+        });
+        let ast = unparser.expr_to_sql(&expr)?;
+        assert_eq!(format!("{ast}"), "CAST(a AS TIMESTAMP WITH TIME ZONE)");
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

DataFusion lowers `expr AT TIME ZONE 'tz'` to `CAST(expr AS Timestamp(_, Some(tz)))` (`sql/src/expr/mod.rs`). The unparser's inverse is lossy: `Dialect::timestamp_cast_dtype` maps `Some(tz)` → the bare SQL marker `TIMESTAMP WITH TIME ZONE`, **dropping the zone name**. So `MQL_AT AT TIME ZONE 'UTC' AT TIME ZONE 'America/Los_Angeles'` round-trips to:

```
CAST(CAST("MQL_AT" AS TIMESTAMP WITH TIME ZONE) AS TIMESTAMP WITH TIME ZONE)
```

When such a predicate is federated wholesale, the federation analyzer's internal optimizer runs only `OptimizeUnions`/`PushDownFilter`/`OptimizeProjections` — **not** `SimplifyExpressions`/`UnwrapCastInComparison` — so the cast chain reaches the unparser un-folded and the zone-stripped SQL is what hits the remote engine. Result: silently wrong rows, no error. (A query shape that blocks full federation gets the chain constant-folded to exact UTC instants first, so it's correct — hence "query shape decides.")

## Fix

- New `Dialect::timestamp_at_time_zone_to_sql(input, tz)` hook, routed from `cast_to_sql` for `Timestamp(_, Some(tz))` casts. **Default emits the SQL-standard `input AT TIME ZONE 'tz'`** — the exact inverse of the planner.
- `MySqlDialect`/`SqliteDialect`/`BigQueryDialect` override it to `None` (they have no `AT TIME ZONE` operator) → unchanged legacy rendering.
- New `TimezoneCastStyle { AtTimeZone, ConvertTimezone, Cast }` selectable via `CustomDialectBuilder::with_timezone_cast_style`. **`CustomDialect` defaults to `Cast` (legacy)** so existing connectors are byte-for-byte unaffected until they opt in.
- `ConvertTimezone` renders `CAST(CONVERT_TIMEZONE('tz', x) AS TIMESTAMP_NTZ)` for Snowflake. The naive `TIMESTAMP_NTZ` result keeps comparisons against naive literals wall-clock based (otherwise Snowflake coerces the naive literal via the session `TIMEZONE`, reintroducing a session-dependent skew).

## Tests

`cargo test -p datafusion-sql --lib unparser` → **35 passed**. New cases: default-dialect single + nested `AT TIME ZONE`, `CustomDialect` AtTimeZone/ConvertTimezone/nested-chain/legacy-default. One pre-existing assertion that encoded the dropped-zone behavior was updated. (The 14 `sql_integration.rs` snapshot failures are pre-existing in this branch — identical on baseline, unrelated to timestamps.)

## ⚠️ Needs live validation before relying on `ConvertTimezone`

The `AT TIME ZONE` default is provably the planner's inverse. The `ConvertTimezone` rendering is reasoned-correct **only with the remote session `TIMEZONE` pinned to `UTC`** (so chained `CONVERT_TIMEZONE` calls over `TIMESTAMP_NTZ` intermediates compose to the intended instant), and has **not** been validated against a live Snowflake instance across `TIMESTAMP_NTZ`/`TIMESTAMP_TZ` column types. The companion Spice PR wires this up and pins the session; it should stay draft until validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)