### PR TITLE
fix(meta cols): fix project_statistics for metadata/partition columns beyond input stats

### DIFF
--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -1579,6 +1579,7 @@ mod tests {
 
     use super::*;
     use crate::TableSchema;
+    use crate::metadata::MetadataColumn;
     use crate::test_util::col;
     use crate::{
         generate_test_files, test_util::MockSource, tests::aggr_test_schema,
@@ -1586,13 +1587,15 @@ mod tests {
     };
 
     use arrow::datatypes::Field;
+    use datafusion_common::ScalarValue;
     use datafusion_common::stats::Precision;
     use datafusion_common::{ColumnStatistics, internal_err};
     use datafusion_expr::{Operator, SortExpr};
     use datafusion_physical_expr::create_physical_sort_expr;
     use datafusion_physical_expr::expressions::{BinaryExpr, Column, Literal};
-    use datafusion_physical_expr::projection::ProjectionExpr;
+    use datafusion_physical_expr::projection::{ProjectionExpr, ProjectionExprs};
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
+    use datafusion_physical_plan::filter_pushdown::PushedDown;
 
     #[derive(Clone)]
     struct InexactSortPushdownSource {
@@ -2646,5 +2649,468 @@ mod tests {
         assert_eq!(pushed_files[1].object_meta.location.as_ref(), "file1");
 
         Ok(())
+    }
+
+    #[test]
+    fn test_partition_statistics_with_metadata_columns() {
+        use crate::source::DataSourceExec;
+        use datafusion_physical_plan::ExecutionPlan;
+
+        // File schema: [compression]
+        let file_schema = Arc::new(Schema::new(vec![Field::new(
+            "compression",
+            DataType::Utf8,
+            true,
+        )]));
+
+        // Partition column: [day]
+        let partition_cols = vec![Arc::new(Field::new("day", DataType::Utf8, true))];
+
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), partition_cols);
+
+        // Metadata column: location
+        let metadata_cols = vec![MetadataColumn::Location(None)];
+
+        let file_group_stats = Statistics {
+            num_rows: Precision::Exact(1),
+            total_byte_size: Precision::Exact(100),
+            column_statistics: vec![
+                // compression
+                ColumnStatistics {
+                    null_count: Precision::Exact(0),
+                    ..ColumnStatistics::new_unknown()
+                },
+                // day (partition)
+                ColumnStatistics {
+                    null_count: Precision::Exact(0),
+                    ..ColumnStatistics::new_unknown()
+                },
+            ],
+        };
+
+        let file_group = FileGroup::new(vec![PartitionedFile::new("data.parquet", 100)])
+            .with_statistics(Arc::new(file_group_stats));
+
+        // table_schema columns: [compression(0), day(1)]
+        // metadata columns:     [location(2)]
+        // SELECT location, day, compression -> projection = [2, 1, 0]
+        let config = FileScanConfigBuilder::new(
+            ObjectStoreUrl::parse("test:///").unwrap(),
+            Arc::new(MockSource::new(table_schema)),
+        )
+        .with_metadata_cols(metadata_cols)
+        .expect("metadata cols valid")
+        .with_projection_indices(Some(vec![2, 1, 0]))
+        .expect("projection indices should be valid")
+        .with_file_groups(vec![file_group])
+        .build();
+
+        let exec = DataSourceExec::from_data_source(config);
+
+        // The projected schema has 3 columns: [location, day, compression]
+        assert_eq!(exec.schema().fields().len(), 3);
+
+        // partition_statistics must return 3 column_statistics entries —
+        // one for each column in the projected schema — so that
+        // ProjectionExec doesn't panic on index access.
+        let stats = exec
+            .partition_statistics(Some(0))
+            .expect("partition_statistics should succeed");
+        assert_eq!(
+            stats.column_statistics.len(),
+            3,
+            "Expected 3 column statistics (2 file/partition + 1 metadata), got {}",
+            stats.column_statistics.len()
+        );
+
+        // Also verify aggregate statistics (partition = None)
+        let agg_stats = exec
+            .partition_statistics(None)
+            .expect("aggregate partition_statistics should succeed");
+        assert_eq!(
+            agg_stats.column_statistics.len(),
+            3,
+            "Expected 3 aggregate column statistics, got {}",
+            agg_stats.column_statistics.len()
+        );
+    }
+
+    /// Test that `try_pushdown_filters` works when a filter references
+    /// a metadata column (e.g. `location`) that is appended after the projection.
+    /// Metadata column indices are beyond the projection length, so they must be
+    /// separated out rather than remapped through `update_expr`.
+    #[test]
+    fn test_try_pushdown_filters_with_metadata_column_filter() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]));
+        let object_store_url = ObjectStoreUrl::parse("test:///").expect("valid url");
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), vec![]);
+        let file_source: Arc<dyn FileSource> =
+            Arc::new(MockSource::new(table_schema.clone()));
+
+        let metadata_cols = vec![MetadataColumn::Location(None)];
+
+        // Build config with metadata columns and a projection that includes metadata.
+        let config =
+            FileScanConfigBuilder::new(object_store_url, Arc::clone(&file_source))
+                .with_metadata_cols(metadata_cols)
+                .expect("metadata cols valid")
+                .with_projection_indices(Some(vec![0, 1, 2]))
+                .expect("valid projection")
+                .build();
+
+        // Push a projection so that `file_source.projection()` is Some.
+        let initial_schema = config.projected_schema().expect("projected schema");
+        let proj_exprs = ProjectionExprs::new(vec![
+            ProjectionExpr::new(col("id", &initial_schema).expect("col"), "id"),
+            ProjectionExpr::new(col("value", &initial_schema).expect("col"), "value"),
+            ProjectionExpr::new(
+                col("_location", &initial_schema).expect("col"),
+                "_location",
+            ),
+        ]);
+        let data_source = config
+            .try_swapping_with_projection(&proj_exprs)
+            .expect("swap ok")
+            .expect("should produce new source");
+
+        // projected schema: [id, value, location]
+        let projected = data_source
+            .as_any()
+            .downcast_ref::<FileScanConfig>()
+            .expect("is FileScanConfig")
+            .projected_schema()
+            .expect("projected schema");
+        assert_eq!(projected.fields().len(), 3);
+        assert_eq!(projected.field(2).name(), "_location");
+
+        // Create a filter on the metadata column: location@2 = 's3://bucket'
+        // (index 2 because projected output is [id@0, value@1, location@2])
+        let location_filter: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("_location", 2)),
+            Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Utf8(Some(
+                "s3://bucket".to_string(),
+            )))),
+        ));
+
+        // This should work without crashing, even though the filter references a metadata column
+        let config_options = ConfigOptions::default();
+        let result =
+            data_source.try_pushdown_filters(vec![location_filter], &config_options);
+        let propagation = result.expect("to pushdown filters");
+
+        // The metadata filter cannot be pushed down to the file source.
+        assert_eq!(propagation.filters.len(), 1);
+        assert!(
+            matches!(propagation.filters[0], PushedDown::No),
+            "metadata column filter should not be pushed down"
+        );
+    }
+
+    /// Test that `try_pushdown_filters` correctly handles a mix of regular
+    /// filters and metadata column filters — regular filters are remapped
+    /// through the projection while metadata filters are returned as not pushed.
+    #[test]
+    fn test_try_pushdown_filters_mixed_regular_and_metadata_filters() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]));
+        let object_store_url = ObjectStoreUrl::parse("test:///").expect("valid url");
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), vec![]);
+        let file_source: Arc<dyn FileSource> =
+            Arc::new(MockSource::new(table_schema.clone()));
+
+        let metadata_cols = vec![MetadataColumn::Location(None)];
+
+        let config =
+            FileScanConfigBuilder::new(object_store_url, Arc::clone(&file_source))
+                .with_metadata_cols(metadata_cols)
+                .expect("metadata cols valid")
+                .with_projection_indices(Some(vec![0, 1, 2]))
+                .expect("valid projection")
+                .build();
+
+        let initial_schema = config.projected_schema().expect("projected schema");
+        let proj_exprs = ProjectionExprs::new(vec![
+            ProjectionExpr::new(col("id", &initial_schema).expect("col"), "id"),
+            ProjectionExpr::new(col("value", &initial_schema).expect("col"), "value"),
+            ProjectionExpr::new(
+                col("_location", &initial_schema).expect("col"),
+                "_location",
+            ),
+        ]);
+        let data_source = config
+            .try_swapping_with_projection(&proj_exprs)
+            .expect("swap ok")
+            .expect("should produce new source");
+
+        // Filter 0: regular filter on id@0 (within projection)
+        let id_filter: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("id", 0)),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(5)))),
+        ));
+        // Filter 1: metadata column filter on location@2 (beyond projection)
+        let location_filter: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("_location", 2)),
+            Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Utf8(Some(
+                "s3://bucket".to_string(),
+            )))),
+        ));
+
+        let config_options = ConfigOptions::default();
+        let result = data_source
+            .try_pushdown_filters(vec![id_filter, location_filter], &config_options);
+        let propagation = result.expect("to pushdown filters");
+
+        // Both filters should be present in results, in the original order.
+        assert_eq!(propagation.filters.len(), 2);
+        // Regular filter: MockSource returns PushedDown::No (default impl).
+        assert!(
+            matches!(propagation.filters[0], PushedDown::No),
+            "regular filter: MockSource default returns No"
+        );
+        // Metadata filter: separated out, returned as PushedDown::No.
+        assert!(
+            matches!(propagation.filters[1], PushedDown::No),
+            "metadata column filter should not be pushed down"
+        );
+    }
+
+    /// Test that `eq_properties` includes metadata columns in its schema.
+    /// `DataSourceExec::schema()` is derived from `eq_properties().schema()`,
+    /// so metadata columns must be appended to match the actual batches
+    /// produced by the file source.
+    #[test]
+    fn test_eq_properties_schema_includes_metadata_columns() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]));
+        let object_store_url = ObjectStoreUrl::parse("test:///").expect("valid url");
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), vec![]);
+        let file_source: Arc<dyn FileSource> =
+            Arc::new(MockSource::new(table_schema.clone()));
+
+        let metadata_cols = vec![MetadataColumn::Location(None), MetadataColumn::Size];
+
+        let config = FileScanConfigBuilder::new(object_store_url, file_source)
+            .with_metadata_cols(metadata_cols)
+            .expect("metadata cols valid")
+            .build();
+
+        let eq_props = config.eq_properties();
+        let schema = eq_props.schema();
+
+        // Schema should include file columns + metadata columns
+        assert_eq!(
+            schema.fields().len(),
+            4,
+            "Expected 4 fields (2 file + 2 metadata), got {}",
+            schema.fields().len()
+        );
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).name(), "value");
+        assert_eq!(schema.field(2).name(), "_location");
+        assert_eq!(schema.field(3).name(), "_size");
+    }
+
+    /// Same as above but with a projection applied — metadata columns must
+    /// still appear in the schema after projection.
+    #[test]
+    fn test_eq_properties_schema_includes_metadata_columns_with_projection() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]));
+        let object_store_url = ObjectStoreUrl::parse("test:///").expect("valid url");
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), vec![]);
+        let file_source: Arc<dyn FileSource> =
+            Arc::new(MockSource::new(table_schema.clone()));
+
+        let metadata_cols = vec![MetadataColumn::Location(None)];
+
+        let config =
+            FileScanConfigBuilder::new(object_store_url, Arc::clone(&file_source))
+                .with_metadata_cols(metadata_cols)
+                .expect("metadata cols valid")
+                .with_projection_indices(Some(vec![0, 1, 2]))
+                .expect("valid projection")
+                .build();
+
+        // Push a projection so that file_source.projection() is Some
+        let initial_schema = config.projected_schema().expect("projected schema");
+        let proj_exprs = ProjectionExprs::new(vec![
+            ProjectionExpr::new(col("id", &initial_schema).expect("col"), "id"),
+            ProjectionExpr::new(col("value", &initial_schema).expect("col"), "value"),
+            ProjectionExpr::new(
+                col("_location", &initial_schema).expect("col"),
+                "_location",
+            ),
+        ]);
+        let data_source = config
+            .try_swapping_with_projection(&proj_exprs)
+            .expect("swap ok")
+            .expect("should produce new source");
+
+        let eq_props = data_source.eq_properties();
+        let schema = eq_props.schema();
+
+        // Projected schema: [id, value] + metadata: [location]
+        assert_eq!(
+            schema.fields().len(),
+            3,
+            "Expected 3 fields (2 projected + 1 metadata), got {}",
+            schema.fields().len()
+        );
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).name(), "value");
+        assert_eq!(schema.field(2).name(), "_location");
+
+        // Verify it matches projected_schema()
+        let projected = data_source
+            .as_any()
+            .downcast_ref::<FileScanConfig>()
+            .expect("is FileScanConfig")
+            .projected_schema()
+            .expect("projected schema");
+        assert_eq!(schema.fields().len(), projected.fields().len());
+        for (eq_field, proj_field) in
+            schema.fields().iter().zip(projected.fields().iter())
+        {
+            assert_eq!(eq_field.name(), proj_field.name());
+        }
+    }
+
+    /// Test that eq_properties schema matches projected_schema when only
+    /// metadata columns are projected (no file/partition columns).
+    #[test]
+    fn test_eq_properties_metadata_only_projection() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]));
+        let object_store_url = ObjectStoreUrl::parse("test:///").expect("valid url");
+
+        let partition_cols = vec![
+            Arc::new(Field::new(
+                "year",
+                wrap_partition_type_in_dict(DataType::Utf8),
+                false,
+            )),
+            Arc::new(Field::new(
+                "month",
+                wrap_partition_type_in_dict(DataType::Utf8),
+                false,
+            )),
+            Arc::new(Field::new(
+                "day",
+                wrap_partition_type_in_dict(DataType::Utf8),
+                false,
+            )),
+        ];
+
+        let table_schema =
+            TableSchema::new(Arc::clone(&file_schema), partition_cols.clone());
+        let file_source: Arc<dyn FileSource> =
+            Arc::new(MockSource::new(table_schema.clone()));
+
+        let metadata_cols = vec![
+            MetadataColumn::LastModified,
+            MetadataColumn::Location(None),
+            MetadataColumn::Size,
+        ];
+
+        // table_schema = [id(0), value(1), year(2), month(3), day(4)] = 5 cols
+        // metadata = [last_modified(5), location(6), size(7)]
+        // SELECT location -> projection = [6]
+        let config = FileScanConfigBuilder::new(object_store_url, file_source)
+            .with_metadata_cols(metadata_cols)
+            .expect("metadata cols valid")
+            .with_projection_indices(Some(vec![6]))
+            .expect("valid projection")
+            .build();
+
+        let eq_props = config.eq_properties();
+        let eq_schema = eq_props.schema();
+
+        let projected = config.projected_schema().expect("projected schema");
+
+        // Both schemas must match: [location]
+        assert_eq!(
+            eq_schema.fields().len(),
+            projected.fields().len(),
+            "eq_properties schema has {} fields but projected_schema has {}",
+            eq_schema.fields().len(),
+            projected.fields().len(),
+        );
+        for (eq_field, proj_field) in
+            eq_schema.fields().iter().zip(projected.fields().iter())
+        {
+            assert_eq!(
+                eq_field.name(),
+                proj_field.name(),
+                "Field name mismatch: eq_properties has '{}' but projected_schema has '{}'",
+                eq_field.name(),
+                proj_field.name(),
+            );
+        }
+    }
+
+    /// Test that eq_properties schema matches projected_schema when a mix of
+    /// file columns and metadata columns are projected, with metadata appearing
+    /// at the beginning of the output.
+    #[test]
+    fn test_eq_properties_metadata_before_file_columns() {
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]));
+        let object_store_url = ObjectStoreUrl::parse("test:///").expect("valid url");
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), vec![]);
+        let file_source: Arc<dyn FileSource> =
+            Arc::new(MockSource::new(table_schema.clone()));
+
+        let metadata_cols = vec![MetadataColumn::Location(None), MetadataColumn::Size];
+
+        // table_schema = [id(0), value(1)] = 2 cols
+        // metadata = [location(2), size(3)]
+        // SELECT location, id -> projection = [2, 0]
+        // Metadata "_location" should be at output position 0, "id" after it.
+        let config = FileScanConfigBuilder::new(object_store_url, file_source)
+            .with_metadata_cols(metadata_cols)
+            .expect("metadata cols valid")
+            .with_projection_indices(Some(vec![2, 0]))
+            .expect("valid projection")
+            .build();
+
+        let eq_props = config.eq_properties();
+        let eq_schema = eq_props.schema();
+
+        let projected = config.projected_schema().expect("projected schema");
+
+        assert_eq!(
+            eq_schema.fields().len(),
+            projected.fields().len(),
+            "eq_properties schema has {} fields but projected_schema has {}",
+            eq_schema.fields().len(),
+            projected.fields().len(),
+        );
+        for (eq_field, proj_field) in
+            eq_schema.fields().iter().zip(projected.fields().iter())
+        {
+            assert_eq!(
+                eq_field.name(),
+                proj_field.name(),
+                "Field name mismatch: eq_properties has '{}' but projected_schema has '{}'",
+                eq_field.name(),
+                proj_field.name(),
+            );
+        }
     }
 }

