### PR TITLE
fix(physical-optimizer): keep coalesce required by a SinglePartition child slot in parallelize_sorts

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_sorting.rs
@@ -1594,6 +1594,69 @@ async fn test_multilayer_coalesce_partitions() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_parallelize_sorts_preserves_collect_left_coalesce() -> Result<()> {
+    use datafusion_common::NullEquality;
+    use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode};
+
+    let schema = create_test_schema()?;
+    // Build side: its `CoalescePartitionsExec` satisfies the CollectLeft
+    // join's SinglePartition requirement and must not be removed.
+    let left =
+        coalesce_partitions_exec(repartition_exec(parquet_exec(schema.clone())));
+    // Probe side: contains a `CoalescePartitionsExec` reachable through
+    // operators that don't require a single partition, so the coalesce link
+    // propagates through the join to the coalesce at the top of the plan.
+    let right = filter_exec(
+        Arc::new(NotExpr::new(col("non_nullable_col", schema.as_ref())?)),
+        coalesce_partitions_exec(repartition_exec(parquet_exec(schema.clone()))),
+    );
+    let join = Arc::new(HashJoinExec::try_new(
+        left,
+        right,
+        vec![(
+            col("nullable_col", &schema)?,
+            col("nullable_col", &schema)?,
+        )],
+        None,
+        &JoinType::LeftAnti,
+        None,
+        PartitionMode::CollectLeft,
+        NullEquality::NullEqualsNothing,
+        false,
+    )?);
+    let physical_plan = coalesce_partitions_exec(join);
+
+    // `parallelize_sorts` may remove the probe-side coalesce, but the
+    // build-side coalesce satisfies the join's SinglePartition requirement
+    // and must survive.
+    let test = EnforceSortingTest::new(physical_plan).with_repartition_sorts(true);
+    assert_snapshot!(test.run(), @r"
+    Input Plan:
+    CoalescePartitionsExec
+      HashJoinExec: mode=CollectLeft, join_type=LeftAnti, accumulator=MinMaxLeftAccumulator, on=[(nullable_col@0, nullable_col@0)]
+        CoalescePartitionsExec
+          RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[x]]}, projection=[nullable_col, non_nullable_col], file_type=parquet
+        FilterExec: NOT non_nullable_col@1
+          CoalescePartitionsExec
+            RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+              DataSourceExec: file_groups={1 group: [[x]]}, projection=[nullable_col, non_nullable_col], file_type=parquet
+
+    Optimized Plan:
+    CoalescePartitionsExec
+      HashJoinExec: mode=CollectLeft, join_type=LeftAnti, accumulator=MinMaxLeftAccumulator, on=[(nullable_col@0, nullable_col@0)]
+        CoalescePartitionsExec
+          RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[x]]}, projection=[nullable_col, non_nullable_col], file_type=parquet
+        FilterExec: NOT non_nullable_col@1
+          RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[x]]}, projection=[nullable_col, non_nullable_col], file_type=parquet
+    ");
+
+    Ok(())
+}
+
 fn create_lost_ordering_plan(source_unbounded: bool) -> Result<Arc<dyn ExecutionPlan>> {
     let schema = create_test_schema3()?;
     let sort_exprs = [sort_expr("a", &schema)];

--- a/datafusion/physical-optimizer/src/enforce_sorting/mod.rs
+++ b/datafusion/physical-optimizer/src/enforce_sorting/mod.rs
@@ -411,7 +411,7 @@ pub fn parallelize_sorts(
         // executors don't require single partition), then we can replace
         // the `CoalescePartitionsExec` + `SortExec` cascade with a `SortExec`
         // + `SortPreservingMergeExec` cascade to parallelize sorting.
-        requirements = remove_bottleneck_in_subplan(requirements)?;
+        requirements = remove_bottleneck_in_subplan(requirements, true)?;
         // We also need to remove the self node since `remove_corresponding_coalesce_in_sub_plan`
         // deals with the children and their children and so on.
         requirements = requirements.children.swap_remove(0);
@@ -431,7 +431,7 @@ pub fn parallelize_sorts(
         let fetch = requirements.plan.fetch();
         // There is an unnecessary `CoalescePartitionsExec` in the plan.
         // This will handle the recursive `CoalescePartitionsExec` plans.
-        requirements = remove_bottleneck_in_subplan(requirements)?;
+        requirements = remove_bottleneck_in_subplan(requirements, true)?;
         // For the removal of self node which is also a `CoalescePartitionsExec`.
         requirements = requirements.children.swap_remove(0);
 
@@ -675,12 +675,22 @@ fn adjust_window_sort_removal(
 /// the plan in `node`. After the removal of such `CoalescePartitionsExec`s from
 /// the plan, some of the remaining `RepartitionExec`s might become unnecessary.
 /// Removes such `RepartitionExec`s from the plan as well.
+///
+/// A `CoalescePartitionsExec` that satisfies a `SinglePartition` requirement of
+/// its parent (e.g. the build side of a CollectLeft [`HashJoinExec`]) is *not*
+/// avoidable and is left in place. `is_entry` exempts the node this removal
+/// starts from: its caller in [`parallelize_sorts`] restores single-partition
+/// output by adding a `SortPreservingMergeExec` above it.
 fn remove_bottleneck_in_subplan(
     mut requirements: PlanWithCorrespondingCoalescePartitions,
+    is_entry: bool,
 ) -> Result<PlanWithCorrespondingCoalescePartitions> {
     let plan = &requirements.plan;
+    let required_dist = plan.required_input_distribution();
     let children = &mut requirements.children;
-    if is_coalesce_partitions(&children[0].plan) {
+    let coalesce_removable =
+        is_entry || !matches!(required_dist[0], Distribution::SinglePartition);
+    if coalesce_removable && is_coalesce_partitions(&children[0].plan) {
         // We can safely use the 0th index since we have a `CoalescePartitionsExec`.
         let mut new_child_node = children[0].children.swap_remove(0);
         while new_child_node.plan.output_partitioning() == plan.output_partitioning()
@@ -694,9 +704,15 @@ fn remove_bottleneck_in_subplan(
         requirements.children = requirements
             .children
             .into_iter()
-            .map(|node| {
-                if node.data {
-                    remove_bottleneck_in_subplan(node)
+            .zip(required_dist)
+            .map(|(node, dist)| {
+                // Follow the coalesce links, but never into a child that must
+                // stay single-partition: the coalesce (and anything below it)
+                // satisfying that requirement must be preserved. The entry
+                // node is exempt for the same reason as above.
+                let single = !is_entry && matches!(dist, Distribution::SinglePartition);
+                if node.data && !single {
+                    remove_bottleneck_in_subplan(node, false)
                 } else {
                     Ok(node)
                 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A — found via TPC-H q16 failures in spiceai benchmarks. The buggy code is identical to upstream apache/datafusion, so this is also a candidate for an upstream PR.

## Rationale for this change

### The optimization this bug lives in

`EnforceSorting`'s `parallelize_sorts` subrule rewrites

```text
SortExec                                 SortPreservingMergeExec
  CoalescePartitionsExec        ──►        SortExec (per-partition)
    RepartitionExec(n)                       RepartitionExec(n)
```

so that sorting happens per-partition in parallel instead of on one coalesced stream. To do this it must *delete* the `CoalescePartitionsExec` — that coalesce is the parallelism bottleneck being optimized away.

The sort and the coalesce are not always adjacent, so a helper (`update_coalesce_ctx_children`) walks the plan bottom-up marking each node with a flag: *"a coalesce is reachable below me through operators that don't require a single partition."* The link deliberately breaks at any child slot whose parent requires `Distribution::SinglePartition`, because such a coalesce is load-bearing, not a removable bottleneck. When the link reaches a sort (or a redundant coalesce), `remove_bottleneck_in_subplan` recurses down and deletes the linked coalesces.

### The bug

`remove_bottleneck_in_subplan` contained:

```rust
if is_coalesce_partitions(&children[0].plan) {
    // remove it, unconditionally
```

It only ever inspects **child 0**, and removes it without re-checking the two things the link-builder was careful about: whether child 0 is actually part of the link, and whether the current node *requires* `SinglePartition` on child 0.

For single-child chains (the shapes the rewrite was designed for) this is fine. It breaks on a **join** — a two-child node where the link can arrive through one child while the *other* child holds a required coalesce. TPC-H q16 produces exactly that shape when the `NOT IN (SELECT … FROM supplier …)` subquery side is served by a single-partition scan (any wrapper that coalesces internally and reports 1 output partition):

```text
CoalescePartitionsExec                    ← removal starts here (top of the linked cascade)
  ...aggregates / repartitions...         ← link flows up through these (no SinglePartition slots)
    HashJoinExec CollectLeft LeftAnti     ← requires SinglePartition on child 0
      CoalescePartitionsExec  ★           ← child 0: REQUIRED — inserted by EnforceDistribution
        HashJoinExec Partitioned          ← output partitioning Hash(…, n)
      FilterExec ...                      ← child 1: the link came through HERE (Unspecified)
        <single-partition scan wrapper>
          CoalescePartitionsExec  ☆       ← the coalesce the link actually points at
```

`update_coalesce_ctx_children` correctly refuses to propagate the link through the join's left slot (`SinglePartition`) but propagates it through the right slot (`Unspecified`). The removal recursion then walks down that valid right-side trail, arrives at the join, looks at child 0, sees a coalesce, and deletes **★** — the wrong one. (It never reaches ☆: the child-0 branch returns without recursing.)

The join's build side is now `Hash(…, n)`-partitioned with nothing restoring a single partition, and `SanityCheckPlan` rejects the plan:

```text
SanityCheckPlan: HashJoinExec: mode=CollectLeft, join_type=LeftAnti, ...
does not satisfy distribution requirements: SinglePartition
Child-0 output partitioning: Hash([p_partkey@2], n)
```

Note the layering: `EnforceDistribution` had already done everything right — it inserted ★ precisely to satisfy the CollectLeft join. `EnforceSorting`, running later, undid it.

## What changes are included in this PR?

`remove_bottleneck_in_subplan` now obeys the same rule as the link-builder:

- the child-0 coalesce is only removed when the current node does **not** require `SinglePartition` on that slot;
- recursion only descends into child slots that do not require `SinglePartition`.

One deliberate exemption (`is_entry`): the node the removal *starts* from is exempt from both gates. When `parallelize_sorts` begins at a `SortExec`, that sort itself requires `SinglePartition` on its child — but deleting that coalesce is the whole optimization, and it is safe because the caller immediately places a `SortPreservingMergeExec` (or a fresh `CoalescePartitionsExec`, in the redundant-coalesce branch) above, restoring single-partition output by construction. Without the exemption, legitimate `Sort ← Filter ← Coalesce` parallelization regresses (covered by the existing `test_multilayer_coalesce_partitions`).

On the q16 plan the fixed pass keeps ★ (required) and instead removes ☆ via the actual link path — harmless there, since every operator on that path accepts any partitioning.

## Are these changes tested?

- New regression test `test_parallelize_sorts_preserves_collect_left_coalesce` builds the minimal failing shape (CollectLeft LeftAnti join; coalesce-over-repartition build side; filter-over-coalesce probe side; coalesce on top). It fails on the base branch (★ removed, ☆ kept) and passes with the fix (★ kept, ☆ removed).
- The `physical_optimizer::enforce_sorting` and `enforce_distribution` suites show the same set of pre-existing failures as the base branch — no new regressions.
- End-to-end: a TPC-H q16 partial-federation regression test in datafusion-federation goes red → green with this change.

## Are there any user-facing changes?

No API changes. Plans that previously failed with the `SanityCheckPlan` distribution violation above now execute; some plans retain a probe-side coalesce removal they effectively already had.
