### PR TITLE
fix(unparser): keep bare output-column alias as top-level ORDER BY key

### DIFF
--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -322,12 +322,10 @@ pub(crate) fn unproject_sort_expr(
     // PostgreSQL and similar dialects reject output-column aliases inside
     // expressions. That path is handled by the recursive `transform` below,
     // which is only reached when `sort_expr.expr` is not a bare column.
-    if let Expr::Column(col) = &sort_expr.expr
-        && col.relation.is_none()
+    if let Expr::Column(Column{relation: None, name, .. }) = &sort_expr.expr
         && let LogicalPlan::Projection(Projection { expr, schema, .. }) = input
-        && let Ok(idx) = schema.index_of_column(col)
-        && let Some(proj_expr) = expr.get(idx)
-        && matches!(proj_expr, Expr::Alias(_))
+        && let Some(idx) = schema.index_of_column_by_name(None, name)
+        && let Some(Expr::Alias(_)) = expr.get(idx)
     {
         return Ok(sort_expr);
     }

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -336,21 +336,22 @@ pub(crate) fn unproject_sort_expr(
             match sub_expr {
                 // Remove alias if present, because ORDER BY cannot use aliases
                 Expr::Alias(alias) => Ok(Transformed::yes(*alias.expr)),
-                Expr::Column(col) => {
-                    if col.relation.is_some() {
-                        return Ok(Transformed::no(Expr::Column(col)));
-                    }
-
-                    // In case of aggregation there could be columns containing aggregation functions we need to unproject
-                    if let Some(agg) = agg
-                        && agg.schema.is_column_from_schema(&col)
-                    {
+                // Qualified columns reference FROM relations directly; only
+                // unqualified columns can name aggregate/projection outputs
+                // that need unprojecting below.
+                Expr::Column(Column { relation: Some(_), .. }) => {
+                    Ok(Transformed::no(sub_expr))
+                }
+                // In case of aggregation there could be columns containing aggregation functions we need to unproject
+                Expr::Column(col) if let Some(agg) = agg
+                    && agg.schema.is_column_from_schema(&col) => {
                         return Ok(Transformed::yes(unproject_agg_exprs(
                             Expr::Column(col),
                             agg,
                             None,
                         )?));
                     }
+                Expr::Column(col) => {
 
                     // When an expression in the `ORDER BY` contains an alias from the `SELECT`
                     // we need to transform it back to the actual expression so that it is

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -309,6 +309,29 @@ pub(crate) fn unproject_sort_expr(
     windows: Option<&[&Window]>,
     input: &LogicalPlan,
 ) -> Result<SortExpr> {
+    // When the *entire* sort key is a bare unqualified column reference that
+    // maps to an explicitly aliased projection expression, the column name IS
+    // the output-column alias — a valid top-level ORDER BY key in all dialects.
+    // Return it as-is; inlining the full aliased expression (which may be a
+    // complex window or arithmetic formula) is both unnecessary and harmful:
+    // remote engines that re-unparse the SQL can produce dangling quoted
+    // identifiers for inner aggregate/window references.
+    //
+    // Inlining IS still needed when the same alias appears *nested* inside a
+    // larger sort expression (e.g. `CASE WHEN alias = 0 THEN ...`), because
+    // PostgreSQL and similar dialects reject output-column aliases inside
+    // expressions. That path is handled by the recursive `transform` below,
+    // which is only reached when `sort_expr.expr` is not a bare column.
+    if let Expr::Column(col) = &sort_expr.expr
+        && col.relation.is_none()
+        && let LogicalPlan::Projection(Projection { expr, schema, .. }) = input
+        && let Ok(idx) = schema.index_of_column(col)
+        && let Some(proj_expr) = expr.get(idx)
+        && matches!(proj_expr, Expr::Alias(_))
+    {
+        return Ok(sort_expr);
+    }
+
     sort_expr.expr = sort_expr
         .expr
         .transform(|sub_expr| {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2438,23 +2438,32 @@ fn test_order_by_window_output_alias_nested_inside_expr() -> Result<()> {
         .build()?;
 
     let sql_str = plan_to_sql(&plan)?.to_string();
-    // The inlined expression must contain the window function...
+    // Scope the ORDER BY assertions to the clause itself: the SELECT list also
+    // inlines the window expression, so whole-string checks for OVER / the
+    // alias would pass regardless of what the ORDER BY contains.
+    let order_by = sql_str
+        .split_once("ORDER BY")
+        .expect("SQL should contain ORDER BY")
+        .1;
+    // The sort key must inline the window function expression...
     assert!(
-        sql_str.to_uppercase().contains("OVER"),
+        order_by.to_uppercase().contains("OVER"),
         "ORDER BY should contain an inlined OVER clause, got: {sql_str}"
     );
-    // ...and must not leak the alias or internal identifiers.
+    // ...with no reference to the SELECT-list alias (engines resolve
+    // identifiers inside ORDER BY expressions against FROM relations only)...
     assert!(
-        !sql_str.contains("ORDER BY CASE WHEN (revenueratio"),
+        !order_by.contains("revenueratio"),
         "ORDER BY leaked the bare alias inside an expression, got: {sql_str}"
     );
+    // ...and no internal identifiers anywhere.
     assert!(
         !sql_str.contains(&format!("\"{window_col_name}\"")),
-        "ORDER BY leaked the window output identifier, got: {sql_str}"
+        "leaked the window output identifier, got: {sql_str}"
     );
     assert!(
         !sql_str.contains(&format!("\"{agg_col}\"")),
-        "ORDER BY leaked the nested aggregate identifier, got: {sql_str}"
+        "leaked the nested aggregate identifier, got: {sql_str}"
     );
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2207,7 +2207,7 @@ fn test_complex_order_by_with_grouping() -> Result<()> {
     }, {
         assert_snapshot!(
             sql,
-            @"SELECT j1.j1_id, j1.j1_string, lochierarchy FROM (SELECT j1.j1_id, j1.j1_string, (grouping(j1.j1_id) + grouping(j1.j1_string)) AS lochierarchy, grouping(j1.j1_string), grouping(j1.j1_id) FROM j1 GROUP BY ROLLUP (j1.j1_id, j1.j1_string) ORDER BY lochierarchy DESC NULLS FIRST, CASE WHEN ((grouping(j1.j1_id) + grouping(j1.j1_string)) = 0) THEN j1.j1_id END ASC NULLS LAST) LIMIT 100"
+            @"SELECT j1.j1_id, j1.j1_string, (grouping(j1.j1_id) + grouping(j1.j1_string)) AS lochierarchy FROM j1 GROUP BY ROLLUP (j1.j1_id, j1.j1_string) ORDER BY lochierarchy DESC NULLS FIRST, CASE WHEN ((grouping(j1.j1_id) + grouping(j1.j1_string)) = 0) THEN j1.j1_id END ASC NULLS LAST LIMIT 100"
         );
     });
 
@@ -2303,36 +2303,23 @@ fn test_order_by_with_computed_alias_inside_expr() -> Result<()> {
     Ok(())
 }
 
-/// Regression test: a BinaryExpr SELECT-list alias that references a window function
-/// output column must be fully inlined in ORDER BY, resolving the window column to
-/// the actual window function expression rather than emitting DataFusion's internal
-/// column name as a quoted identifier.
+/// Regression test: a sort key that is exactly a SELECT-list alias (here for a
+/// BinaryExpr referencing a window function output) must be emitted as the bare
+/// alias, not inlined.
 ///
-/// Pattern from TPC-DS q12:
+/// Pattern from TPC-DS q12/q20/q98:
 ///   SELECT ..., sum(ws) * 100 / sum(sum(ws)) OVER (PARTITION BY i_class ...) AS revenueratio
 ///   FROM ...
 ///   ORDER BY revenueratio
 ///
-/// Without the fix, `revenueratio` inlines to:
+/// A bare output-column alias is a valid top-level ORDER BY key in every
+/// dialect, and inlining the aliased expression is harmful: engines that
+/// re-plan and re-unparse the received SQL (e.g. a federated remote) can leak
+/// the window's internal schema name as a quoted identifier, e.g.
 ///   ((sum(ws) * 100) / "sum(sum(ws_ext_sales_price)) PARTITION BY [i_class] ...")
-/// where the window result becomes a quoted column name that PostgreSQL rejects.
-///
-/// With the fix, it inlines to the full window function expression.
+/// which the downstream engine rejects (PostgreSQL 42703 / DuckDB Binder Error).
 #[test]
 fn test_order_by_with_binary_expr_referencing_window_output() -> Result<()> {
-    // Mirrors the TPC-DS q12 pattern:
-    //   SELECT ..., sum(ws) * 100 / sum(sum(ws)) OVER (PARTITION BY class) AS revenueratio
-    //   FROM ...
-    //   GROUP BY class, ...
-    //   ORDER BY revenueratio
-    //
-    // After GROUP BY, sum(sales_price) becomes a column named "sum(t.sales_price)".
-    // The window function takes that aggregated column as its arg.
-    // The revenueratio BinaryExpr alias is then the direct sort key.
-    //
-    // Without the fix, the window output column is emitted as a quoted identifier
-    // (DataFusion's internal name), which PostgreSQL rejects with SQLSTATE 42703.
-    // With the fix, the window function expression is fully inlined.
     let schema = Schema::new(vec![
         Field::new("class", DataType::Utf8, false),
         Field::new("sales_price", DataType::Float64, true),
@@ -2366,9 +2353,9 @@ fn test_order_by_with_binary_expr_referencing_window_output() -> Result<()> {
     let window_col_name = plan.schema().fields().last().unwrap().name().clone();
 
     // revenueratio = sum(sales_price) * 100 / (sum(sum(sales_price)) OVER (...))
-    let revenueratio =
-        ((col(agg_col.clone()) * lit(100i64)) / col(window_col_name.clone()))
-            .alias("revenueratio");
+    let revenueratio = ((col(agg_col.clone()) * lit(100i64))
+        / col(window_col_name.clone()))
+    .alias("revenueratio");
 
     let plan = LogicalPlanBuilder::from(plan)
         .project(vec![col("class"), revenueratio])?
@@ -2376,9 +2363,91 @@ fn test_order_by_with_binary_expr_referencing_window_output() -> Result<()> {
         .build()?;
 
     let sql_str = plan_to_sql(&plan)?.to_string();
-    // ORDER BY must inline the window expression, leaving neither the window
-    // output column nor its nested aggregate argument as a quoted DataFusion
-    // internal identifier (both would be rejected by PostgreSQL as 42703).
+    // The sort key is exactly the projection alias, so ORDER BY must keep the
+    // bare alias rather than inlining the window/aggregate expression.
+    assert!(
+        sql_str.ends_with("ORDER BY revenueratio ASC NULLS FIRST"),
+        "ORDER BY should be the bare output-column alias, got: {sql_str}"
+    );
+    // Neither the window output column nor its nested aggregate argument may
+    // appear anywhere as a quoted DataFusion internal identifier (both would
+    // be rejected by PostgreSQL as 42703).
+    assert!(
+        !sql_str.contains(&format!("\"{window_col_name}\"")),
+        "leaked the window output identifier, got: {sql_str}"
+    );
+    assert!(
+        !sql_str.contains(&format!("\"{agg_col}\"")),
+        "leaked the nested aggregate identifier, got: {sql_str}"
+    );
+    Ok(())
+}
+
+/// Companion to [`test_order_by_with_binary_expr_referencing_window_output`]:
+/// when the same window-referencing alias appears *nested* inside a larger
+/// ORDER BY expression, keeping the bare alias is not an option (engines
+/// resolve identifiers inside expressions against the FROM relations only), so
+/// the unparser must inline the aliased expression — resolving the window
+/// output column to its full OVER expression and the aggregate-output column
+/// nested in the window's argument to the aggregate function call, leaving
+/// neither as a quoted DataFusion internal identifier.
+#[test]
+fn test_order_by_window_output_alias_nested_inside_expr() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("class", DataType::Utf8, false),
+        Field::new("sales_price", DataType::Float64, true),
+    ]);
+
+    let plan = table_scan(Some("t"), &schema, None)?
+        .aggregate(vec![col("class")], vec![sum(col("sales_price"))])?
+        .build()?;
+    let agg_col = plan.schema().fields().last().unwrap().name().clone();
+
+    // Build: sum(<agg output>) OVER (PARTITION BY class)
+    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
+        fun: WindowFunctionDefinition::AggregateUDF(sum_udaf()),
+        params: WindowFunctionParams {
+            args: vec![col(agg_col.clone())],
+            partition_by: vec![col("class")],
+            order_by: vec![],
+            window_frame: WindowFrame::new(None),
+            null_treatment: None,
+            distinct: false,
+            filter: None,
+        },
+    }));
+    let plan = LogicalPlanBuilder::from(plan)
+        .window(vec![window_expr])?
+        .build()?;
+    let window_col_name = plan.schema().fields().last().unwrap().name().clone();
+
+    let revenueratio = ((col(agg_col.clone()) * lit(100i64))
+        / col(window_col_name.clone()))
+    .alias("revenueratio");
+
+    // Sort key: CASE WHEN revenueratio = 0 THEN class END — the alias is
+    // nested inside a larger expression, so it must be inlined.
+    let case_expr =
+        datafusion_expr::when(col("revenueratio").eq(lit(0i64)), col("class"))
+            .end()
+            .unwrap();
+
+    let plan = LogicalPlanBuilder::from(plan)
+        .project(vec![col("class"), revenueratio])?
+        .sort(vec![case_expr.sort(true, true)])?
+        .build()?;
+
+    let sql_str = plan_to_sql(&plan)?.to_string();
+    // The inlined expression must contain the window function...
+    assert!(
+        sql_str.to_uppercase().contains("OVER"),
+        "ORDER BY should contain an inlined OVER clause, got: {sql_str}"
+    );
+    // ...and must not leak the alias or internal identifiers.
+    assert!(
+        !sql_str.contains("ORDER BY CASE WHEN (revenueratio"),
+        "ORDER BY leaked the bare alias inside an expression, got: {sql_str}"
+    );
     assert!(
         !sql_str.contains(&format!("\"{window_col_name}\"")),
         "ORDER BY leaked the window output identifier, got: {sql_str}"
@@ -2386,11 +2455,6 @@ fn test_order_by_with_binary_expr_referencing_window_output() -> Result<()> {
     assert!(
         !sql_str.contains(&format!("\"{agg_col}\"")),
         "ORDER BY leaked the nested aggregate identifier, got: {sql_str}"
-    );
-    // ORDER BY must contain the inlined window function expression.
-    assert!(
-        sql_str.to_uppercase().contains("OVER"),
-        "ORDER BY should contain an inlined OVER clause, got: {sql_str}"
     );
     Ok(())
 }
@@ -4201,4 +4265,3 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
     );
     Ok(())
 }
-


### PR DESCRIPTION
## Which issue does this PR close?

- N/A — regression caught by the spicecloud-federated TPC-DS benchmark suite (q12, q20, q98).

## Rationale for this change

The ORDER BY alias inlining introduced in 1af54a07b is over-eager: it also inlines sort keys that are a *bare, top-level* reference to an aliased SELECT-list expression (e.g. `ORDER BY revenueratio`), rewriting them to the full expression, including window functions:

```sql
ORDER BY ((sum("ws_ext_sales_price") * 100) / sum(sum("ws_ext_sales_price")) OVER (PARTITION BY "i_class" ...)) ASC
```

A bare output-column alias is a valid top-level ORDER BY key in every dialect, so the inlining is unnecessary there — and harmful in federated setups: a remote engine that re-plans and re-unparses the received SQL can leak the window's internal schema name as a quoted identifier, which its downstream engine rejects:

```
Binder Error: Referenced column "sum(sum(tpcds.web_sales.ws_ext_sales_price)) PARTITION BY [tpcds.item.i_class] ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING" not found in FROM clause!
```

This failed TPC-DS q12/q20/q98 (the three structurally identical revenue-ratio queries) on spicecloud-federated.

## What changes are included in this PR?

An early return in `unproject_sort_expr`: when the entire sort key is an unqualified column that resolves to an explicitly `Alias`-ed projection expression of the input `Projection`, keep the bare alias. Every guard falls through to the previous behavior, so inlining still applies where it is required:

- the alias appears nested inside a larger sort expression (the `ORDER BY CASE WHEN lochierarchy ...` pattern of q36/q70/q86, fixed by 1af54a07b), and
- the sort key is an unaliased DataFusion-internal name that cannot be referenced remotely (fixed by db1d14222).

Note: this diverges slightly from upstream, which inlines top-level aliased ScalarFunction sort keys; keeping the alias is valid SQL and more faithful to the original query.

Side benefit: the q36-style grouping query no longer needs a derived-table wrapping with extra projected `grouping()` columns (see updated `test_complex_order_by_with_grouping` snapshot).

## Are these changes tested?

- `test_order_by_with_binary_expr_referencing_window_output` repurposed: asserts the bare alias is kept and no internal identifiers leak.
- New `test_order_by_window_output_alias_nested_inside_expr`: same plan with the alias nested in `ORDER BY CASE WHEN ...` — asserts the window expression is inlined and its nested aggregate argument resolved, preserving db1d14222's regression coverage.
- `test_order_by_with_computed_alias_inside_expr` (1af54a07b's regression test) passes unchanged.
- Full `datafusion-sql` `sql_integration` suite diffed against the branch baseline: zero new failures.

## Are there any user-facing changes?

Unparsed SQL for top-level aliased sort keys now emits the alias (`ORDER BY revenueratio`) instead of the inlined expression. No API changes.