### PR TITLE
fix(stats): recompute total_byte_size from per-column sizes after projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "datafusion-pruning 54.0.0",
  "insta",
  "itertools 0.14.0",
+ "log",
  "recursive",
  "tokio",
 ]

--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -416,29 +416,64 @@ impl Statistics {
         }
     }
 
-    /// Calculates `total_byte_size` based on the schema and `num_rows`.
-    /// If any of the columns has non-primitive width, `total_byte_size` is set to inexact.
+    /// Recalculates `total_byte_size` from the per-column statistics and `schema`.
+    ///
+    /// Each column contributes, in priority order:
+    /// 1. its own `byte_size` (a per-column total across all rows) when known
+    /// 2. `primitive_width() * num_rows` for a fixed-width type whose `byte_size`
+    ///    is absent.
+    ///
+    /// This matters after a projection: without per-column accounting, a scan
+    /// that projects a wide table down to a few narrow columns would keep the
+    /// full unprojected `total_byte_size` the moment one variable-width column
+    /// (e.g. `Utf8`) survived — drastically over-reporting the materialized size
+    ///
+    /// Falls back to the existing `total_byte_size` (downgraded to inexact) only
+    /// when it cannot be derived: `num_rows` is unknown, or some column is
+    /// variable-width *and* has no `byte_size` (nothing to size it from).
+    ///
+    /// Requires `column_statistics` to be aligned with `schema`.
     pub fn calculate_total_byte_size(&mut self, schema: &Schema) {
-        let mut row_size = Some(0);
-        for field in schema.fields() {
+        let Some(&num_rows) = self.num_rows.get_value() else {
+            // No row-count signal to derive sizes from; keep the prior estimate.
+            self.total_byte_size = self.total_byte_size.to_inexact();
+            return;
+        };
+
+        let mut sum: usize = 0;
+        let mut exact = true;
+        let num_rows_exact = self.num_rows.is_exact().unwrap_or(false);
+
+        for (i, field) in schema.fields().iter().enumerate() {
+            // 1) Prefer the column's own byte_size (a per-column total).
+            if let Some(col) = self.column_statistics.get(i) {
+                if let Some(&bytes) = col.byte_size.get_value() {
+                    sum = sum.saturating_add(bytes);
+                    exact &= col.byte_size.is_exact().unwrap_or(false);
+                    continue;
+                }
+            }
+            // 2) Fall back to the type width when byte_size is absent.
             match field.data_type().primitive_width() {
                 Some(width) => {
-                    row_size = row_size.map(|s| s + width);
+                    sum = sum.saturating_add(width.saturating_mul(num_rows));
+                    exact &= num_rows_exact;
                 }
                 None => {
-                    row_size = None;
-                    break;
+                    // Variable-width column with no byte_size: nothing to size it
+                    // from. Preserve the prior behavior — keep the existing
+                    // estimate, downgraded to inexact — rather than under-counting.
+                    self.total_byte_size = self.total_byte_size.to_inexact();
+                    return;
                 }
             }
         }
-        match row_size {
-            None => {
-                self.total_byte_size = self.total_byte_size.to_inexact();
-            }
-            Some(size) => {
-                self.total_byte_size = self.num_rows.multiply(&Precision::Exact(size));
-            }
-        }
+
+        self.total_byte_size = if exact {
+            Precision::Exact(sum)
+        } else {
+            Precision::Inexact(sum)
+        };
     }
 
     /// Returns an unbounded `ColumnStatistics` for each field in the schema.
@@ -1482,6 +1517,68 @@ mod tests {
         let projection = Some(vec![1, 2, 1, 1, 0, 2]);
         let stats = make_stats(vec![10, 20, 30]).project(projection.as_ref());
         assert_eq!(stats, make_stats(vec![20, 30, 20, 20, 10, 30]));
+    }
+
+    #[test]
+    fn test_calculate_total_byte_size_sums_per_column_byte_size() {
+        // Mixed fixed/variable-width schema; every column carries its own
+        // byte_size (as Vortex surfaces via UncompressedSizeInBytes).
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false), // variable-width
+        ]);
+        let mut stats = Statistics {
+            num_rows: Precision::Exact(1000),
+            // A stale, inflated total (as if inherited from an unprojected table).
+            total_byte_size: Precision::Exact(999_999_999),
+            column_statistics: vec![
+                ColumnStatistics::new_unknown().with_byte_size(Precision::Exact(4_000)),
+                ColumnStatistics::new_unknown().with_byte_size(Precision::Exact(6_000)),
+            ],
+        };
+        stats.calculate_total_byte_size(&schema);
+        // Sum of per-column byte_size, NOT the stale total — and the surviving
+        // Utf8 column no longer forces a fallback to the full size.
+        assert_eq!(stats.total_byte_size, Precision::Exact(10_000));
+    }
+
+    #[test]
+    fn test_calculate_total_byte_size_fixed_width_fallback() {
+        // No per-column byte_size: fall back to type widths * num_rows.
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false), // 4 bytes
+            Field::new("b", DataType::Int64, false), // 8 bytes
+        ]);
+        let mut stats = Statistics {
+            num_rows: Precision::Exact(100),
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![
+                ColumnStatistics::new_unknown(),
+                ColumnStatistics::new_unknown(),
+            ],
+        };
+        stats.calculate_total_byte_size(&schema);
+        assert_eq!(stats.total_byte_size, Precision::Exact(1_200)); // (4+8)*100
+    }
+
+    #[test]
+    fn test_calculate_total_byte_size_variable_width_no_byte_size_keeps_prior() {
+        // Variable-width column with no byte_size: nothing to size it from, so the
+        // prior estimate is preserved (downgraded to inexact), not under-counted.
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false),
+        ]);
+        let mut stats = Statistics {
+            num_rows: Precision::Exact(100),
+            total_byte_size: Precision::Exact(123_456),
+            column_statistics: vec![
+                ColumnStatistics::new_unknown().with_byte_size(Precision::Exact(400)),
+                ColumnStatistics::new_unknown(), // Utf8, byte_size Absent
+            ],
+        };
+        stats.calculate_total_byte_size(&schema);
+        assert_eq!(stats.total_byte_size, Precision::Inexact(123_456));
     }
 
     // Make a Statistics structure with the specified null counts for each column

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -729,8 +729,11 @@ impl ProjectionExprs {
             };
             column_statistics.push(col_stats);
         }
