### PR TITLE
Proper support for date_trunc in BigQueryDialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -18,8 +18,9 @@
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    Unparser, utils::character_length_to_sql, utils::date_part_to_sql,
-    utils::sqlite_date_trunc_to_sql, utils::sqlite_from_unixtime_to_sql,
+    Unparser, utils::bigquery_date_trunc_to_sql, utils::character_length_to_sql,
+    utils::date_part_to_sql, utils::sqlite_date_trunc_to_sql,
+    utils::sqlite_from_unixtime_to_sql,
 };
 use arrow::array::timezone::Tz;
 use arrow::datatypes::TimeUnit;
@@ -854,6 +855,10 @@ impl Dialect for BigQueryDialect {
     ) -> Result<Option<ast::Expr>> {
         if func_name == "date_part" {
             return date_part_to_sql(unparser, self.date_field_extract_style(), args);
+        }
+
+        if func_name == "date_trunc" {
+            return bigquery_date_trunc_to_sql(unparser, args);
         }
 
         Ok(None)

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -3465,6 +3465,7 @@ mod tests {
     fn test_date_trunc() -> Result<()> {
         let default_dialect: Arc<dyn Dialect> = Arc::new(DefaultDialect {});
         let sqlite_dialect: Arc<dyn Dialect> = Arc::new(SqliteDialect {});
+        let bigquery_dialect: Arc<dyn Dialect> = Arc::new(BigQueryDialect::new());
 
         for (dialect, precision, expected) in [
             (
@@ -3476,6 +3477,33 @@ mod tests {
                 Arc::clone(&sqlite_dialect),
                 "YEAR",
                 "strftime('%Y', `date_col`)",
+            ),
+            // BigQuery reverses the argument order and emits the granularity as
+            // a bare keyword (not a quoted string).
+            (
+                Arc::clone(&bigquery_dialect),
+                "YEAR",
+                "TIMESTAMP_TRUNC(`date_col`, YEAR)",
+            ),
+            (
+                Arc::clone(&bigquery_dialect),
+                "QUARTER",
+                "TIMESTAMP_TRUNC(`date_col`, QUARTER)",
+            ),
+            (
+                Arc::clone(&bigquery_dialect),
+                "WEEK",
+                "TIMESTAMP_TRUNC(`date_col`, WEEK)",
+            ),
+            (
+                Arc::clone(&bigquery_dialect),
+                "MONTH",
+                "TIMESTAMP_TRUNC(`date_col`, MONTH)",
+            ),
+            (
+                Arc::clone(&bigquery_dialect),
+                "SECOND",
+                "TIMESTAMP_TRUNC(`date_col`, SECOND)",
             ),
             (
                 Arc::clone(&default_dialect),

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -3490,10 +3490,12 @@ mod tests {
                 "QUARTER",
                 "TIMESTAMP_TRUNC(`date_col`, QUARTER)",
             ),
+            // DataFusion truncates weeks to Monday → BigQuery ISOWEEK (also
+            // Monday-based), not the Sunday-based bare WEEK.
             (
                 Arc::clone(&bigquery_dialect),
                 "WEEK",
-                "TIMESTAMP_TRUNC(`date_col`, WEEK)",
+                "TIMESTAMP_TRUNC(`date_col`, ISOWEEK)",
             ),
             (
                 Arc::clone(&bigquery_dialect),

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -642,12 +642,15 @@ pub(crate) fn sqlite_date_trunc_to_sql(
 ///    second (`TIMESTAMP_TRUNC(ts, MONTH)` vs `date_trunc('month', ts)`).
 /// 2. **The granularity is a bare keyword**, not a quoted string literal
 ///    (`MONTH`, not `'month'`), so it is emitted as an unquoted identifier.
-/// 3. The function name is type-specific. We emit `TIMESTAMP_TRUNC`, which is
-///    the correct choice for DataFusion's `date_trunc` since it operates on (and
-///    returns) `Timestamp` values. BigQuery `DATETIME`/`DATE` columns (arrow
-///    `Timestamp` without a timezone / `Date32`) would need `DATETIME_TRUNC` /
-///    `DATE_TRUNC`, but the source type is not available at unparse time, so
-///    callers truncating those types should not push the function down.
+/// 3. The function name is type-specific. We always emit `TIMESTAMP_TRUNC`,
+///    which is correct for the common case of a `Timestamp` (with timezone)
+///    input. DataFusion's `date_trunc` also accepts `Timestamp` *without* a
+///    timezone, `Date32`, and `Time32`/`Time64`, which in BigQuery map to
+///    `DATETIME_TRUNC`, `DATE_TRUNC`, and `TIME_TRUNC` respectively. The source
+///    type is not available at unparse time, so those inputs are rendered as
+///    `TIMESTAMP_TRUNC` too — which BigQuery rejects or mis-types. Callers
+///    truncating non-`TIMESTAMP` types should therefore not push the function
+///    down.
 ///
 /// Returns `Ok(None)` (falling back to default unparsing) when the arguments
 /// don't match the expected shape or the granularity is not one BigQuery
@@ -656,12 +659,11 @@ pub(crate) fn bigquery_date_trunc_to_sql(
     unparser: &Unparser,
     date_trunc_args: &[Expr],
 ) -> Result<Option<ast::Expr>> {
-    assert_eq_or_internal_err!(
-        date_trunc_args.len(),
-        2,
-        "date_trunc for BigQuery expects 2 arguments, found {}",
-        date_trunc_args.len()
-    );
+    // Fall back to default unparsing rather than erroring if the shape is
+    // unexpected; date_trunc is documented as taking exactly 2 arguments.
+    if date_trunc_args.len() != 2 {
+        return Ok(None);
+    }
 
     let Expr::Literal(ScalarValue::Utf8(Some(granularity)), _) = &date_trunc_args[0]
     else {
@@ -674,7 +676,9 @@ pub(crate) fn bigquery_date_trunc_to_sql(
         "year" => "YEAR",
         "quarter" => "QUARTER",
         "month" => "MONTH",
-        "week" => "WEEK",
+        // DataFusion truncates weeks to Monday; BigQuery's bare `WEEK` is
+        // Sunday-based, so use `ISOWEEK`, which truncates to Monday.
+        "week" => "ISOWEEK",
         "day" => "DAY",
         "hour" => "HOUR",
         "minute" => "MINUTE",

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -632,3 +632,86 @@ pub(crate) fn sqlite_date_trunc_to_sql(
 
     Ok(None)
 }
+
+/// Converts DataFusion's `date_trunc(granularity, expr)` to BigQuery's
+/// `TIMESTAMP_TRUNC(expr, GRANULARITY)`.
+///
+/// BigQuery's truncation function differs from DataFusion's in three ways, all
+/// of which this rewrite handles:
+/// 1. **Argument order is reversed** — the value comes first, the granularity
+///    second (`TIMESTAMP_TRUNC(ts, MONTH)` vs `date_trunc('month', ts)`).
+/// 2. **The granularity is a bare keyword**, not a quoted string literal
+///    (`MONTH`, not `'month'`), so it is emitted as an unquoted identifier.
+/// 3. The function name is type-specific. We emit `TIMESTAMP_TRUNC`, which is
+///    the correct choice for DataFusion's `date_trunc` since it operates on (and
+///    returns) `Timestamp` values. BigQuery `DATETIME`/`DATE` columns (arrow
+///    `Timestamp` without a timezone / `Date32`) would need `DATETIME_TRUNC` /
+///    `DATE_TRUNC`, but the source type is not available at unparse time, so
+///    callers truncating those types should not push the function down.
+///
+/// Returns `Ok(None)` (falling back to default unparsing) when the arguments
+/// don't match the expected shape or the granularity is not one BigQuery
+/// supports, so the caller can decide how to proceed.
+pub(crate) fn bigquery_date_trunc_to_sql(
+    unparser: &Unparser,
+    date_trunc_args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    assert_eq_or_internal_err!(
+        date_trunc_args.len(),
+        2,
+        "date_trunc for BigQuery expects 2 arguments, found {}",
+        date_trunc_args.len()
+    );
+
+    let Expr::Literal(ScalarValue::Utf8(Some(granularity)), _) = &date_trunc_args[0]
+    else {
+        return Ok(None);
+    };
+
+    // Map DataFusion granularities to BigQuery `TIMESTAMP_TRUNC` date parts.
+    // https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp_trunc
+    let part = match granularity.to_lowercase().as_str() {
+        "year" => "YEAR",
+        "quarter" => "QUARTER",
+        "month" => "MONTH",
+        "week" => "WEEK",
+        "day" => "DAY",
+        "hour" => "HOUR",
+        "minute" => "MINUTE",
+        "second" => "SECOND",
+        "millisecond" => "MILLISECOND",
+        "microsecond" => "MICROSECOND",
+        _ => return Ok(None),
+    };
+
+    let value_expr = unparser.expr_to_sql(&date_trunc_args[1])?;
+
+    Ok(Some(ast::Expr::Function(ast::Function {
+        name: ast::ObjectName::from(vec![ast::Ident {
+            value: "TIMESTAMP_TRUNC".to_string(),
+            quote_style: None,
+            span: Span::empty(),
+        }]),
+        args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+            duplicate_treatment: None,
+            args: vec![
+                ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(value_expr)),
+                // The date part must be an unquoted keyword, not a string literal.
+                ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(
+                    ast::Expr::Identifier(ast::Ident {
+                        value: part.to_string(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }),
+                )),
+            ],
+            clauses: vec![],
+        }),
+        filter: None,
+        null_treatment: None,
+        over: None,
+        within_group: vec![],
+        parameters: ast::FunctionArguments::None,
+        uses_odbc_syntax: false,
+    })))
+}

--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -703,8 +703,7 @@ mod tests {
     use arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema};
     use datafusion_common::{Column, DFSchema, Result};
     use datafusion_expr::{
-        ColumnUnnestList, EmptyRelation, Expr, LogicalPlan, col, expr::Alias, lit,
-        unnest,
+        ColumnUnnestList, EmptyRelation, Expr, LogicalPlan, col, expr::Alias, lit, unnest,
     };
     use datafusion_functions::core::expr_ext::FieldAccessor;
     use datafusion_functions_aggregate::expr_fn::count;


### PR DESCRIPTION
## Which issue does this PR close?

Properly handle `date_trunc` when pushing down using `BigQueryDialect `.