### PR TITLE
fix(unparser): inline computed projection aliases in ORDER BY expressions

### DIFF
--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -330,17 +330,59 @@ pub(crate) fn unproject_sort_expr(
                         )?));
                     }
 
-                    // If SELECT and ORDER BY contain the same expression with a scalar function, the ORDER BY expression will
-                    // be replaced by a Column expression (e.g., "substr(customer.c_last_name, Int64(0), Int64(5))"), and we need
-                    // to transform it back to the actual expression.
+                    // If SELECT and ORDER BY contain the same expression (e.g., a scalar function
+                    // or any other non-trivial computed expression like BinaryExpr), the ORDER BY
+                    // expression will be replaced by a Column expression referencing the SELECT-list
+                    // alias. We need to transform it back to the actual expression so that it is
+                    // valid SQL in all positions inside ORDER BY (PostgreSQL only allows bare
+                    // output-column aliases as top-level sort keys, not inside larger expressions
+                    // such as CASE WHEN).
+                    //
+                    // We do NOT re-inline when the underlying expression (after stripping aliases)
+                    // is a plain Expr::Column (simple rename), an AggregateFunction, or a
+                    // WindowFunction — those cases either don't need inlining or are handled
+                    // separately by the aggregate/window unproject branches.
+                    //
+                    // When the inlined expression contains aggregate output column references
+                    // (e.g., `grouping(a) + grouping(b)` which in the projection is stored as
+                    // `col("grouping(a)") + col("grouping(b)")`), we also apply a best-effort
+                    // agg unprojection so those references resolve to their actual function-call
+                    // representations rather than emitting as quoted identifiers.
                     if let LogicalPlan::Projection(Projection { expr, schema, .. }) =
                         input
                         && let Ok(idx) = schema.index_of_column(&col)