--- a/datafusion/datasource/src/test_util.rs
+++ b/datafusion/datasource/src/test_util.rs
@@ -88,6 +88,17 @@ impl FileSource for MockSource {
         Arc::new(Self { ..self.clone() })
     }
 
+    fn with_metadata_cols(
+        &self,
+        metadata_cols: Vec<crate::metadata::MetadataColumn>,
+    ) -> Option<Arc<dyn FileSource>> {
+        let mut source = self.clone();
+        source.table_schema = source.table_schema.with_metadata_cols(metadata_cols);
+        source.projection =
+            crate::projection::SplitProjection::unprojected(&source.table_schema);
+        Some(Arc::new(source))
+    }
+
     fn metrics(&self) -> &ExecutionPlanMetricsSet {
         &self.metrics
     }
@@ -106,8 +117,8 @@ impl FileSource for MockSource {
     ) -> Result<Option<Arc<dyn FileSource>>> {
         let mut source = self.clone();
         let new_projection = self.projection.source.try_merge(projection)?;
-        let split_projection = crate::projection::SplitProjection::new(
-            self.table_schema.file_schema(),
+        let split_projection = crate::projection::SplitProjection::new_with_table_schema(
+            &self.table_schema,
             &new_projection,
         );
         source.projection = split_projection;

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -661,7 +661,15 @@ impl ProjectionExprs {
         for proj_expr in self.exprs.iter() {
             let expr = &proj_expr.expr;
             let col_stats = if let Some(col) = expr.as_any().downcast_ref::<Column>() {
-                std::mem::take(&mut stats.column_statistics[col.index()])
+                // Spice metadata columns (and projected partition columns) reference
+                // table-schema indices that fall beyond the upstream file-level
+                // statistics, which only cover the file (and partition) columns. Those
+                // injected columns have no known statistics, so fall back to unknown
+                if col.index() < stats.column_statistics.len() {
+                    std::mem::take(&mut stats.column_statistics[col.index()])
+                } else {
+                    ColumnStatistics::new_unknown()
+                }
             } else if let Some(literal) = expr.as_any().downcast_ref::<Literal>() {
                 // Handle literal expressions (constants) by calculating proper statistics
                 let data_type = expr.data_type(output_schema)?;
@@ -2732,6 +2740,54 @@ pub(crate) mod tests {
         assert_eq!(
             output_stats.column_statistics[1].distinct_count,
             Precision::Exact(1)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_project_statistics_column_index_beyond_input_stats() -> Result<()> {
+        // File-level statistics only cover the three file columns.
+        let input_stats = get_stats();
+        assert_eq!(input_stats.column_statistics.len(), 3);
+
+        // The table schema additionally exposes a metadata column at index 3.
+        let table_schema = Schema::new(vec![
+            Field::new("col0", DataType::Int64, false),
+            Field::new("col1", DataType::Utf8, false),
+            Field::new("col2", DataType::Float32, false),
+            Field::new("_location", DataType::Utf8, true),
+        ]);
+
+        // SELECT col0, _location — the metadata column (index 3) is beyond the
+        // input statistics width (3).
+        let projection = ProjectionExprs::new(vec![
+            ProjectionExpr {
+                expr: Arc::new(Column::new("col0", 0)),
+                alias: "col0".to_string(),
+            },
+            ProjectionExpr {
+                expr: Arc::new(Column::new("_location", 3)),
+                alias: "_location".to_string(),
+            },
+        ]);
+
+        let output_stats = projection
+            .project_statistics(input_stats, &projection.project_schema(&table_schema)?)?;
+
+        assert_eq!(output_stats.num_rows, Precision::Exact(5));
+        assert_eq!(output_stats.column_statistics.len(), 2);
+
+        // col0 keeps its known statistics.
+        assert_eq!(
+            output_stats.column_statistics[0].max_value,
+            Precision::Exact(ScalarValue::Int64(Some(21)))
+        );
+
+        // The metadata column has no upstream statistics -> unknown, not a panic.
+        assert_eq!(
+            output_stats.column_statistics[1],
+            ColumnStatistics::new_unknown()
         );
 
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

`ProjectionExprs::project_statistics` panics with an out-of-bounds index when a projection references a `Column` whose index is ≥ `stats.column_statistics.len()`. Triggered by Spice metadata columns (`_location`, `_last_modified`, `_size`) — or any column appended to `TableSchema` past the file-level statistics — being projected through `FileScanConfig::partition_statistics`.

spiceai-52 worked around it externally: `partition_statistics` post-processed the output and inserted `ColumnStatistics::new_unknown()` at metadata-column positions. The DF53 reconcile (`d599c7272`) folded metadata columns into `TableSchema` and dropped the post-processing, feeding metadata indices straight into the unguarded `column_statistics[col.index()]`.

## Fix
Bounds-guard the `Column` arm in `ProjectionExprs::project_statistics` (`datafusion/physical-expr/src/projection.rs`): if `col.index()` is beyond the input stats width, fall back to `ColumnStatistics::new_unknown()` instead of indexing.

## Tests
- New regression test `test_project_statistics_column_index_beyond_input_stats` — projects `_location` at index 3 over file stats of width 3, asserts trailing column comes back as unknown.
- All `project_statistics` tests pass (8/8).
- All `datafusion-datasource` metadata tests pass (10/10).
- `test_partition_statistics_projection` (the call-site path) passes.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
