### PR TITLE
fix(functions-nested): array_any_value returns NULL for empty list elements

### DIFF
--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -1062,9 +1062,19 @@ where
 
     for (row_index, offset_window) in array.offsets().windows(2).enumerate() {
         let start = offset_window[0];
+        let end = offset_window[1];
 
-        // array is null
+        // the list element is null
         if array.is_null(row_index) {
+            mutable.extend_nulls(1);
+            continue;
+        }
+
+        // the list element is empty; there is no value to take, so the result
+        // is NULL. Without this guard the no-nulls branch below would read
+        // `values[start]`, which is either the next element (wrong value) or
+        // out of bounds when `start == values.len()` (panic).
+        if start == end {
             mutable.extend_nulls(1);
             continue;
         }
@@ -1212,6 +1222,51 @@ mod tests {
         assert!(!result.is_null(0));
         assert!(result.is_null(1));
         assert!(!result.is_null(2));
+
+        Ok(())
+    }
+
+    // Regression test for https://github.com/spiceai/spiceai/issues/11945
+    // An empty (length-0) list element that is not null must yield NULL, not
+    // the next element's value. Previously the no-nulls branch unconditionally
+    // read values[start], returning the wrong element for interior empty lists.
+    #[test]
+    fn test_array_any_value_empty_list_element() -> Result<()> {
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        // row 0 = [1], row 1 = [] (empty, non-null), row 2 = [2, 3]
+        let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 1, 3]));
+        let field = Arc::new(Field::new("item", DataType::Int32, true));
+
+        let list_array = ListArray::new(field, offsets, values, None);
+
+        let result = general_array_any_value(&list_array)?;
+        let result = result.as_any().downcast_ref::<Int32Array>().unwrap();
+
+        assert_eq!(result.value(0), 1);
+        assert!(result.is_null(1)); // empty list -> NULL (previously read `2`)
+        assert_eq!(result.value(2), 2);
+
+        Ok(())
+    }
+
+    // Regression test for https://github.com/spiceai/spiceai/issues/11945
+    // A trailing empty list element has start == values.len(); the old code did
+    // `extend(0, start, start + 1)` and panicked with an out-of-bounds slice.
+    #[test]
+    fn test_array_any_value_trailing_empty_list_element() -> Result<()> {
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
+        // row 0 = [1], row 1 = [2], row 2 = [] (empty, non-null, start == len)
+        let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 2, 2]));
+        let field = Arc::new(Field::new("item", DataType::Int32, true));
+
+        let list_array = ListArray::new(field, offsets, values, None);
+
+        let result = general_array_any_value(&list_array)?;
+        let result = result.as_any().downcast_ref::<Int32Array>().unwrap();
+
+        assert_eq!(result.value(0), 1);
+        assert_eq!(result.value(1), 2);
+        assert!(result.is_null(2)); // empty list -> NULL (previously panicked)
 
         Ok(())
     }

--- a/datafusion/sqllogictest/test_files/array/array_any_value.slt
+++ b/datafusion/sqllogictest/test_files/array/array_any_value.slt
@@ -145,6 +145,37 @@ select array_any_value(make_array(NULL, 1, 2, 3, 4, 5)), array_any_value(column1
 1 41
 1 51
 
+# array_any_value with empty (length-0) list elements
+# Regression: https://github.com/spiceai/spiceai/issues/11945
+# A non-null but empty list must yield NULL, including a trailing empty element
+# whose start offset equals the values length (previously read out of bounds
+# and panicked the worker task).
+statement ok
+create table any_value_empty (id int, tags bigint[]) as values
+  (1, make_array(10)),
+  (2, cast(make_array() as bigint[])),
+  (3, make_array(20, 30)),
+  (4, cast(make_array() as bigint[]));
+
+query II
+select id, array_any_value(tags) from any_value_empty order by id;
+----
+1 10
+2 NULL
+3 20
+4 NULL
+
+query II
+select id, array_any_value(arrow_cast(tags, 'LargeList(Int64)')) from any_value_empty order by id;
+----
+1 10
+2 NULL
+3 20
+4 NULL
+
+statement ok
+drop table any_value_empty;
+
 # make_array with nulls
 query ???????
 select make_array(make_array('a','b'), null),


### PR DESCRIPTION
## Summary

`array_any_value` panics the worker task (or returns silently wrong data) when its input list column contains a non-null **empty** (length-0) element.

`general_array_any_value` guarded null and all-null elements, but a non-null empty element fell through to the no-nulls branch, which unconditionally did `mutable.extend(0, start, start + 1)`:

- **interior empty list** → reads `values[start]`, i.e. the *next* element's value (silently wrong data)
- **trailing empty list** (`start == values.len()`) → out-of-bounds slice → panic `range end index N out of range for slice of length N-1`

This surfaced downstream in spiceai when the `array_any_value` output flowed into a hash `RepartitionExec` (e.g. used as an equi-join key): repartitioning slices batches so an empty element lands at the end of a values buffer, tripping the out-of-bounds read on a spawned task (reported as a tokio "Join Error" / `13 INTERNAL`).

## Fix

Guard the empty case explicitly — an empty list has no value to take, so the result is `NULL`.

Sibling functions in `extract.rs` were audited and are already safe: `array_element` bounds-checks the index against `len`; `array_slice` / `array_pop_front` / `array_pop_back` guard `len == 0`.

## Tests

- Kernel-level regression tests: interior empty element (wrong-value) and trailing empty element (panic).
- sqllogictest cases in `array_any_value.slt` covering `List` and `LargeList` with interior + trailing empty elements.

Ref: https://github.com/spiceai/spiceai/issues/11945