-                        && let Some(Expr::ScalarFunction(scalar_fn)) = expr.get(idx)
+                        && let Some(proj_expr) = expr.get(idx)
                     {
-                        return Ok(Transformed::yes(Expr::ScalarFunction(
-                            scalar_fn.clone(),
-                        )));
+                        let unaliased = proj_expr.clone().unalias_nested().data;
+                        if !matches!(
+                            unaliased,
+                            Expr::Column(_)
+                                | Expr::AggregateFunction(_)
+                                | Expr::WindowFunction(_)
+                        ) {
+                            // If there is an aggregate in scope, resolve any aggregate output
+                            // column references inside the inlined expression. We use a
+                            // best-effort approach: columns not found in the aggregate schema
+                            // are left as-is rather than causing an error.
+                            let resolved = if let Some(agg) = agg {
+                                unaliased.transform(|e| {
+                                    if let Expr::Column(c) = &e {
+                                        if let Ok(Some(unprojected)) =
+                                            find_agg_expr(agg, c)
+                                        {
+                                            return Ok(Transformed::yes(
+                                                unprojected.clone(),
+                                            ));
+                                        }
+                                    }
+                                    Ok(Transformed::no(e))
+                                })?
+                                .data
+                            } else {
+                                unaliased
+                            };
+                            return Ok(Transformed::yes(resolved));
+                        }
                     }
 
                     Ok(Transformed::no(Expr::Column(col)))

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -168,8 +168,8 @@ pub(crate) fn find_window_nodes_within_select<'a>(
 pub(crate) fn unproject_unnest_expr(expr: Expr, unnest: &Unnest) -> Result<Expr> {
     expr.transform(|sub_expr| {
             if let Expr::Column(col_ref) = &sub_expr {
-                // Check if the column is among the columns to run unnest on. 
-                // Currently, only List/Array columns (defined in `list_type_columns`) are supported for unnesting. 
+                // Check if the column is among the columns to run unnest on.
+                // Currently, only List/Array columns (defined in `list_type_columns`) are supported for unnesting.
                 if unnest.list_type_columns.iter().any(|e| e.1.output_column.name == col_ref.name) {
                     if let Ok(idx) = unnest.schema.index_of_column(col_ref)
                         && let LogicalPlan::Projection(Projection { expr, .. }) = unnest.input.as_ref()
@@ -330,10 +330,8 @@ pub(crate) fn unproject_sort_expr(
                         )?));
                     }
 
-                    // If SELECT and ORDER BY contain the same expression (e.g., a scalar function
-                    // or any other non-trivial computed expression like BinaryExpr), the ORDER BY
-                    // expression will be replaced by a Column expression referencing the SELECT-list
-                    // alias. We need to transform it back to the actual expression so that it is
+                    // When an expression in the `ORDER BY` contains an alias from the `SELECT`
+                    // we need to transform it back to the actual expression so that it is
                     // valid SQL in all positions inside ORDER BY (PostgreSQL only allows bare
                     // output-column aliases as top-level sort keys, not inside larger expressions
                     // such as CASE WHEN).

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2152,10 +2152,99 @@ fn test_complex_order_by_with_grouping() -> Result<()> {
     }, {
         assert_snapshot!(
             sql,
-            @"SELECT j1.j1_id, j1.j1_string, (grouping(j1.j1_id) + grouping(j1.j1_string)) AS lochierarchy FROM j1 GROUP BY ROLLUP (j1.j1_id, j1.j1_string) ORDER BY lochierarchy DESC NULLS FIRST, CASE WHEN (lochierarchy = 0) THEN j1.j1_id END ASC NULLS LAST LIMIT 100"
+            @"SELECT j1.j1_id, j1.j1_string, (grouping(j1.j1_id) + grouping(j1.j1_string)) AS lochierarchy FROM j1 GROUP BY ROLLUP (j1.j1_id, j1.j1_string) ORDER BY (grouping(j1.j1_id) + grouping(j1.j1_string)) DESC NULLS FIRST, CASE WHEN ((grouping(j1.j1_id) + grouping(j1.j1_string)) = 0) THEN j1.j1_id END ASC NULLS LAST LIMIT 100"
         );
     });
 
+    Ok(())
+}
+
+/// Regression test: a computed (`BinaryExpr`) SELECT-list alias referenced
+/// inside an `ORDER BY` *expression* (e.g. `CASE WHEN`) must be unparsed as the
+/// underlying expression, not left as a bare alias column.
+///
+/// `unproject_sort_expr` previously only re-inlined `ScalarFunction` projection
+/// expressions; any other computed expression (here `id + age`) fell through and
+/// the alias leaked into the `ORDER BY`. This produces SQL that is invalid under
+/// the SQL standard's name-resolution rules for `ORDER BY`: a bare output-column
+/// alias is accepted as a top-level sort key, but when the alias appears inside a
+/// larger expression, identifiers are resolved against the `FROM` relations only —
+/// where the alias does not exist.
+///
+/// So the buggy output
+/// `... ORDER BY CASE WHEN (computed = 0) THEN t1.id END`
+/// is rejected by every standard-conforming engine, e.g.:
+///   - PostgreSQL: `ERROR: column "computed" does not exist` (SQLSTATE 42703)
+///   - DuckDB:     `Binder Error: Referenced column "computed" not found`
+///   - MySQL:      `ERROR 1054 (42S22): Unknown column 'computed' in 'order clause'`
+///
+/// This was the root cause of the `column "lochierarchy" does not exist` failures
+/// observed in federated TPC-DS queries (q36 / q70 / q86), where `lochierarchy` is
+/// a `grouping(a) + grouping(b)` alias used inside an `ORDER BY CASE WHEN`.
+///
+/// ```text
+///   t1
+///  ┌─────┬─────┐    ```sql
+///  │ id  │ i32 │      SELECT id + age AS computed, id
+///  ├─────┼─────┤      FROM t1
+///  │ age │ i32 │      ORDER BY CASE WHEN computed = 0 THEN id END
+///  └─────┴─────┘    ```
+///
+///  ── logical plan ───────────────────────────────────────────────────────────
+///   Sort: CASE WHEN computed = 0 THEN id END ASC NULLS FIRST
+///     Projection: (id + age) AS computed, id
+///       TableScan: t1
+///
+///  ── unparsed SQL, before the fix (BROKEN) ──────────────────────────────────
+///   SELECT (t1.id + t1.age) AS computed, t1.id
+///   FROM t1
+///   ORDER BY CASE WHEN (computed = 0) THEN t1.id END
+///                      ▲
+///                      └─ `computed` is a SELECT alias, not a column of t1;
+///                         inside an expression the engine resolves it against
+///                         FROM only → PostgreSQL: ERROR: column "computed"
+///                         does not exist (SQLSTATE 42703)
+///
+///  ── Unparsed SQL, after the fix (VALID) ────────────────────────────────────
+///   SELECT (t1.id + t1.age) AS computed, t1.id
+///   FROM t1
+///   ORDER BY CASE WHEN ((t1.id + t1.age) = 0) THEN t1.id END
+///                       ▲
+///                       └─ underlying expression inlined; resolves against t1
+///                          → valid on every standard-conforming engine
+/// ```
+#[test]
+fn test_order_by_with_computed_alias_inside_expr() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    // Build plan:  Sort(CASE WHEN computed = 0 THEN id END)
+    //                Projection((id + age) AS computed, id)
+    //                  TableScan(t1)
+    //
+    // `computed` is a BinaryExpr alias in the Projection.  The sort expression
+    // references it via col("computed") inside a CASE.  Without the fix the
+    // unparser emits `CASE WHEN (computed = 0) THEN t1.id END` which is invalid
+    // SQL in PostgreSQL; with the fix it emits
+    // `CASE WHEN ((t1.id + t1.age) = 0) THEN t1.id END`.
+    let computed_alias = (col("id") + col("age")).alias("computed");
+    let case_expr = datafusion_expr::when(col("computed").eq(lit(0i32)), col("id"))
+        .end()
+        .unwrap();
+
+    let plan = table_scan(Some("t1"), &schema, None)?
+        .project(vec![computed_alias, col("id")])?
+        .sort(vec![case_expr.sort(true, true)])?
+        .build()?;
+
+    let sql = plan_to_sql(&plan)?;
+    // The CASE condition must reference the inlined expression, not the bare alias.
+    assert_snapshot!(
+        sql,
+        @"SELECT (t1.id + t1.age) AS computed, t1.id FROM t1 ORDER BY CASE WHEN ((t1.id + t1.age) = 0) THEN t1.id END ASC NULLS FIRST"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Problem
During Datafusion unparsing, only `ScalarFunction` projections are reinlined for `ORDER BY` expression. Any other computed expression — e.g. a `BinaryExpr` such as `grouping(a) + grouping(b)` — fell through, leaving a bare SELECT-list alias inside the `ORDER BY`.

A bare alias is a valid top-level sort key, but when it appears **inside a larger expression** (e.g. `CASE WHEN`), standard-conforming engines resolve identifiers against the `FROM` relations only and reject it:

- PostgreSQL: `ERROR: column "computed" does not exist` (SQLSTATE 42703)
- DuckDB: `Binder Error: Referenced column "computed" not found`
- MySQL: `ERROR 1054 (42S22): Unknown column 'computed' in 'order clause'`

### Before (broken)
```sql
SELECT (t1.id + t1.age) AS computed, t1.id
FROM t1
ORDER BY CASE WHEN (computed = 0) THEN t1.id END   -- alias leaks into expression
```

### After (valid)
```sql
SELECT (t1.id + t1.age) AS computed, t1.id
FROM t1
ORDER BY CASE WHEN ((t1.id + t1.age) = 0) THEN t1.id END   -- inlined
```

### Fix

Generalize the re-inlining in `unproject_sort_expr` to **any non-trivial projection expression** (excluding plain `Column` renames, `AggregateFunction`, and `WindowFunction`).

## Why this surfaced in the DataFusion 54 upgrade

Changes to `OptimizeProjections` in DF54 changed the produced `LogicalPlan` and caused this issue.

**DF53**: Projection → Sort → Projection → WindowAggr
**DF54**: Sort → Projection → WindowAggr

If a projection is **already open** above the `Sort` (`already_projected() == true`), the unparser wraps the whole thing in a `derived_sort` subquery: `SELECT ... FROM (SELECT ... AS computed ... ORDER BY ...) AS derived_sort`. Within this CTE, `computed` is a real derived-table column. 

## Tests

- New regression test `test_order_by_with_computed_alias_inside_expr`. Verified to fail without the fix.