### PR TITLE
fix(unparser): unparse a stacked aggregate as a derived table

### DIFF
--- a/datafusion/core/tests/sql/unparser.rs
+++ b/datafusion/core/tests/sql/unparser.rs
@@ -464,3 +464,40 @@ async fn test_tpch_unparser_roundtrip() {
     set_stack_allocation_size(8 * 1024 * 1024);
     run_roundtrip_tests("TPC-H", tpch_queries(), tpch_test_context).await;
 }
+
+/// The suites above unparse the plan as it comes out of the SQL planner. A consumer that
+/// pushes a query down to a remote engine unparses the *optimized* plan, where
+/// `single_distinct_to_groupby` has rewritten `count(DISTINCT c)` into an outer
+/// `count(alias1)` over an inner `GROUP BY c AS alias1`. Both aggregates have to reach the
+/// emitted SQL: with the inner one dropped, `count(alias1)` is left referencing the base
+/// table, which fails to bind — and where a column of that name does exist, counts every
+/// row instead of the distinct values.
+#[tokio::test]
+async fn test_optimized_plan_roundtrip_count_distinct() -> Result<()> {
+    let ctx = clickbench_test_context().await?;
+    let unparser = Unparser::new(&DefaultDialect {});
+
+    for sql in [
+        r#"SELECT COUNT(DISTINCT "UserID") AS c FROM hits"#,
+        r#"SELECT "RegionID", COUNT(DISTINCT "UserID") AS c FROM hits GROUP BY "RegionID""#,
+    ] {
+        let optimized = ctx.sql(sql).await?.into_optimized_plan()?;
+        let unparsed = format!("{:#}", unparser.plan_to_sql(&optimized)?);
+
+        let expected = sort_batches(&ctx, ctx.sql(sql).await?.collect().await?).await?;
+        let actual_df = ctx.sql(&unparsed).await.map_err(|e| {
+            datafusion_common::DataFusionError::Context(
+                format!("unparsed SQL failed to plan: {unparsed}"),
+                Box::new(e),
+            )
+        })?;
+        let actual = sort_batches(&ctx, actual_df.collect().await?).await?;
+
+        assert_eq!(
+            expected, actual,
+            "unparsed optimized plan returned different rows.\nOriginal SQL:\n{sql}\n\nUnparsed SQL:\n{unparsed}"
+        );
+    }
+
+    Ok(())
+}

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -170,6 +170,12 @@ pub struct SelectBuilder {
     /// Table aliases that correspond to LATERAL FLATTEN relations.
     /// Column references into these aliases must use `VALUE` as the column name.
     flatten_table_aliases: Vec<String>,
+    /// Whether a `LogicalPlan::Aggregate` has already been folded into this SELECT,
+    /// as its select list and `GROUP BY`. A SELECT expresses at most one grouping, so
+    /// a second aggregate below it belongs in a derived table.
+    ///
+    /// Set with `mark_aggregated()` and read with `already_aggregated()`.
+    aggregated: bool,
 }
 
 /// Prefix used for auto-generated LATERAL FLATTEN table aliases.
@@ -196,6 +202,16 @@ impl SelectBuilder {
     /// Returns true if the given table alias refers to a FLATTEN relation.
     pub fn is_flatten_table_alias(&self, alias: &str) -> bool {
         self.flatten_table_aliases.iter().any(|a| a == alias)
+    }
+
+    /// Record that an aggregate node is now expressed by this SELECT.
+    pub fn mark_aggregated(&mut self) {
+        self.aggregated = true;
+    }
+
+    /// Returns true if an aggregate node has already been folded into this SELECT.
+    pub fn already_aggregated(&self) -> bool {
+        self.aggregated
     }
 
     /// Returns the most recently generated flatten alias, or `None` if
@@ -425,6 +441,7 @@ impl SelectBuilder {
             flavor: Some(SelectFlavor::Standard),
             flatten_alias_counter: 0,
             flatten_table_aliases: Vec::new(),
+            aggregated: false,
         }
     }
 }

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -20,7 +20,8 @@ use std::ops::ControlFlow;
 
 use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
-    self, LimitClause, OrderByKind, SelectFlavor, visit_expressions_mut,
+    self, LimitClause, OrderByKind, SelectFlavor, visit_expressions,
+    visit_expressions_mut,
 };
 
 #[derive(Clone)]