-        stats.calculate_total_byte_size(output_schema);
+        // Assign the projected per-column statistics first so
+        // `calculate_total_byte_size` sums the projected columns' own `byte_size`
+        // (aligned with `output_schema`)
         stats.column_statistics = column_statistics;
+        stats.calculate_total_byte_size(output_schema);
         Ok(stats)
     }
 }
@@ -2366,6 +2369,42 @@ pub(crate) mod tests {
         };
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_stats_projection_sums_per_column_byte_size() {
+        // Wide source: [c_id Int32, c_state Utf8 (narrow), c_data Utf8 (fat)].
+        let schema = Schema::new(vec![
+            Field::new("c_id", DataType::Int32, false),
+            Field::new("c_state", DataType::Utf8, false),
+            Field::new("c_data", DataType::Utf8, false),
+        ]);
+        let source = Statistics {
+            num_rows: Precision::Exact(1_000_000),
+            total_byte_size: Precision::Exact(744_000_000), // full row incl. c_data
+            column_statistics: vec![
+                ColumnStatistics::new_unknown().with_byte_size(Precision::Exact(4_000_000)),
+                ColumnStatistics::new_unknown().with_byte_size(Precision::Exact(6_000_000)),
+                ColumnStatistics::new_unknown()
+                    .with_byte_size(Precision::Exact(734_000_000)),
+            ],
+        };
+        // Project [c_id, c_state] (drop the fat c_data column).
+        let projection = ProjectionExprs::new(vec![
+            ProjectionExpr {
+                expr: Arc::new(Column::new("c_id", 0)),
+                alias: "c_id".to_string(),
+            },
+            ProjectionExpr {
+                expr: Arc::new(Column::new("c_state", 1)),
+                alias: "c_state".to_string(),
+            },
+        ]);
+        let result = projection
+            .project_statistics(source, &projection.project_schema(&schema).unwrap())
+            .unwrap();
+        // Sum of the two surviving columns' byte_size, not the 744MB full row.
+        assert_eq!(result.total_byte_size, Precision::Exact(10_000_000));
     }
 
     // Tests for Projection struct

--- a/datafusion/physical-optimizer/Cargo.toml
+++ b/datafusion/physical-optimizer/Cargo.toml
@@ -51,6 +51,7 @@ datafusion-physical-expr-common = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 datafusion-pruning = { workspace = true }
 itertools = { workspace = true }
+log = { workspace = true }
 recursive = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/datafusion/physical-optimizer/src/join_selection.rs
+++ b/datafusion/physical-optimizer/src/join_selection.rs
@@ -97,21 +97,28 @@ pub(crate) fn should_swap_join_order(
     let left_stats = get_stats(left, registry)?;
     let right_stats = get_stats(right, registry)?;
 
+    let l_b = left_stats.total_byte_size.get_value().copied();
+    let r_b = right_stats.total_byte_size.get_value().copied();
+    let l_r = left_stats.num_rows.get_value().copied();
+    let r_r = right_stats.num_rows.get_value().copied();
+
     // First compare total_byte_size, then fall back to num_rows if byte
     // sizes are unavailable.
-    match (
-        left_stats.total_byte_size.get_value(),
-        right_stats.total_byte_size.get_value(),
-    ) {
-        (Some(l), Some(r)) => Ok(l > r),
-        _ => match (
-            left_stats.num_rows.get_value(),
-            right_stats.num_rows.get_value(),
-        ) {
-            (Some(l), Some(r)) => Ok(l > r),
-            _ => Ok(false),
+    let swap = match (l_b, r_b) {
+        (Some(l), Some(r)) => l > r,
+        _ => match (l_r, r_r) {
+            (Some(l), Some(r)) => l > r,
+            _ => false,
         },
-    }
+    };
+
+    log::trace!(
+        "should_swap_join_order left={} right={} left_bytes={l_b:?} right_bytes={r_b:?} left_rows={l_r:?} right_rows={r_r:?} swap={swap}",
+        left.name(),
+        right.name()
+    );
+
+    Ok(swap)
 }
 
 fn supports_collect_by_thresholds(


### PR DESCRIPTION
## Which issue does this PR close?

`Statistics::calculate_total_byte_size` fell back to the full, unprojected `total_byte_size` whenever *any* output column was variable-width (e.g. `Utf8`), because `primitive_width()` returns `None` for those types and the function bailed on the first one. A scan that projects a wide table down to a few narrow columns then over-reported its size by orders of magnitude — e.g. a table projected to `[id i32, state Utf8]` reported the full ~20-column row width (dominated by an unprojected `VARCHAR(500)`) instead of the two projected columns.

## Fix

`calculate_total_byte_size` now accounts per column:
1. use the column's own `byte_size` when known
2. else `primitive_width() * num_rows` for fixed-width columns (original logic);

`ProjectionExprs::project_statistics` now assigns the projected column statistics before recomputing, so the sum aligns with the output schema.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
