### PR TITLE
fix(unparser): keep ORDER BY out of a derived table when the sort key is computed

### DIFF
--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -321,10 +321,17 @@ pub(super) fn rewrite_plan_for_sort_on_non_projected_fields(
                     .clone()
                     .transform_down(|e| {
                         Ok(match &e {
-                            Expr::Column(col) => match dropped_aliases.get(col.name()) {
-                                Some(underlying) => Transformed::yes(underlying.clone()),
-                                None => Transformed::no(e),
-                            },
+                            // Only an unqualified column can name a projection
+                            // alias: `t.x` refers to `t`'s own column even when a
+                            // dropped alias happens to share the name.
+                            Expr::Column(col) if col.relation.is_none() => {
+                                match dropped_aliases.get(col.name()) {
+                                    Some(underlying) => {
+                                        Transformed::yes(underlying.clone())
+                                    }
+                                    None => Transformed::no(e),
+                                }
+                            }
                             _ => Transformed::no(e),
                         })
                     })

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -184,6 +184,20 @@ pub(super) fn rewrite_qualify(plan: LogicalPlan) -> Result<LogicalPlan> {
 ///       TableScan: j2
 ///
 /// This prevents the original plan generate query with derived table but missing alias.
+///
+/// It also keeps the ORDER BY at the top level of the emitted statement. Left as
+/// `Projection -> Sort`, the `Sort` is unparsed as a derived table:
+///
+/// ```sql
+/// SELECT id FROM (SELECT person.id, person.age FROM person ORDER BY person.age)
+/// ```
+///
+/// SQL does not require the enclosing query to preserve the ordering of a derived
+/// table, so the rows come back in an arbitrary order.
+///
+/// A sort key does not have to *be* one of the inner Projection's outputs for the
+/// hoist to be valid -- it only has to be computable from them, as `age + 1` is from
+/// `age`.
 pub(super) fn rewrite_plan_for_sort_on_non_projected_fields(
     p: &Projection,
 ) -> Option<LogicalPlan> {
@@ -221,6 +235,15 @@ pub(super) fn rewrite_plan_for_sort_on_non_projected_fields(
         })
         .collect::<Vec<_>>();
 
+    // Compare outer collects Expr::to_string with inner collected transformed values
+    // alias -> alias column
+    // column -> remain
+    // others, extract schema field name
+    let inner_collects = inner_exprs
+        .iter()
+        .map(Expr::to_string)
+        .collect::<HashSet<_>>();
+
     let mut collects = p.expr.clone();
     for sort in &sort.expr {
         // Strip aliases from sort expressions so the comparison matches
@@ -231,18 +254,21 @@ pub(super) fn rewrite_plan_for_sort_on_non_projected_fields(
         while let Expr::Alias(alias) = expr {
             expr = *alias.expr;
         }
-        collects.push(expr);
+        if inner_collects.contains(&expr.to_string()) {
+            collects.push(expr);
+            continue;
+        }
+        // The sort key is not itself one of the inner Projection's outputs, but
+        // it may be an expression *over* them (`ORDER BY age + 1` while the
+        // inner Projection exposes `age`). Account for the columns it reads so
+        // an inner Projection that exists only to expose them still matches.
+        // Without this the rewrite bails out and the Sort is emitted as a
+        // derived table, where SQL does not guarantee the ORDER BY is honoured
+        // by the enclosing query -- the rows come back in an arbitrary order.
+        collects.extend(expr.column_refs().into_iter().cloned().map(Expr::Column));
     }
 
-    // Compare outer collects Expr::to_string with inner collected transformed values
-    // alias -> alias column
-    // column -> remain
-    // others, extract schema field name
     let outer_collects = collects.iter().map(Expr::to_string).collect::<HashSet<_>>();
-    let inner_collects = inner_exprs
-        .iter()
-        .map(Expr::to_string)
-        .collect::<HashSet<_>>();
 
     if outer_collects == inner_collects {
         let mut sort = sort.clone();
@@ -288,11 +314,21 @@ pub(super) fn rewrite_plan_for_sort_on_non_projected_fields(
                 while let Expr::Alias(alias) = expr {
                     expr = *alias.expr;
                 }
-                if let Expr::Column(ref col) = expr
-                    && let Some(underlying) = dropped_aliases.get(col.name())
-                {
-                    sort_expr.expr = underlying.clone();
-                }
+                // Substitute nested references too, not just a whole-expression
+                // one: `ORDER BY x + 1` over a dropped `expr AS x` has to become
+                // `ORDER BY expr + 1`.
+                sort_expr.expr = expr
+                    .clone()
+                    .transform_down(|e| {
+                        Ok(match &e {
+                            Expr::Column(col) => match dropped_aliases.get(col.name()) {
+                                Some(underlying) => Transformed::yes(underlying.clone()),
+                                None => Transformed::no(e),
+                            },
+                            _ => Transformed::no(e),
+                        })
+                    })
+                    .map_or(expr, |transformed| transformed.data);
             }
         }
 

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1342,7 +1342,10 @@ fn table_scan_with_empty_projection_and_none_projection_helper(
 // yielding `Projection: <empty> -> TableScan`. It must not be unparsed as an
 // empty `SELECT` list for dialects that reject `SELECT FROM t` (e.g. DuckDB):
 // fall back to `SELECT 1` just like the bare empty-projection `TableScan`.
-fn empty_projection_over_table_helper(table_name: &str, table_schema: Schema) -> LogicalPlan {
+fn empty_projection_over_table_helper(
+    table_name: &str,
+    table_schema: Schema,
+) -> LogicalPlan {
     project(
         table_scan(Some(table_name), &table_schema, None)
             .unwrap()
@@ -4272,5 +4275,61 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
         sql,
         @r#"SELECT DISTINCT * FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "left" WHERE EXISTS (SELECT 1 FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "right" WHERE ("left"."first_name" = "right"."first_name") AND ("left"."order_id" = "right"."order_id")) AND EXISTS (SELECT 1 FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id") WHERE ("left"."first_name" = "p"."first_name") AND ("left"."order_id" = "o"."order_id"))"#
     );
+    Ok(())
+}
+
+/// A `Sort` that has to be emitted below the SELECT list must not end up inside a
+/// derived table: SQL does not require an enclosing query to honour the ORDER BY of
+/// a derived table, so the rows come back in an arbitrary order.
+#[test]
+fn order_by_over_non_projected_field_stays_top_level() -> Result<()> {
+    // Sort key is an expression over a column the SELECT list does not project.
+    roundtrip_statement_with_dialect_helper!(
+        sql: "SELECT id FROM person ORDER BY age + 1 DESC",
+        parser_dialect: GenericDialect {},
+        unparser_dialect: UnparserDefaultDialect {},
+        expected: @"SELECT person.id FROM person ORDER BY (person.age + 1) DESC NULLS FIRST",
+    );
+
+    // Same, with the sort key an expression over an aggregate that is not selected.
+    roundtrip_statement_with_dialect_helper!(
+        sql: "SELECT id, first_name FROM person GROUP BY id, first_name ORDER BY max(age) + 1 DESC",
+        parser_dialect: GenericDialect {},
+        unparser_dialect: UnparserDefaultDialect {},
+        expected: @"SELECT person.id, person.first_name FROM person GROUP BY person.id, person.first_name ORDER BY (max(person.age) + 1) DESC NULLS FIRST",
+    );
+
+    // A plain non-projected column already worked; keep it covered so the
+    // generalisation above cannot regress it.
+    roundtrip_statement_with_dialect_helper!(
+        sql: "SELECT id FROM person ORDER BY age DESC",
+        parser_dialect: GenericDialect {},
+        unparser_dialect: UnparserDefaultDialect {},
+        expected: @"SELECT person.id FROM person ORDER BY person.age DESC NULLS FIRST",
+    );
+
+    Ok(())
+}
+
+/// The inner `Projection` may define an alias that only the `Sort` uses. Hoisting the
+/// `Sort` drops that alias, so every reference to it -- including one nested inside a
+/// larger sort expression -- has to be replaced by the expression it named.
+#[test]
+fn order_by_nested_reference_to_dropped_alias() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("age", DataType::Int64, false),
+    ]);
+    let plan = table_scan(Some("person"), &schema, None)?
+        .project(vec![col("id"), (col("age") * lit(2)).alias("doubled")])?
+        .sort(vec![(col("doubled") + lit(1)).sort(false, true)])?
+        .project(vec![col("id")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @"SELECT person.id FROM person ORDER BY ((person.age * 2) + 1) DESC NULLS FIRST"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary (root cause)

`rewrite_plan_for_sort_on_non_projected_fields` hoists a `Sort` sandwiched between two `Projection`s to the top of the plan, so the unparsed statement carries the ORDER BY itself. The gate was a **set equality on expression strings**: the inner `Projection`'s outputs had to be exactly the outer `Projection`'s expressions plus the sort keys.

A sort key that is an *expression over* a projected column never matched that gate. `ORDER BY age + 1` contributes the string `person.age + Int64(1)` while the inner `Projection` exposes `person.age`, so the rewrite bailed out and `select_to_sql_recursively` fell into its `derived_sort` branch:

```sql
-- SELECT id FROM person ORDER BY age + 1 DESC   unparsed to:
SELECT id FROM (SELECT person.id, person.age FROM person ORDER BY (person.age + 1) DESC NULLS FIRST)
```

**SQL does not require an enclosing query to preserve the ordering of a derived table.** The ORDER BY is buried where the remote engine is free to ignore it, so a federated `SELECT ... ORDER BY <expression>` comes back in arbitrary order — silently, with no error.

`ORDER BY age` (a bare column) was unaffected, which is why this went unnoticed: the failure needs the sort key to be *computed*.

## Changes

- When a sort key is not itself one of the inner `Projection`'s outputs, account for the **columns it reads** instead. An inner `Projection` that exists only to expose those columns then matches, and the `Sort` is hoisted as intended. A sort key does not have to *be* a projected output for the hoist to be valid — it only has to be computable from them.
- Hoisting replaces the inner `Projection`'s expressions, so any alias it defined is dropped. The existing dropped-alias substitution only fired when the *whole* sort expression was that alias; it now substitutes nested references too, so `ORDER BY x + 1` over a dropped `expr AS x` becomes `ORDER BY expr + 1` rather than a dangling `x`.

## Test plan

- `cargo test -p datafusion-sql` — **499 passed**, 22 failed. Those 22 are **pre-existing on `spiceai-54`**: the same 22 tests with byte-identical snapshot diffs fail on an unmodified checkout of the base commit (`b8b95926`). Verified by diffing the full run output before and after this change — the failure set and every snapshot assertion are unchanged. The delta is `497 -> 499` passing, i.e. only the two tests added here.
- `cargo test -p datafusion --test tpcds_planning` — 198 passed, no change.
- Swept all 99 TPC-DS queries (optimize -> `plan_to_sql`) checking that a plan rooted at `Sort` always emits a top-level ORDER BY: **0 lost** before and after, and the same 4 pre-existing `grouping id` unparse errors (q27/q36/q70/q86). No plan's output changed.
- `cargo clippy -p datafusion-sql --all-targets` clean; `cargo fmt` clean for both touched files (`expr.rs` has pre-existing fmt drift, left alone).

### Tests added

- `order_by_over_non_projected_field_stays_top_level` — the expression sort key (`ORDER BY age + 1`), the aggregate-expression variant (`ORDER BY max(age) + 1`), and the bare-column case that already worked, so the generalisation cannot regress it.
- `order_by_nested_reference_to_dropped_alias` — sort key referencing a dropped inner alias from inside a larger expression.

**Neutered-fix check:** with `rewrite.rs` reverted and the tests kept, both new tests fail (the emitted SQL is the derived-table form above) while the 33 existing `order_by_*` tests still pass. The regression guards genuinely bite.

## Note on scope

The reported case (spiceai/spiceai#6931, Dremio TPC-DS q91) no longer reproduces through q91 itself on DataFusion 54 — the optimizer now leaves `Sort` at the plan root there. The unparser hazard behind it was still live and is what this fixes; the sweep above is the evidence that no TPC-DS query is currently affected while the one-line query `SELECT id FROM person ORDER BY age + 1` is.