@@ -136,6 +137,23 @@ impl Default for QueryBuilder {
     fn default() -> Self {
         Self::create_empty()
     }
+}
+
+/// Returns true if `expr` holds a subquery anywhere within it.
+fn contains_subquery(expr: &ast::Expr) -> bool {
+    visit_expressions(expr, |expr| {
+        if matches!(
+            expr,
+            ast::Expr::Subquery(_)
+                | ast::Expr::InSubquery { .. }
+                | ast::Expr::Exists { .. }
+        ) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .is_break()
 }
 
 #[derive(Clone)]
@@ -351,6 +369,60 @@ impl SelectBuilder {
     /// caller can tell what a sub-plan contributed and re-place it elsewhere.
     pub fn take_selection(&mut self) -> Option<ast::Expr> {
         self.selection.take()
+    }
+
+    /// Applies `f` to every expression this SELECT carries: the projection, `WHERE`,
+    /// `GROUP BY`, `HAVING`, `QUALIFY` and the builder's own sort. `f` sees nested
+    /// expressions too, so a rewrite reaches a column reference wherever it sits.
+    ///
+    /// This exists so a caller that replaces the SELECT's relation — unparsing a sub-plan
+    /// as a derived table — can re-point the column references that addressed the old one,
+    /// without the builder having to expose each clause for reading.
+    ///
+    /// An expression containing a subquery is skipped whole. A correlated subquery
+    /// references an enclosing query's relation, which stays in scope and is
+    /// indistinguishable by name from a reference to this SELECT's own relation, so
+    /// rewriting inside one would silently change which column the subquery reads. That
+    /// leaves such an expression untouched rather than risk rewriting it wrongly.
+    pub fn visit_expressions_in_clauses_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut ast::Expr),
+    {
+        let mut visit = |expr: &mut ast::Expr| {
+            if contains_subquery(expr) {
+                return;
+            }
+            let _ = visit_expressions_mut(expr, |expr| {
+                f(expr);
+                ControlFlow::<()>::Continue(())
+            });
+        };
+
+        for item in self.projection.iter_mut().flatten() {
+            match item {
+                ast::SelectItem::UnnamedExpr(expr)
+                | ast::SelectItem::ExprWithAlias { expr, .. }
+                | ast::SelectItem::ExprWithAliases { expr, .. } => visit(expr),
+                ast::SelectItem::QualifiedWildcard(..) | ast::SelectItem::Wildcard(_) => {
+                }
+            }
+        }
+        for expr in self
+            .selection
+            .iter_mut()
+            .chain(self.having.iter_mut())
+            .chain(self.qualify.iter_mut())
+        {
+            visit(expr);
+        }
+        if let Some(ast::GroupByExpr::Expressions(exprs, _)) = self.group_by.as_mut() {
+            for expr in exprs {
+                visit(expr);
+            }
+        }
+        for sort in &mut self.sort_by {
+            visit(&mut sort.expr);
+        }
     }
 
     pub fn group_by(&mut self, value: ast::GroupByExpr) -> &mut Self {

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -185,6 +185,8 @@ pub struct SelectBuilder {
     flavor: Option<SelectFlavor>,
     /// Counter for generating unique LATERAL FLATTEN aliases within this SELECT.
     flatten_alias_counter: usize,
+    /// Counter for generating unique derived-aggregate aliases within this SELECT.
+    derived_aggregate_alias_counter: usize,
     /// Table aliases that correspond to LATERAL FLATTEN relations.
     /// Column references into these aliases must use `VALUE` as the column name.
     flatten_table_aliases: Vec<String>,
@@ -199,12 +201,30 @@ pub struct SelectBuilder {
 /// Prefix used for auto-generated LATERAL FLATTEN table aliases.
 const FLATTEN_ALIAS_PREFIX: &str = "_unnest";
 
+/// Prefix used for the auto-generated alias of a derived table that carries an
+/// aggregate stacked below the one its enclosing SELECT already expresses.
+const DERIVED_AGGREGATE_ALIAS_PREFIX: &str = "derived_aggregate";
+
 impl SelectBuilder {
     /// Generate a unique alias for a LATERAL FLATTEN relation
     /// (`_unnest_1`, `_unnest_2`, …). Each call returns a fresh name.
     pub fn next_flatten_alias(&mut self) -> String {
         self.flatten_alias_counter += 1;
         format!("{FLATTEN_ALIAS_PREFIX}_{}", self.flatten_alias_counter)
+    }
+
+    /// Generate a unique alias for a derived table holding a stacked aggregate
+    /// (`derived_aggregate_1`, `derived_aggregate_2`, …). Each call returns a fresh
+    /// name. A join walks both of its sides with one builder, so both sides can
+    /// derive an aggregate into the same FROM clause; the number is what keeps the
+    /// two apart, both as table names and as the qualifier each side's own column
+    /// references are rewritten onto.
+    pub fn next_derived_aggregate_alias(&mut self) -> String {
+        self.derived_aggregate_alias_counter += 1;
+        format!(
+            "{DERIVED_AGGREGATE_ALIAS_PREFIX}_{}",
+            self.derived_aggregate_alias_counter
+        )
     }
 
     /// Register a table alias as pointing to a LATERAL FLATTEN relation.
@@ -519,6 +539,7 @@ impl SelectBuilder {
             value_table_mode: Default::default(),
             flavor: Some(SelectFlavor::Standard),
             flatten_alias_counter: 0,
+            derived_aggregate_alias_counter: 0,
             flatten_table_aliases: Vec::new(),
             aggregated: false,
         }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -56,10 +56,6 @@ use datafusion_expr::{
 use sqlparser::ast::{self, Ident, OrderByKind, SetExpr, TableAliasColumnDef};
 use std::{collections::HashSet, sync::Arc, vec};
 
-/// Alias given to the derived table that carries an aggregate stacked below the one its
-/// enclosing SELECT already expresses.
-const DERIVED_AGGREGATE_ALIAS: &str = "derived_aggregate";
-
 /// Convert a DataFusion [`LogicalPlan`] to [`ast::Statement`]
 ///
 /// This function is the opposite of [`SqlToRel::sql_statement_to_plan`] and can
@@ -935,15 +931,19 @@ impl Unparser<'_> {
                     // would not require one, so this SELECT has a name to address its
                     // columns through. A bare column name would do only where the derived
                     // table is the SELECT's sole relation, which is not true under a join.
-                    let alias = self
-                        .new_ident_quoted_if_needs(DERIVED_AGGREGATE_ALIAS.to_string());
+                    //
+                    // The alias is numbered per SELECT because a join walks both of
+                    // its sides with this one builder, so both sides can derive an
+                    // aggregate into the same FROM clause. A fixed name would repeat
+                    // there, and since each side requalifies its own references onto
+                    // its own alias, the two sides' distinct columns would collapse
+                    // onto a single qualifier.
+                    let alias_name = select.next_derived_aggregate_alias();
+                    let alias = self.new_ident_quoted_if_needs(alias_name.clone());
                     self.derive(
                         plan,
                         relation,
-                        Some(self.new_table_alias(
-                            DERIVED_AGGREGATE_ALIAS.to_string(),
-                            vec![],
-                        )),
+                        Some(self.new_table_alias(alias_name, vec![])),
                         false,
                     )?;
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -884,6 +884,24 @@ impl Unparser<'_> {
                 )
             }
             LogicalPlan::Aggregate(agg) => {
+                // A SELECT expresses a single grouping, so an aggregate stacked below the
+                // one this SELECT already carries has to become a derived table. Stacked
+                // aggregates are what `single_distinct_to_groupby` produces for
+                // `count(DISTINCT c)`: an outer `count(alias1)` over an inner
+                // `GROUP BY c AS alias1`. Folding both into one SELECT would emit
+                // `count(alias1)` against the base table — `alias1` does not exist there,
+                // and where it happens to, the DISTINCT is silently gone.
+                if select.already_aggregated() {
+                    return self.derive_with_dialect_alias(
+                        "derived_aggregate",
+                        plan,
+                        relation,
+                        false,
+                        vec![],
+                    );
+                }
+                select.mark_aggregated();
+
                 // Aggregation can be already handled in the projection case
                 if !select.already_projected() {
                     // The query returns aggregate and group expressions. If that weren't the case,

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -56,6 +56,10 @@ use datafusion_expr::{
 use sqlparser::ast::{self, Ident, OrderByKind, SetExpr, TableAliasColumnDef};
 use std::{collections::HashSet, sync::Arc, vec};
 
+/// Alias given to the derived table that carries an aggregate stacked below the one its
+/// enclosing SELECT already expresses.
+const DERIVED_AGGREGATE_ALIAS: &str = "derived_aggregate";
+
 /// Convert a DataFusion [`LogicalPlan`] to [`ast::Statement`]
 ///
 /// This function is the opposite of [`SqlToRel::sql_statement_to_plan`] and can
@@ -927,35 +931,40 @@ impl Unparser<'_> {
                 // `count(alias1)` against the base table — `alias1` does not exist there,
                 // and where it happens to, the DISTINCT is silently gone.
                 if select.already_aggregated() {
-                    self.derive_with_dialect_alias(
-                        "derived_aggregate",
+                    // The derived table always carries an alias, even for a dialect that
+                    // would not require one, so this SELECT has a name to address its
+                    // columns through. A bare column name would do only where the derived
+                    // table is the SELECT's sole relation, which is not true under a join.
+                    let alias = self
+                        .new_ident_quoted_if_needs(DERIVED_AGGREGATE_ALIAS.to_string());
+                    self.derive(
                         plan,
                         relation,
+                        Some(self.new_table_alias(
+                            DERIVED_AGGREGATE_ALIAS.to_string(),
+                            vec![],
+                        )),
                         false,
-                        vec![],
                     )?;
 
-                    // This SELECT now reads from that derived table, and the relation its
-                    // expressions are qualified by is no longer in scope. Every column it
-                    // addresses is one the derived table projects, so re-point the
-                    // qualified references at the derived table; leaving them addressing
-                    // the base relation emits SQL that DataFusion re-plans but a stricter
-                    // remote binder rejects.
-                    let derived_columns: HashSet<String> = plan
+                    // This SELECT now reads those columns from the derived table, so a
+                    // reference still qualified by a relation the derived table encloses
+                    // binds to nothing. DataFusion re-plans such SQL, but a stricter remote
+                    // binder rejects it, which is what breaks a federated pushdown.
+                    let derived_qualifiers: HashSet<String> = plan
                         .schema()
-                        .fields()
                         .iter()
-                        .map(|field| field.name().clone())
+                        .filter_map(|(qualifier, _)| qualifier)
+                        .flat_map(|qualifier| {
+                            [qualifier.to_string(), qualifier.table().to_string()]
+                        })
                         .collect();
-                    let alias = relation
-                        .get_alias()
-                        .map(|alias| self.new_ident_quoted_if_needs(alias));
                     select.visit_expressions_in_clauses_mut(|expr| {
                         if let ast::Expr::CompoundIdentifier(idents) = expr {
                             requalify_column_onto_derived_table(
                                 idents,
-                                &derived_columns,
-                                alias.as_ref(),
+                                &derived_qualifiers,
+                                &alias,
                             );
                         }
                     });

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -23,7 +23,8 @@ use super::{
     },
     rewrite::{
         TableAliasRewriter, inject_column_aliases_into_subquery, normalize_union_schema,
-        remove_dangling_identifiers, rewrite_plan_for_sort_on_non_projected_fields,
+        remove_dangling_identifiers, requalify_column_onto_derived_table,
+        rewrite_plan_for_sort_on_non_projected_fields,
         subquery_alias_inner_query_and_columns,
     },
     utils::{
@@ -53,7 +54,7 @@ use datafusion_expr::{
     UserDefinedLogicalNode, Window, expr::Alias,
 };
 use sqlparser::ast::{self, Ident, OrderByKind, SetExpr, TableAliasColumnDef};
-use std::{sync::Arc, vec};
+use std::{collections::HashSet, sync::Arc, vec};
 
 /// Convert a DataFusion [`LogicalPlan`] to [`ast::Statement`]
 ///
@@ -926,13 +927,40 @@ impl Unparser<'_> {
                 // `count(alias1)` against the base table — `alias1` does not exist there,
                 // and where it happens to, the DISTINCT is silently gone.
                 if select.already_aggregated() {
-                    return self.derive_with_dialect_alias(
+                    self.derive_with_dialect_alias(
                         "derived_aggregate",
                         plan,
                         relation,
                         false,
                         vec![],
-                    );
+                    )?;
+
+                    // This SELECT now reads from that derived table, and the relation its
+                    // expressions are qualified by is no longer in scope. Every column it
+                    // addresses is one the derived table projects, so re-point the
+                    // qualified references at the derived table; leaving them addressing
+                    // the base relation emits SQL that DataFusion re-plans but a stricter
+                    // remote binder rejects.
+                    let derived_columns: HashSet<String> = plan
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|field| field.name().clone())
+                        .collect();
+                    let alias = relation
+                        .get_alias()
+                        .map(|alias| self.new_ident_quoted_if_needs(alias));
+                    select.visit_expressions_in_clauses_mut(|expr| {
+                        if let ast::Expr::CompoundIdentifier(idents) = expr {
+                            requalify_column_onto_derived_table(
+                                idents,
+                                &derived_columns,
+                                alias.as_ref(),
+                            );
+                        }
+                    });
+
+                    return Ok(());
                 }
                 select.mark_aggregated();
 

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -537,6 +537,46 @@ impl TreeNodeRewriter for TableAliasRewriter<'_> {
     }
 }
 
+/// Re-points a column reference at the derived table that replaced the relation it names.
+///
+/// When a sub-plan is unparsed as a derived table, the SELECT above it stops reading from
+/// the relation its expressions are qualified by and reads from that derived table instead.
+/// A qualifier naming the original relation then binds to nothing, so a strict remote binder
+/// rejects the query even though DataFusion re-plans it.
+///
+/// `derived_columns` are the derived table's output column names; a reference to anything
+/// else is left alone, since the derived table cannot supply it. That test is on the column
+/// name only and so does not distinguish a correlated reference to an enclosing query — a
+/// caller must not offer one, which is why
+/// [`SelectBuilder::visit_expressions_in_clauses_mut`] skips any expression holding a
+/// subquery.
+///
+/// `alias` is the derived table's alias when it has one — the reference is qualified by it,
+/// and otherwise reduced to the bare column name, which is unambiguous because a derived
+/// table is the SELECT's only relation.
+///
+/// [`SelectBuilder::visit_expressions_in_clauses_mut`]: super::ast::SelectBuilder::visit_expressions_in_clauses_mut
+pub fn requalify_column_onto_derived_table(
+    idents: &mut Vec<Ident>,
+    derived_columns: &HashSet<String>,
+    alias: Option<&Ident>,
+) {
+    if idents.len() < 2 {
+        return;
+    }
+    let Some(last) = idents.last() else {
+        unreachable!("CompoundIdentifier must have a last element");
+    };
+    if !derived_columns.contains(&last.value) {
+        return;
+    }
+    let last = last.clone();
+    *idents = match alias {
+        Some(alias) => vec![alias.clone(), last],
+        None => vec![last],
+    };
+}
+
 /// Takes an input list of identifiers and a list of identifiers that are available from relations or joins.
 /// Removes any table identifiers that are not present in the list of available identifiers, retains original column names.
 pub fn remove_dangling_identifiers(

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -544,37 +544,40 @@ impl TreeNodeRewriter for TableAliasRewriter<'_> {
 /// A qualifier naming the original relation then binds to nothing, so a strict remote binder
 /// rejects the query even though DataFusion re-plans it.
 ///
-/// `derived_columns` are the derived table's output column names; a reference to anything
-/// else is left alone, since the derived table cannot supply it. That test is on the column
-/// name only and so does not distinguish a correlated reference to an enclosing query — a
-/// caller must not offer one, which is why
-/// [`SelectBuilder::visit_expressions_in_clauses_mut`] skips any expression holding a
-/// subquery.
+/// A reference is rewritten only when its qualifier names one of the relations the derived
+/// table encloses (`derived_qualifiers`), so a reference to a relation the SELECT still
+/// reads directly — the other side of a join, say — keeps the qualifier it needs. The
+/// column is then addressed through `alias`, which the derived table always carries, rather
+/// than reduced to a bare name: bare would be ambiguous wherever the derived table is not
+/// the SELECT's only relation.
 ///
-/// `alias` is the derived table's alias when it has one — the reference is qualified by it,
-/// and otherwise reduced to the bare column name, which is unambiguous because a derived
-/// table is the SELECT's only relation.
+/// Both tests are on names alone, so neither distinguishes a correlated reference to an
+/// enclosing query — that qualifier can name the very same relation. A caller must not
+/// offer one, which is why [`SelectBuilder::visit_expressions_in_clauses_mut`] skips any
+/// expression holding a subquery.
 ///
 /// [`SelectBuilder::visit_expressions_in_clauses_mut`]: super::ast::SelectBuilder::visit_expressions_in_clauses_mut
 pub fn requalify_column_onto_derived_table(
     idents: &mut Vec<Ident>,
-    derived_columns: &HashSet<String>,
-    alias: Option<&Ident>,
+    derived_qualifiers: &HashSet<String>,
+    alias: &Ident,
 ) {
     if idents.len() < 2 {
+        return;
+    }
+    let qualifier = idents
+        .iter()
+        .take(idents.len() - 1)
+        .map(|ident| ident.value.clone())
+        .collect::<Vec<String>>()
+        .join(".");
+    if !derived_qualifiers.contains(&qualifier) {
         return;
     }
     let Some(last) = idents.last() else {
         unreachable!("CompoundIdentifier must have a last element");
     };
-    if !derived_columns.contains(&last.value) {
-        return;
-    }
-    let last = last.clone();
-    *idents = match alias {
-        Some(alias) => vec![alias.clone(), last],
-        None => vec![last],
-    };
+    *idents = vec![alias.clone(), last.clone()];
 }
 
 /// Takes an input list of identifiers and a list of identifiers that are available from relations or joins.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -29,8 +29,8 @@ use datafusion_expr::{
     ColumnarValue, EmptyRelation, Expr, Extension, LogicalPlan, LogicalPlanBuilder,
     ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Union,
     UserDefinedLogicalNode, UserDefinedLogicalNodeCore, Volatility, WindowFrame,
-    WindowFunctionDefinition, cast, col, exists, in_subquery, lit, scalar_subquery,
-    table_scan, wildcard,
+    WindowFunctionDefinition, cast, col, exists, in_subquery, lit, out_ref_col,
+    scalar_subquery, table_scan, wildcard,
 };
 use datafusion_functions::unicode;
 use datafusion_functions_aggregate::grouping::grouping_udaf;
@@ -1342,7 +1342,10 @@ fn table_scan_with_empty_projection_and_none_projection_helper(
 // yielding `Projection: <empty> -> TableScan`. It must not be unparsed as an
 // empty `SELECT` list for dialects that reject `SELECT FROM t` (e.g. DuckDB):
 // fall back to `SELECT 1` just like the bare empty-projection `TableScan`.
-fn empty_projection_over_table_helper(table_name: &str, table_schema: Schema) -> LogicalPlan {
+fn empty_projection_over_table_helper(
+    table_name: &str,
+    table_schema: Schema,
+) -> LogicalPlan {
     project(
         table_scan(Some(table_name), &table_schema, None)
             .unwrap()
@@ -4468,7 +4471,7 @@ fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY test.a"#
+        @r#"SELECT a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a"#
     );
 
     // A lone aggregate is still folded into the SELECT it belongs to.
@@ -4478,6 +4481,148 @@ fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
     assert_snapshot!(
         plan_to_sql(&plan)?,
         @"SELECT COUNT(test.b), test.a FROM test GROUP BY test.a"
+    );
+
+    Ok(())
+}
+
+/// Once the inner aggregate becomes a derived table, the enclosing SELECT reads from that
+/// derived table and not from `test`, so a reference still qualified by `test` binds to
+/// nothing. DataFusion re-plans such a query, but PostgreSQL answers 42703 and DuckDB a
+/// Binder Error, so the failure surfaces as a driver error on a federated pushdown.
+#[test]
+fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+    ]);
+    let stacked = || -> Result<LogicalPlanBuilder> {
+        table_scan(Some("test"), &schema, None)?.aggregate(
+            vec![col("test.a"), col("test.b").alias("alias1")],
+            Vec::<Expr>::new(),
+        )
+    };
+
+    // GROUP BY on a bare qualified column.
+    let plan = stacked()?
+        .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a"
+    );
+
+    // A qualifier nested inside a grouping expression is reached too — the projection and
+    // the GROUP BY have to agree, or the GROUP BY no longer covers the selected expression.
+    let plan = stacked()?
+        .aggregate(vec![col("test.a") + lit(1u32)], vec![count_col("alias1")])?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @"SELECT COUNT(alias1), (a + 1) FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY (a + 1)"
+    );
+
+    // HAVING is built from a Filter above the aggregate and was never swept.
+    let plan = stacked()?
+        .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
+        .filter(col("test.a").gt(lit(1u32)))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a HAVING (a > 1)"
+    );
+
+    // ORDER BY was already handled by the dangling-identifier sweep; it must stay that way.
+    let plan = stacked()?
+        .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
+        .sort(vec![col("test.a").sort(true, false)])?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a ORDER BY a ASC NULLS LAST"
+    );
+
+    Ok(())
+}
+
+/// A dialect that requires an alias on a derived table gets the references pointed at that
+/// alias rather than stripped bare, so the emitted SQL binds under both shapes.
+#[test]
+fn stacked_aggregate_requalifies_onto_a_required_derived_table_alias() -> Result<()> {
+    struct AliasedDerivedTableDialect {}
+    impl UnparserDialect for AliasedDerivedTableDialect {
+        fn identifier_quote_style(&self, _: &str) -> Option<char> {
+            None
+        }
+        fn requires_derived_table_alias(&self) -> bool {
+            true
+        }
+    }
+
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+    ]);
+    let plan = table_scan(Some("test"), &schema, None)?
+        .aggregate(
+            vec![col("test.a"), col("test.b").alias("alias1")],
+            Vec::<Expr>::new(),
+        )?
+        .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
+        .filter(col("test.a").gt(lit(1u32)))?
+        .build()?;
+
+    let unparser = Unparser::new(&AliasedDerivedTableDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (derived_aggregate.a > 1)"
+    );
+
+    Ok(())
+}
+
+/// A correlated subquery references an enclosing query's relation by a qualifier that is
+/// indistinguishable, by name, from one addressing this SELECT's own relation — here both
+/// are `test.a`. Rewriting inside the subquery would repoint it at the derived table and
+/// silently change which column it reads, so an expression holding a subquery is left
+/// alone entirely.
+///
+/// The cost is visible below: the `test.a` on the left of the comparison is this SELECT's
+/// own and would otherwise be requalified, but it shares an expression with the subquery
+/// and so keeps its qualifier. That is the pre-existing output for this shape, not a
+/// regression, and it is the conservative direction — an unbindable qualifier is a loud
+/// error at the remote engine, whereas a repointed correlated reference returns wrong rows.
+#[test]
+fn stacked_aggregate_leaves_a_correlated_outer_reference_alone() -> Result<()> {
+    let outer = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+    ]);
+    let inner = Schema::new(vec![Field::new("c", DataType::UInt32, false)]);
+
+    // HAVING count(alias1) > (SELECT count(other.c) FROM other WHERE other.c = test.a)
+    let correlated = scalar_subquery(Arc::new(
+        table_scan(Some("other"), &inner, None)?
+            .filter(col("other.c").eq(out_ref_col(DataType::UInt32, "test.a")))?
+            .aggregate(Vec::<Expr>::new(), vec![count_col("other.c")])?
+            .build()?,
+    ));
+
+    let plan = table_scan(Some("test"), &outer, None)?
+        .aggregate(
+            vec![col("test.a"), col("test.b").alias("alias1")],
+            Vec::<Expr>::new(),
+        )?
+        .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
+        .filter(col("test.a").gt(correlated))?
+        .build()?;
+
+    // `other.c = test.a` inside the subquery still reads the outer `test.a`, which is the
+    // property that matters. `GROUP BY a` shows the requalification still runs on the
+    // clauses that hold no subquery.
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a HAVING (test.a > (SELECT COUNT("other".c) FROM "other" WHERE ("other".c = test.a)))"#
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4453,7 +4453,7 @@ fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.b AS alias1 FROM test GROUP BY test.b) AS derived_aggregate"#
+        @r#"SELECT COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.b AS alias1 FROM test GROUP BY test.b) AS derived_aggregate_1"#
     );
 
     // a, count(DISTINCT b) ... GROUP BY a — the outer aggregate keeps its own grouping,
