### PR TITLE
feat(physical-plan): improve join cardinality estimation for computed keys (+ overflow guard)

### DIFF
--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -735,6 +735,28 @@ impl ProjectionExprs {
     }
 }
 
+/// Upper bound on the distinct values of `mod(_, k)` when `k` is a positive
+/// integer literal: the result lies in `{0, …, k-1}`, so at most `k` distinct
+/// values.
+fn modulo_result_distinct_count(expr: &dyn PhysicalExpr) -> Option<usize> {
+    let func = expr.downcast_ref::<ScalarFunctionExpr>()?;
+    if !func.name().eq_ignore_ascii_case("mod") || func.args().len() != 2 {
+        return None;
+    }
+    let divisor = func.args()[1].as_ref().downcast_ref::<Literal>()?;
+    match divisor.value() {
+        ScalarValue::Int8(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::Int16(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::Int32(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::Int64(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::UInt8(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::UInt16(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::UInt32(Some(k)) if *k > 0 => Some(*k as usize),
+        ScalarValue::UInt64(Some(k)) if *k > 0 => Some(*k as usize),
+        _ => None,
+    }
+}
+
 /// Propagate column statistics through CAST projections. Other expressions
 /// return unknown — generalizing via [`PhysicalExpr::evaluate_bounds`] is
 /// unsafe for aggregate folding since many impls (e.g. `sin`) return a fixed
@@ -745,6 +767,14 @@ fn project_column_statistics_through_expr(
 ) -> ColumnStatistics {
     if let Some(col) = expr.downcast_ref::<Column>() {
         return column_stats[col.index()].clone();
+    }
+    // A `mod(.., k)` result takes at most `k` distinct values.  Otherwise the join
+    // cardinality falls back to row-count and JoinSelection picks the wrong (huge) build side.
+    if let Some(k) = modulo_result_distinct_count(expr) {
+        return ColumnStatistics {
+            distinct_count: Precision::Inexact(k),
+            ..ColumnStatistics::new_unknown()
+        };
     }
     let Some(cast_expr) = expr.downcast_ref::<CastExpr>() else {
         return ColumnStatistics::new_unknown();

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -735,26 +735,33 @@ impl ProjectionExprs {
     }
 }
 
-/// Upper bound on the distinct values of `mod(_, k)` when `k` is a positive
-/// integer literal: the result lies in `{0, …, k-1}`, so at most `k` distinct
-/// values.
+/// Conservative estimate of the distinct values produced by `mod(_, k)` for a
+/// positive integer literal `k`. For a non-negative dividend (the targeted
+/// `mod(id * id, k)` join keys) the result lies in `{0, …, k-1}`, so `k` is an
+/// exact upper bound. Truncated-remainder semantics allow `{-(k-1), …, k-1}`
+/// for negative dividends; there `k` under-counts the NDV, which only
+/// over-estimates cardinality (the safe direction — never collapses the join).
+/// Reported as `Inexact` either way.
 fn modulo_result_distinct_count(expr: &dyn PhysicalExpr) -> Option<usize> {
     let func = expr.downcast_ref::<ScalarFunctionExpr>()?;
     if !func.name().eq_ignore_ascii_case("mod") || func.args().len() != 2 {
         return None;
     }
     let divisor = func.args()[1].as_ref().downcast_ref::<Literal>()?;
-    match divisor.value() {
-        ScalarValue::Int8(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::Int16(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::Int32(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::Int64(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::UInt8(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::UInt16(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::UInt32(Some(k)) if *k > 0 => Some(*k as usize),
-        ScalarValue::UInt64(Some(k)) if *k > 0 => Some(*k as usize),
-        _ => None,
-    }
+    // Normalize the positive literal to u64, then do a single fallible
+    // conversion to usize (guards against truncation on 32-bit targets).
+    let k: u64 = match divisor.value() {
+        ScalarValue::Int8(Some(k)) if *k > 0 => *k as u64,
+        ScalarValue::Int16(Some(k)) if *k > 0 => *k as u64,
+        ScalarValue::Int32(Some(k)) if *k > 0 => *k as u64,
+        ScalarValue::Int64(Some(k)) if *k > 0 => *k as u64,
+        ScalarValue::UInt8(Some(k)) if *k > 0 => u64::from(*k),
+        ScalarValue::UInt16(Some(k)) if *k > 0 => u64::from(*k),
+        ScalarValue::UInt32(Some(k)) if *k > 0 => u64::from(*k),
+        ScalarValue::UInt64(Some(k)) if *k > 0 => *k,
+        _ => return None,
+    };
+    usize::try_from(k).ok()
 }
 
 /// Propagate column statistics through CAST projections. Other expressions
@@ -1335,8 +1342,44 @@ pub(crate) mod tests {
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, TimeUnit};
     use datafusion_common::config::ConfigOptions;
-    use datafusion_expr::{Operator, ScalarUDF};
+    use datafusion_expr::{
+        ColumnarValue, Operator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+        Volatility,
+    };
     use insta::assert_snapshot;
+
+    /// Minimal `mod(a, b)` UDF used only to drive statistics propagation in
+    /// tests — it is never executed, so `invoke_with_args` is unreachable.
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct ModUdf {
+        signature: Signature,
+    }
+
+    impl ModUdf {
+        fn new() -> Self {
+            Self {
+                signature: Signature::exact(
+                    vec![DataType::Int64, DataType::Int64],
+                    Volatility::Immutable,
+                ),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for ModUdf {
+        fn name(&self) -> &str {
+            "mod"
+        }
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int64)
+        }
+        fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            unimplemented!("mod UDF is statistics-only in tests and never invoked")
+        }
+    }
 
     pub(crate) fn output_schema(
         mapping: &ProjectionMapping,
@@ -2940,6 +2983,47 @@ pub(crate) mod tests {
         assert_eq!(
             output_stats.column_statistics[0].max_value,
             Precision::Exact(ScalarValue::Int32(Some(21)))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_project_statistics_modulo_distinct_count() -> Result<()> {
+        let input_stats = get_stats();
+        let input_schema = get_schema();
+
+        // SELECT mod(col0, 10) AS bucket
+        //
+        // col0 is Int64 with distinct_count=Exact(5). A `mod(_, 10)` result has
+        // at most 10 distinct values, so the projected column reports
+        // distinct_count = Inexact(10) instead of the Absent it would otherwise
+        // get for an arbitrary scalar function. Keeping an NDV on modulo join
+        // keys stops join planning from falling back to row counts.
+        let mod_udf = Arc::new(ScalarUDF::new_from_impl(ModUdf::new()));
+        let mod_expr = Arc::new(ScalarFunctionExpr::try_new(
+            mod_udf,
+            vec![
+                Arc::new(Column::new("col0", 0)),
+                Arc::new(Literal::new(ScalarValue::Int64(Some(10)))),
+            ],
+            &input_schema,
+            Arc::new(ConfigOptions::default()),
+        )?) as PhysicalExprRef;
+
+        let projection = ProjectionExprs::new(vec![ProjectionExpr {
+            expr: mod_expr,
+            alias: "bucket".to_string(),
+        }]);
+
+        let output_stats = projection.project_statistics(
+            input_stats,
+            &projection.project_schema(&input_schema)?,
+        )?;
+
+        assert_eq!(
+            output_stats.column_statistics[0].distinct_count,
+            Precision::Inexact(10)
         );
 
         Ok(())

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -487,7 +487,29 @@ fn estimate_join_cardinality(
                         .cloned()
                         .unwrap_or_else(ColumnStatistics::new_unknown),
                 ),
-                _ => (
+                // One side is a plain column, the other an expression key
+                // (e.g. `mod(s_w_id * s_i_id, 10000) = su_suppkey` or
+                // `ascii(substr(c_state,1,1)) - 65 = su_nationkey`). The
+                // expression's distinct count is unknown, but for an equi-join
+                // the match selectivity is bounded by the known column's NDV
+                // Reuse the column's statistics as a proxy for *both* sides
+                (Some(left), None) => {
+                    let stat = left_stats
+                        .column_statistics
+                        .get(left.index())
+                        .cloned()
+                        .unwrap_or_else(ColumnStatistics::new_unknown);
+                    (stat.clone(), stat)
+                }
+                (None, Some(right)) => {
+                    let stat = right_stats
+                        .column_statistics
+                        .get(right.index())
+                        .cloned()
+                        .unwrap_or_else(ColumnStatistics::new_unknown);
+                    (stat.clone(), stat)
+                }
+                (None, None) => (
                     ColumnStatistics::new_unknown(),
                     ColumnStatistics::new_unknown(),
                 ),
@@ -648,22 +670,25 @@ fn estimate_inner_join_cardinality(
         }
     }
 
-    // With the assumption that the smaller input's domain is generally represented in the bigger
-    // input's domain, we can estimate the inner join's cardinality by taking the cartesian product
-    // of the two inputs and normalizing it by the selectivity factor.
+    // With the assumption that the smaller input's domain is generally represented
+    // in the bigger input's domain, the inner join cardinality is the cartesian
+    // product normalized by the selectivity factor. Use `checked_mul`: an upstream
+    // reorder can feed inflated intermediate row estimates whose product exceeds
+    // `usize::MAX`. Vanilla DataFusion multiplies unchecked and *panics* ("attempt
+    // to multiply with overflow", seen on chbench q8); return `None` (unknown —
+    // handled like the Absent-selectivity case) on overflow instead.
     let left_num_rows = left_stats.num_rows.get_value()?;
     let right_num_rows = right_stats.num_rows.get_value()?;
-    match join_selectivity {
-        Precision::Exact(value) if value > 0 => {
-            Some(Precision::Exact((left_num_rows * right_num_rows) / value))
+    let cartesian = left_num_rows.checked_mul(*right_num_rows);
+    match (join_selectivity, cartesian) {
+        (Precision::Exact(value), Some(card)) if value > 0 => {
+            Some(Precision::Exact(card / value))
         }
-        Precision::Inexact(value) if value > 0 => {
-            Some(Precision::Inexact((left_num_rows * right_num_rows) / value))
+        (Precision::Inexact(value), Some(card)) if value > 0 => {
+            Some(Precision::Inexact(card / value))
         }
-        // Since we don't have any information about the selectivity (which is derived
-        // from the number of distinct rows information) we can give up here for now.
-        // And let other passes handle this (otherwise we would need to produce an
-        // overestimation using just the cartesian product).
+        // No selectivity information, or the cartesian product overflowed: give up
+        // here and let other passes handle it (rather than over-estimate).
         _ => None,
     }
 }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -2179,6 +2179,7 @@ mod tests {
     use datafusion_common::stats::Precision::{Absent, Exact, Inexact};
     use datafusion_common::{ScalarValue, arrow_datafusion_err, arrow_err};
     use datafusion_physical_expr::PhysicalSortExpr;
+    use datafusion_physical_expr::expressions::CastExpr;
 
     use rstest::rstest;
 
@@ -2812,6 +2813,89 @@ mod tests {
                 [left_col_stats.clone(), right_col_stats.clone()].concat()
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_cardinality_with_expression_key() -> Result<()> {
+        // Regression test for the `Column = <non-Column expr>` heuristic.
+        //
+        // When one equi-join key is a plain column (with a known NDV) and the
+        // other is a computed expression (e.g. `mod(s_w_id * s_i_id, 10000)`),
+        // the expression's distinct count is unknown. Previously such a key fell
+        // through to fully-unknown stats, so `max_distinct_count` defaulted the
+        // selectivity to each side's row count (the cartesian product normalized
+        // by `num_rows`). Now we reuse the known column's statistics as a proxy
+        // for *both* sides, so the selectivity is driven by the column's NDV
+        // rather than by row counts.
+        //
+        // Left table (rows=1000): a: min=0, max=100, distinct=100
+        // Right table (rows=2000): c: min=0, max=100, distinct=50
+        //
+        // A non-Column expression is just a Cast wrapping the other side's column.
+        let left_col_stats = vec![create_column_stats(
+            Inexact(0),
+            Inexact(100),
+            Inexact(100),
+            Absent,
+        )];
+        let right_col_stats = vec![create_column_stats(
+            Inexact(0),
+            Inexact(100),
+            Inexact(50),
+            Absent,
+        )];
+
+        let column_a = || Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+        let column_c = || Arc::new(Column::new("c", 0)) as Arc<dyn PhysicalExpr>;
+        let expr_key = |inner: Arc<dyn PhysicalExpr>| {
+            Arc::new(CastExpr::new(inner, DataType::Int64, None)) as Arc<dyn PhysicalExpr>
+        };
+
+        // Left key is the plain column `a` (NDV=100), right key is an expression.
+        // The column's NDV is reused for both sides:
+        //   selectivity = max_distinct = 100
+        //   cardinality = (1000 * 2000) / 100 = 20_000
+        let left_column_on = vec![(column_a(), expr_key(column_c()))];
+        let stats = estimate_join_cardinality(
+            &JoinType::Inner,
+            create_stats(Some(1000), left_col_stats.clone(), false),
+            create_stats(Some(2000), right_col_stats.clone(), false),
+            &left_column_on,
+        )
+        .expect("column NDV should drive a finite estimate");
+        assert_eq!(stats.num_rows, 20_000);
+
+        // Symmetric case: right key is the plain column `c` (NDV=50), left key is
+        // an expression. The column's NDV is reused for both sides:
+        //   cardinality = (1000 * 2000) / 50 = 40_000
+        let right_column_on = vec![(expr_key(column_a()), column_c())];
+        let stats = estimate_join_cardinality(
+            &JoinType::Inner,
+            create_stats(Some(1000), left_col_stats.clone(), false),
+            create_stats(Some(2000), right_col_stats.clone(), false),
+            &right_column_on,
+        )
+        .expect("column NDV should drive a finite estimate");
+        assert_eq!(stats.num_rows, 40_000);
+
+        // Contrast: when *both* keys are expressions there is no column NDV to
+        // lean on, so we fall back to the old behaviour — fully-unknown stats
+        // make `max_distinct_count` default to each side's row count:
+        //   selectivity = max(1000, 2000) = 2000
+        //   cardinality = (1000 * 2000) / 2000 = 1000
+        // This is the `num_rows` fallback the heuristic above avoids whenever one
+        // side is a plain column.
+        let both_expr_on = vec![(expr_key(column_a()), expr_key(column_c()))];
+        let stats = estimate_join_cardinality(
+            &JoinType::Inner,
+            create_stats(Some(1000), left_col_stats.clone(), false),
+            create_stats(Some(2000), right_col_stats.clone(), false),
+            &both_expr_on,
+        )
+        .expect("num_rows fallback still yields an estimate");
+        assert_eq!(stats.num_rows, 1000);
 
         Ok(())
     }

--- a/datafusion/spark/src/function/array/array_contains.rs
+++ b/datafusion/spark/src/function/array/array_contains.rs
@@ -25,7 +25,6 @@ use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_functions_nested::array_has::array_has_udf;
-use std::any::Any;
 use std::sync::Arc;
 
 /// Spark-compatible `array_contains` function.


### PR DESCRIPTION
## Which issue does this PR close?

PR improves join cardinality estimation for `JoinSelection`, which picks the hash-join build side. Three gaps cause it to pick the wrong (huge) build side or panic on queries with *computed* join keys:

1. **Expression = column equi-keys discard usable stats.** For keys like `mod(s_w_id * s_i_id, 10000) = su_suppkey` or `ascii(substr(c_state, 1, 1)) - 65 = su_nationkey`, only one side is a plain column. The expression side has no distinct-count, so estimation drops *both* sides' stats and falls back to `num_rows`, badly over-estimating the join and inverting the build/probe choice.

2. **A modulo key loses its NDV when materialized into a projection.** Even  though `mod(_, k)` can produce at most `k` distinct values, a projected `mod(_, k)` column reported unknown NDV, so the estimate again fell back to row-count.

3. **The final cartesian product can overflow and panic.** Inflated intermediate row estimates (e.g. from an upstream reorder) make `left_rows * right_rows` exceed `usize::MAX`, panicking with `"attempt to multiply with overflow"` instead of degrading gracefully.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
