### PR TITLE
fix(unparser): emit SELECT 1 for empty Projection nodes (fixes spiceai/spiceai#10704)

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -293,6 +293,22 @@ impl Unparser<'_> {
     ) -> Result<()> {
         let mut exprs = p.expr.clone();
 
+        // A projection with no output expressions (e.g. `count(*)` over a view
+        // that prunes every column, producing `Projection: <empty> -> TableScan`)
+        // must not be unparsed as an empty `SELECT` list: dialects such as DuckDB
+        // reject `SELECT FROM t` with a parser error. Mirror the bare `TableScan`
+        // handling and fall back to a dummy `SELECT 1` for dialects that do not
+        // support an empty select list.
+        if exprs.is_empty() {
+            let items = self
+                .empty_projection_fallback()
+                .iter()
+                .map(|e| self.select_item_to_sql(e))
+                .collect::<Result<Vec<_>>>()?;
+            select.projection(items);
+            return Ok(());
+        }
+
         // If an Unnest node is found within the select, find and unproject the unnest column
         let flatten_alias = select.current_flatten_alias();
         if let Some(unnest) = find_unnest_node_within_select(plan) {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1337,6 +1337,61 @@ fn table_scan_with_empty_projection_and_none_projection_helper(
         .unwrap()
 }
 
+// An empty `Projection` node (0 output expressions) arises when, for example,
+// `count(*)` is planned over a view/subquery whose columns are all pruned,
+// yielding `Projection: <empty> -> TableScan`. It must not be unparsed as an
+// empty `SELECT` list for dialects that reject `SELECT FROM t` (e.g. DuckDB):
+// fall back to `SELECT 1` just like the bare empty-projection `TableScan`.
+fn empty_projection_over_table_helper(table_name: &str, table_schema: Schema) -> LogicalPlan {
+    project(
+        table_scan(Some(table_name), &table_schema, None)
+            .unwrap()
+            .build()
+            .unwrap(),
+        Vec::<Expr>::new(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_empty_projection_node_in_plan_to_sql_default_dialect() {
+    let plan = empty_projection_over_table_helper("table", test_schema());
+    let unparser = Unparser::new(&UnparserDefaultDialect {});
+    let sql = unparser.plan_to_sql(&plan).unwrap();
+    assert_snapshot!(
+        sql,
+        @r#"SELECT 1 FROM "table""#
+    );
+}
+
+#[test]
+fn test_empty_projection_node_in_plan_to_sql_postgres() {
+    let plan = empty_projection_over_table_helper("table", test_schema());
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan).unwrap();
+    assert_snapshot!(
+        sql,
+        @r#"SELECT FROM "table""#
+    );
+}
+
+#[test]
+fn test_empty_projection_under_subquery_alias_default_dialect() {
+    let plan = subquery_alias(
+        empty_projection_over_table_helper("table", test_schema()),
+        "v",
+    )
+    .unwrap();
+    let unparser = Unparser::new(&UnparserDefaultDialect {});
+    let sql = unparser.plan_to_sql(&plan).unwrap();
+    // The inner empty projection (the view body) is what previously unparsed to
+    // the invalid `SELECT FROM "table"`; it now renders as `SELECT 1 FROM "table"`.
+    assert_snapshot!(
+        sql,
+        @r#"SELECT * FROM (SELECT 1 FROM "table") AS v"#
+    );
+}
+
 #[test]
 fn test_pretty_roundtrip() -> Result<()> {
     let schema = Schema::new(vec![


### PR DESCRIPTION
## Problem

`SELECT count(*)` over a **view/subquery whose columns are all pruned** unparses to invalid SQL and fails against dialects that reject an empty select list. Reproduced in Spice.ai against a DuckDB-accelerated table:

```
Query Error: Parser Error: SELECT clause without selection list
```

The federated plan is:

```
Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]
  SubqueryAlias: v
    Projection:                              <- empty projection (0 exprs)
      TableScan: t projection=[]
```

which unparses to the broken inner `... FROM (SELECT FROM "t" AS "v") ...`.

## Root cause

DataFusion already handles a bare **`TableScan` with `projection=Some([])`** via `empty_projection_fallback()` (emits `SELECT 1` when `dialect.supports_empty_select_list()` is false), so `count(*)` directly over a table works. But an explicit **empty `Projection` node** (0 output expressions, produced by projection pushdown over a view/subquery) is handled by `reconstruct_select_statement`, which builds the SELECT list straight from `p.expr` — an empty list — and never applies the fallback. The result is an empty `SELECT ` for every dialect.

## Fix

In `reconstruct_select_statement`, when the projection expression list is empty, reuse `empty_projection_fallback()` for the select items — mirroring the `TableScan` handling. Dialects with `supports_empty_select_list() == false` (e.g. DuckDB, the default dialect) now emit `SELECT 1`; dialects that allow it (e.g. Postgres) keep the empty list.

## Tests

Adds three unparser tests in `plan_to_sql.rs`:
- empty `Projection` node, default dialect -> `SELECT 1 FROM "table"`
- empty `Projection` node, Postgres dialect -> `SELECT FROM "table"` (unchanged)
- empty `Projection` under a `SubqueryAlias`, default dialect -> `SELECT * FROM (SELECT 1 FROM "table") AS v` (the view shape from the bug)

Verified locally: `cargo test -p datafusion-sql --test sql_integration -- plan_to_sql::test_empty_projection` — 3 passed. (Some unrelated `plan_to_sql` snapshots are already red on `spiceai-54` before this change; this PR neither fixes nor worsens them.)

## Downstream

Fixes the root cause of spiceai/spiceai#10704. Requires a follow-up `datafusion` rev bump in `spiceai/spiceai` once this lands on `spiceai-54` to close that issue.