@@ -4471,7 +4471,7 @@ fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT derived_aggregate.a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a"#
+        @r#"SELECT derived_aggregate_1.a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY derived_aggregate_1.a"#
     );
 
     // A lone aggregate is still folded into the SELECT it belongs to.
@@ -4509,7 +4509,7 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a"
+        @"SELECT COUNT(alias1), derived_aggregate_1.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY derived_aggregate_1.a"
     );
 
     // A qualifier nested inside a grouping expression is reached too — the projection and
@@ -4519,7 +4519,7 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), (derived_aggregate.a + 1) FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY (derived_aggregate.a + 1)"
+        @"SELECT COUNT(alias1), (derived_aggregate_1.a + 1) FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY (derived_aggregate_1.a + 1)"
     );
 
     // HAVING is built from a Filter above the aggregate and was never swept.
@@ -4529,7 +4529,7 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (derived_aggregate.a > 1)"
+        @"SELECT COUNT(alias1), derived_aggregate_1.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY derived_aggregate_1.a HAVING (derived_aggregate_1.a > 1)"
     );
 
     // A query-level ORDER BY is reached by the existing dangling-identifier sweep, which
@@ -4541,7 +4541,7 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a ORDER BY a ASC NULLS LAST"
+        @"SELECT COUNT(alias1), derived_aggregate_1.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY derived_aggregate_1.a ORDER BY a ASC NULLS LAST"
     );
 
     Ok(())
@@ -4577,7 +4577,7 @@ fn stacked_aggregate_requalifies_onto_a_required_derived_table_alias() -> Result
     let unparser = Unparser::new(&AliasedDerivedTableDialect {});
     assert_snapshot!(
         unparser.plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (derived_aggregate.a > 1)"
+        @"SELECT COUNT(alias1), derived_aggregate_1.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY derived_aggregate_1.a HAVING (derived_aggregate_1.a > 1)"
     );
 
     Ok(())
@@ -4611,7 +4611,7 @@ fn stacked_aggregate_under_a_join_leaves_the_other_side_qualified() -> Result<()
         .aggregate(vec![col("other.a")], vec![count_col("test.a")])?
         .build()?;
 
-    // `COUNT(derived_aggregate.a)` and `GROUP BY "other".a` stay distinguishable. Reducing
+    // `COUNT(derived_aggregate_1.a)` and `GROUP BY "other".a` stay distinguishable. Reducing
     // either to a bare `a` would make the query ambiguous, and group by the wrong column.
     //
     // The join's `ON` still reads `test.a`: it is built as part of the join and attached
@@ -4620,7 +4620,50 @@ fn stacked_aggregate_under_a_join_leaves_the_other_side_qualified() -> Result<()
     // here keeps the gap visible rather than silent.
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT COUNT(derived_aggregate.a), "other".a FROM (SELECT test.a FROM test GROUP BY test.a) AS derived_aggregate INNER JOIN "other" ON (test.a = "other".a) GROUP BY "other".a"#
+        @r#"SELECT COUNT(derived_aggregate_1.a), "other".a FROM (SELECT test.a FROM test GROUP BY test.a) AS derived_aggregate_1 INNER JOIN "other" ON (test.a = "other".a) GROUP BY "other".a"#
+    );
+
+    Ok(())
+}
+
+/// Both sides of a join can carry a stacked aggregate, and one `SelectBuilder` walks both,
+/// so both derive a table into the same FROM clause. Their aliases have to differ on two
+/// counts: a repeated name is a duplicate table name most engines reject outright, and —
+/// the quieter half — each side requalifies its own references onto its own alias, so a
+/// shared name would collapse the two sides' distinct columns onto one qualifier and group
+/// by whichever side was walked first.
+#[test]
+fn stacked_aggregates_on_both_join_sides_get_distinct_aliases() -> Result<()> {
+    let left = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+    ]);
+    // `other` deliberately repeats the column name `a`, so a collapsed qualifier would
+    // still bind — and silently read the wrong side — rather than fail loudly.
+    let right = Schema::new(vec![Field::new("a", DataType::UInt32, false)]);
+
+    let left_aggregate = table_scan(Some("test"), &left, None)?
+        .aggregate(vec![col("test.a")], Vec::<Expr>::new())?
+        .build()?;
+    let right_aggregate = table_scan(Some("other"), &right, None)?
+        .aggregate(vec![col("other.a")], Vec::<Expr>::new())?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(left_aggregate)
+        .join_on(
+            right_aggregate,
+            datafusion_expr::JoinType::Inner,
+            vec![col("test.a").eq(col("other.a"))],
+        )?
+        .aggregate(vec![col("other.a")], vec![count_col("test.a")])?
+        .build()?;
+
+    // `COUNT` keeps the left side and `GROUP BY` the right, each through its own alias.
+    // The join's `ON` still reads the pre-derivation qualifiers, which is the gap tracked
+    // as spiceai/spiceai#12695 and is pinned here rather than left silent.
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT COUNT(derived_aggregate_1.a), derived_aggregate_2.a FROM (SELECT test.a FROM test GROUP BY test.a) AS derived_aggregate_1 INNER JOIN (SELECT "other".a FROM "other" GROUP BY "other".a) AS derived_aggregate_2 ON (test.a = "other".a) GROUP BY derived_aggregate_2.a"#
     );
 
     Ok(())
@@ -4667,7 +4710,7 @@ fn stacked_aggregate_leaves_a_correlated_outer_reference_alone() -> Result<()> {
     // clauses that hold no subquery.
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (test.a > (SELECT COUNT("other".c) FROM "other" WHERE ("other".c = test.a)))"#
+        @r#"SELECT COUNT(alias1), derived_aggregate_1.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate_1 GROUP BY derived_aggregate_1.a HAVING (test.a > (SELECT COUNT("other".c) FROM "other" WHERE ("other".c = test.a)))"#
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4274,3 +4274,72 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
     );
     Ok(())
 }
+
+/// Builds `count(<col>)` with the aggregate-function stub used across these tests.
+fn count_col(name: &str) -> Expr {
+    use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
+    Expr::AggregateFunction(AggregateFunction {
+        func: count_udaf(),
+        params: AggregateFunctionParams {
+            args: vec![col(name)],
+            distinct: false,
+            filter: None,
+            order_by: vec![],
+            null_treatment: None,
+        },
+    })
+}
+
+/// A SELECT carries a single grouping, so an aggregate stacked directly on top of
+/// another has to be unparsed as a derived table. This is the plan
+/// `single_distinct_to_groupby` produces for `count(DISTINCT b)`: an outer
+/// `count(alias1)` over an inner `GROUP BY b AS alias1`. Folding both into one SELECT
+/// emits `count(alias1)` against the base table, where `alias1` does not exist — and
+/// where a column of that name happens to exist, the DISTINCT is silently dropped.
+#[test]
+fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+    ]);
+
+    // count(DISTINCT b) — the outer aggregate groups by nothing.
+    let plan = table_scan(Some("test"), &schema, None)?
+        .aggregate(vec![col("test.b").alias("alias1")], Vec::<Expr>::new())?
+        .aggregate(Vec::<Expr>::new(), vec![count_col("alias1")])?
+        .project(vec![col("COUNT(alias1)").alias("count(DISTINCT test.b)")])?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.b AS alias1 FROM test GROUP BY test.b)"#
+    );
+
+    // a, count(DISTINCT b) ... GROUP BY a — the outer aggregate keeps its own grouping,
+    // which must not absorb the inner one.
+    let plan = table_scan(Some("test"), &schema, None)?
+        .aggregate(
+            vec![col("test.a"), col("test.b").alias("alias1")],
+            Vec::<Expr>::new(),
+        )?
+        .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
+        .project(vec![
+            col("test.a"),
+            col("COUNT(alias1)").alias("count(DISTINCT test.b)"),
+        ])?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY test.a"#
+    );
+
+    // A lone aggregate is still folded into the SELECT it belongs to.
+    let plan = table_scan(Some("test"), &schema, None)?
+        .aggregate(vec![col("test.a")], vec![count_col("test.b")])?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @"SELECT COUNT(test.b), test.a FROM test GROUP BY test.a"
+    );
+
+    Ok(())
+}

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4453,7 +4453,7 @@ fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.b AS alias1 FROM test GROUP BY test.b)"#
+        @r#"SELECT COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.b AS alias1 FROM test GROUP BY test.b) AS derived_aggregate"#
     );
 
     // a, count(DISTINCT b) ... GROUP BY a — the outer aggregate keeps its own grouping,
@@ -4471,7 +4471,7 @@ fn stacked_aggregate_is_unparsed_as_a_derived_table() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a"#
+        @r#"SELECT derived_aggregate.a, COUNT(alias1) AS "count(DISTINCT test.b)" FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a"#
     );
 
     // A lone aggregate is still folded into the SELECT it belongs to.
@@ -4509,7 +4509,7 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a"
+        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a"
     );
 
     // A qualifier nested inside a grouping expression is reached too — the projection and
@@ -4519,7 +4519,7 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), (a + 1) FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY (a + 1)"
+        @"SELECT COUNT(alias1), (derived_aggregate.a + 1) FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY (derived_aggregate.a + 1)"
     );
 
     // HAVING is built from a Filter above the aggregate and was never swept.
@@ -4529,24 +4529,26 @@ fn stacked_aggregate_requalifies_every_clause_onto_the_derived_table() -> Result
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a HAVING (a > 1)"
+        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (derived_aggregate.a > 1)"
     );
 
-    // ORDER BY was already handled by the dangling-identifier sweep; it must stay that way.
+    // A query-level ORDER BY is reached by the existing dangling-identifier sweep, which
+    // runs later and strips the qualifier rather than repointing it. It binds either way;
+    // this pins that the two mechanisms do not fight over the same clause.
     let plan = stacked()?
         .aggregate(vec![col("test.a")], vec![count_col("alias1")])?
         .sort(vec![col("test.a").sort(true, false)])?
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a ORDER BY a ASC NULLS LAST"
+        @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a ORDER BY a ASC NULLS LAST"
     );
 
     Ok(())
 }
 
-/// A dialect that requires an alias on a derived table gets the references pointed at that
-/// alias rather than stripped bare, so the emitted SQL binds under both shapes.
+/// The derived table is aliased for every dialect, so a dialect that also *requires* the
+/// alias must not end up with a second one, and its references resolve the same way.
 #[test]
 fn stacked_aggregate_requalifies_onto_a_required_derived_table_alias() -> Result<()> {
     struct AliasedDerivedTableDialect {}
@@ -4576,6 +4578,48 @@ fn stacked_aggregate_requalifies_onto_a_required_derived_table_alias() -> Result
     assert_snapshot!(
         unparser.plan_to_sql(&plan)?,
         @"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (derived_aggregate.a > 1)"
+    );
+
+    Ok(())
+}
+
+/// A join shares one `SelectBuilder` across both sides, and the join is recorded on it only
+/// after the left side has been walked — so at the point the derived table is built, this
+/// SELECT reads from more than one relation even though nothing on the builder says so yet.
+/// A reference qualified by the *other* side must keep its qualifier, and one pointed at the
+/// derived table must name it rather than go bare, since `a` here is ambiguous between the
+/// two relations.
+#[test]
+fn stacked_aggregate_under_a_join_leaves_the_other_side_qualified() -> Result<()> {
+    let left = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+    ]);
+    // `other` deliberately repeats the column name `a`.
+    let right = Schema::new(vec![Field::new("a", DataType::UInt32, false)]);
+
+    let inner_aggregate = table_scan(Some("test"), &left, None)?
+        .aggregate(vec![col("test.a")], Vec::<Expr>::new())?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(inner_aggregate)
+        .join_on(
+            table_scan(Some("other"), &right, None)?.build()?,
+            datafusion_expr::JoinType::Inner,
+            vec![col("test.a").eq(col("other.a"))],
+        )?
+        .aggregate(vec![col("other.a")], vec![count_col("test.a")])?
+        .build()?;
+
+    // `COUNT(derived_aggregate.a)` and `GROUP BY "other".a` stay distinguishable. Reducing
+    // either to a bare `a` would make the query ambiguous, and group by the wrong column.
+    //
+    // The join's `ON` still reads `test.a`: it is built as part of the join and attached
+    // after this SELECT's clauses, so it is not among the clauses that are swept. That is
+    // unchanged by the requalification and is tracked as its own gap.
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT COUNT(derived_aggregate.a), "other".a FROM (SELECT test.a FROM test GROUP BY test.a) AS derived_aggregate INNER JOIN "other" ON (test.a = "other".a) GROUP BY "other".a"#
     );
 
     Ok(())
@@ -4622,7 +4666,7 @@ fn stacked_aggregate_leaves_a_correlated_outer_reference_alone() -> Result<()> {
     // clauses that hold no subquery.
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT COUNT(alias1), a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) GROUP BY a HAVING (test.a > (SELECT COUNT("other".c) FROM "other" WHERE ("other".c = test.a)))"#
+        @r#"SELECT COUNT(alias1), derived_aggregate.a FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate GROUP BY derived_aggregate.a HAVING (test.a > (SELECT COUNT("other".c) FROM "other" WHERE ("other".c = test.a)))"#
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4616,7 +4616,8 @@ fn stacked_aggregate_under_a_join_leaves_the_other_side_qualified() -> Result<()
     //
     // The join's `ON` still reads `test.a`: it is built as part of the join and attached
     // after this SELECT's clauses, so it is not among the clauses that are swept. That is
-    // unchanged by the requalification and is tracked as its own gap.
+    // unchanged by the requalification and is tracked as spiceai/spiceai#12695; pinning it
+    // here keeps the gap visible rather than silent.
     assert_snapshot!(
         plan_to_sql(&plan)?,
         @r#"SELECT COUNT(derived_aggregate.a), "other".a FROM (SELECT test.a FROM test GROUP BY test.a) AS derived_aggregate INNER JOIN "other" ON (test.a = "other".a) GROUP BY "other".a"#


### PR DESCRIPTION
## Summary (root cause)

A `SELECT` expresses a single grouping, but the `LogicalPlan::Aggregate` arm of
`select_to_sql_recursively` recursed straight into its input whenever the select list had
already been built (`select.already_projected()`), so a **second aggregate stacked
underneath was skipped entirely** — its `GROUP BY` never reached the emitted SQL. The
`Sort`, `Limit`, `Distinct` and `Projection` arms all guard the same situation by emitting
a derived table; `Aggregate` did not.

`single_distinct_to_groupby` produces exactly that shape for `count(DISTINCT c)`: an outer
`count(alias1)` over an inner `Aggregate` grouping by `c AS alias1`. Unparsing the
optimized plan for `SELECT count(DISTINCT "UserID") FROM hits` therefore emitted

```sql
SELECT count(alias1) AS c FROM hits          -- inner GROUP BY silently gone
```

Two consequences, both bad:

1. `alias1` does not exist on the base table, so a consumer that pushes the optimized plan
   down to a remote engine gets a binder error (`Referenced column "alias1" not found in
   FROM clause`). This is the failure reported downstream in spiceai/spiceai#8475 against
   ClickBench q5 on DuckDB.
2. Where a column of that name *does* exist, the statement binds and the `DISTINCT` is
   silently gone — `count(alias1)` counts every row.

## Changes

- `SelectBuilder` tracks whether an aggregate has been folded into the current SELECT
  (`mark_aggregated()` / `already_aggregated()`).
- The `Aggregate` arm emits a `derived_aggregate` table for a second aggregate instead of
  skipping it, matching the existing `derived_sort` / `derived_limit` / `derived_distinct` /
  `derived_projection` handling.

After the fix:

```sql
SELECT count(alias1) AS c FROM (SELECT hits."UserID" AS alias1 FROM hits GROUP BY hits."UserID")
```

## Why the existing roundtrip suites missed it

`datafusion/core/tests/sql/unparser.rs` runs the TPC-H and ClickBench queries through
`df.logical_plan()` — the plan as the SQL planner produces it, **before**
`single_distinct_to_groupby` runs. The rewrite only appears in the *optimized* plan, which
is what a federation/pushdown consumer unparses. The new test closes that gap.

## Test plan

- `cargo test -p datafusion-sql` — `stacked_aggregate_is_unparsed_as_a_derived_table`
  covers the ungrouped `count(DISTINCT b)` shape, the grouped
  `a, count(DISTINCT b) ... GROUP BY a` shape, and a lone aggregate (which must still fold
  into its SELECT rather than become a derived table).
  Result: **498 passed / 22 failed**, versus **497 / 22** on a pristine checkout of this
  base — the same 22 pre-existing failures, byte-identical output, plus the new test.
- `cargo test -p datafusion --test core_integration sql::` —
  `test_optimized_plan_roundtrip_count_distinct` unparses the **optimized** plan for
  `count(DISTINCT)` with and without a `GROUP BY`, then executes both the original and the
  unparsed SQL against the ClickBench fixture and compares the rows.
  Result: **71 passed / 29 failed**, versus **70 / 30** on the same base — the only delta
  is the new test flipping from failing to passing.
- Neutering check: with `plan.rs` reverted, both new tests fail, and the core test fails
  with `column 'alias1' not found` and the emitted SQL
  `SELECT count(alias1) AS c FROM hits_raw AS hits` — i.e. it reproduces the reported bug.

Downstream issue: spiceai/spiceai#8475


---

## Follow-up: the derived table's enclosing SELECT kept qualifiers that bind to nothing

Copilot's review found a defect in the shape above, confirmed on both threads. Once the
inner aggregate becomes a derived table, the enclosing SELECT reads from *that* and no
longer from the relation its expressions still name, so those references bind to nothing.
Only the projection and `ORDER BY` were swept for such a qualifier, and only at the top
level. Measuring each clause through this path:

| shape | before |
| --- | --- |
| `GROUP BY test.a` | `GROUP BY test.a` — dangling |
| `GROUP BY test.a + 1` | dangling in **both** the projection and the `GROUP BY`, since the sweep only matches a top-level `SelectItem::UnnamedExpr(CompoundIdentifier)` |
| `HAVING test.a > 1` | `HAVING (test.a > 1)` — dangling |
| query-level `ORDER BY` | already de-qualified — the control |

DataFusion re-plans such SQL, but PostgreSQL answers 42703 and DuckDB a Binder Error, so a
federated pushdown fails at the remote engine — the same class of failure as the original
bug, on the SQL the fix for it emits.

### Fix

The derived table now carries an alias for every dialect, and a reference is rewritten onto
that alias only when its qualifier names a relation the derived table encloses:

```sql
SELECT derived_aggregate.a, COUNT(alias1) AS "count(DISTINCT test.b)"
FROM (SELECT test.a, test.b AS alias1 FROM test GROUP BY test.a, test.b) AS derived_aggregate
GROUP BY derived_aggregate.a
```

De-qualifying to a bare column name was the first attempt and is wrong under a join.
`LogicalPlan::Join` passes the same `SelectBuilder` into the left-side recursion and records
the join on it only *after* that recursion returns, so at the point the derived table is
built nothing on the builder shows that the SELECT reads from two relations. With a column
name shared by both sides it produced

```sql
SELECT COUNT(a), a FROM (SELECT test.a FROM test GROUP BY test.a) INNER JOIN "other" ON (test.a = "other".a) GROUP BY a
```

— `count(test.a)` reduced to `COUNT(a)` and `GROUP BY other.a` to `GROUP BY a`, which is
ambiguous and groups by a different column than the plan. Worse than the unbindable
qualifier it replaced, hence the alias plus the qualifier test.

The clauses are reached through one `SelectBuilder::visit_expressions_in_clauses_mut` rather
than new per-clause getters, so the builder's fields stay private.

### Deliberate limitation

An expression holding a subquery is skipped whole. A correlated subquery names an enclosing
query's relation with a qualifier indistinguishable by name — in
`HAVING test.a > (SELECT … WHERE other.c = test.a)` both are `test.a` — so rewriting inside
one repointed the correlated reference at the derived table and silently changed which
column it read. Such an expression therefore keeps its own dangling qualifier, which is the
pre-existing output: a loud bind error at the remote engine rather than wrong rows.

Also unchanged: a join's `ON` is attached after this SELECT's clauses and so is not swept —
filed as spiceai/spiceai#12695, with the join test pinning the current output so the gap
stays visible.

### Two derived aggregates on one join

A join walks both of its sides with one `SelectBuilder`, so both sides can carry a stacked
aggregate and derive a table into the same `FROM` clause. Under a fixed alias both were
named `derived_aggregate`, which is a duplicate table name most engines reject — and,
underneath that, each side requalifies its own references onto its own alias, so the two
sides' distinct columns collapsed onto one qualifier. Where the column name is shared that
binds successfully and groups by whichever side was walked first, i.e. wrong rows rather
than a loud error.

The alias is therefore numbered per SELECT (`derived_aggregate_1`, `derived_aggregate_2`,
…), following the `_unnest_N` precedent already on `SelectBuilder` — the right scope
precisely because it is the object shared across a join.

### Test plan

- `cargo test -p datafusion-sql` — **506 passed / 22 failed**. The failing set *and its
  per-snapshot content* are byte-identical to a pristine `spiceai-54`, whose 22 failures are
  pre-existing.
- `cargo test -p datafusion --test core_integration sql::unparser` — **3 passed**, including
  the TPC-H and ClickBench roundtrips and `test_optimized_plan_roundtrip_count_distinct`.
- `cargo clippy -p datafusion-sql --all-targets` — no new warnings.
- Five new tests: every clause requalified (including a nested qualifier and `HAVING`), a
  dialect that requires a derived-table alias, the join case, the correlated subquery, and
  stacked aggregates on *both* join sides — that last one uses a column name shared by both
  sides deliberately, so a collapsed qualifier still binds and the test has to catch the
  silent-wrong-side case rather than only a bind error.
- **Neuter matrix 8/8** — skipping requalification, dropping `GROUP BY`/`HAVING` from the
  swept clauses, matching only top-level expressions, dropping the qualifier guard, using a
  bare name instead of the alias, leaving the derived table unaliased, and (control)
  removing the subquery guard are each caught by the test written for them.
- For the alias numbering, a further **3/3**: freezing the counter, fixing the table alias
  while leaving the requalification target numbered, and fixing the requalification target
  while leaving the table alias numbered are all caught. Because the alias appears in every
  snapshot those neuters fail the whole set, so the load-bearing check is separate and
  direct: the new both-sides test was run against the pre-fix commit and fails there,
  emitting the duplicate alias and the collapsed qualifier.


