### PR TITLE
fix(unparser): Ensure filters on outer joins are kept on the appropriate side

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -330,6 +330,13 @@ impl SelectBuilder {
 
         self
     }
+
+    /// Removes the `WHERE` predicate accumulated so far and returns it, so a
+    /// caller can tell what a sub-plan contributed and re-place it elsewhere.
+    pub fn take_selection(&mut self) -> Option<ast::Expr> {
+        self.selection.take()
+    }
+
     pub fn group_by(&mut self, value: ast::GroupByExpr) -> &mut Self {
         self.group_by = Some(value);
         self

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2344,7 +2344,13 @@ impl Unparser<'_> {
         // * Full — both sides are preserved, so neither clause preserves either
         //   side's filter; only a derived table would. Left in ON as before.
         let (on_scan_filters, where_scan_filters) = match join_type {
-            JoinType::Inner => (vec![], [left_scan_filters, right_scan_filters].concat()),
+            JoinType::Inner => (
+                vec![],
+                left_scan_filters
+                    .into_iter()
+                    .chain(right_scan_filters)
+                    .collect(),
+            ),
             JoinType::Left => (right_scan_filters, left_scan_filters),
             JoinType::Right => (left_scan_filters, right_scan_filters),
             // Semi/anti/mark joins do not reach this function: their filters
@@ -2355,9 +2361,13 @@ impl Unparser<'_> {
             | JoinType::LeftAnti
             | JoinType::RightAnti
             | JoinType::LeftMark
-            | JoinType::RightMark => {
-                ([left_scan_filters, right_scan_filters].concat(), vec![])
-            }
+            | JoinType::RightMark => (
+                left_scan_filters
+                    .into_iter()
+                    .chain(right_scan_filters)
+                    .collect(),
+                vec![],
+            ),
         };
 
         if on_scan_filters.is_empty() {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1092,16 +1092,29 @@ impl Unparser<'_> {
                     select.selection(Some(filter_expr));
                 }
 
-                let join_constraint = self.join_constraint_to_sql(
+                let mut join_constraint = self.join_constraint_to_sql(
                     join.join_constraint,
                     &join.on,
                     join_filters.as_ref(),
                 )?;
+                // `USING`/`NATURAL` cannot carry an extra predicate. Normally
+                // the predicate goes back where it was, since nothing is
+                // gained by mangling the join — but a predicate hoisted from
+                // the non-preserved side of a null-extending join has nowhere
+                // else to go: returning it to the SELECT-global `WHERE` would
+                // discard unmatched rows from the preserved side. Downgrade
+                // to an equivalent `ON` constraint so it can be appended.
+                if hoisted_from_left.is_some()
+                    && matches!(
+                        join_constraint,
+                        ast::JoinConstraint::Using(_) | ast::JoinConstraint::Natural
+                    )
+                {
+                    join_constraint =
+                        self.join_conditions_to_sql_on(&join.on, join_filters.as_ref())?;
+                }
                 let (join_constraint, unhoistable) =
                     Self::and_into_join_constraint(join_constraint, hoisted_from_left);
-                // `USING`/`NATURAL` cannot carry an extra predicate. Nothing is
-                // gained by mangling the join, so the predicate goes back where
-                // it was.
                 select.selection(unhoistable);
 
                 let right_projection: Option<Vec<ast::SelectItem>> =

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -994,12 +994,35 @@ impl Unparser<'_> {
                         None => Arc::clone(left_plan),
                     };
 
+                // A join that null-extends its left input must not let a
+                // predicate from that subtree reach the SELECT-global `WHERE`:
+                // `WHERE` is evaluated after this join and would discard the
+                // very rows this join preserves. Set the accumulated predicate
+                // aside, see what the left subtree adds, and fold that into
+                // this join's `ON` instead (where, for the non-preserved side,
+                // it means the same thing).
+                let left_is_null_extended =
+                    matches!(join.join_type, JoinType::Right | JoinType::Full);
+                let outer_selection = if left_is_null_extended {
+                    select.take_selection()
+                } else {
+                    None
+                };
+
                 self.select_to_sql_recursively(
                     left_plan.as_ref(),
                     query,
                     select,
                     relation,
                 )?;
+
+                let hoisted_from_left = if left_is_null_extended {
+                    let contributed = select.take_selection();
+                    select.selection(outer_selection);
+                    contributed
+                } else {
+                    None
+                };
 
                 let left_projection: Option<Vec<ast::SelectItem>> = if !already_projected
                 {
@@ -1071,6 +1094,12 @@ impl Unparser<'_> {
                     &join.on,
                     join_filters.as_ref(),
                 )?;
+                let (join_constraint, unhoistable) =
+                    Self::and_into_join_constraint(join_constraint, hoisted_from_left);
+                // `USING`/`NATURAL` cannot carry an extra predicate. Nothing is
+                // gained by mangling the join, so the predicate goes back where
+                // it was.
+                select.selection(unhoistable);
 
                 let right_projection: Option<Vec<ast::SelectItem>> =
                     if !already_projected && !is_exists_join {
@@ -2258,6 +2287,33 @@ impl Unparser<'_> {
         let mut select = SelectBuilder::default();
         select.push_from(from);
         Ok(select.build()?)
+    }
+
+    /// AND-folds `predicate` into a join's `ON` clause.
+    ///
+    /// Returns the constraint together with the predicate it could not take:
+    /// `USING` and `NATURAL` joins have nowhere to put one.
+    fn and_into_join_constraint(
+        constraint: ast::JoinConstraint,
+        predicate: Option<ast::Expr>,
+    ) -> (ast::JoinConstraint, Option<ast::Expr>) {
+        let Some(predicate) = predicate else {
+            return (constraint, None);
+        };
+
+        match constraint {
+            ast::JoinConstraint::On(existing) => (
+                ast::JoinConstraint::On(ast::Expr::BinaryOp {
+                    left: Box::new(existing),
+                    op: ast::BinaryOperator::And,
+                    right: Box::new(predicate),
+                }),
+                None,
+            ),
+            ast::JoinConstraint::None => (ast::JoinConstraint::On(predicate), None),
+            constraint @ (ast::JoinConstraint::Using(_)
+            | ast::JoinConstraint::Natural) => (constraint, Some(predicate)),
+        }
     }
 
     /// Decides where the table-scan filters extracted from a join's two inputs

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -969,7 +969,11 @@ impl Unparser<'_> {
                 self.select_to_sql_recursively(input, query, select, relation)
             }
             LogicalPlan::Join(join) => {
-                let mut table_scan_filters = vec![];
+                // Kept apart by input: where a filter may be re-emitted depends
+                // on which side of the join it came from (see
+                // `split_join_on_and_where_filters`).
+                let mut left_scan_filters = vec![];
+                let mut right_scan_filters = vec![];
                 let (left_plan, right_plan) = match join.join_type {
                     JoinType::RightSemi | JoinType::RightAnti => {
                         (&join.right, &join.left)
@@ -984,7 +988,7 @@ impl Unparser<'_> {
                 let left_plan =
                     match try_transform_to_simple_table_scan_with_filters(left_plan)? {
                         Some((plan, filters)) => {
-                            table_scan_filters.extend(filters);
+                            left_scan_filters.extend(filters);
                             Arc::new(plan)
                         }
                         None => Arc::clone(left_plan),
@@ -1027,7 +1031,7 @@ impl Unparser<'_> {
                     let right_plan =
                         match try_transform_to_simple_table_scan_with_filters(right_plan)? {
                             Some((plan, filters)) => {
-                                table_scan_filters.extend(filters);
+                                right_scan_filters.extend(filters);
                                 Arc::new(plan)
                             }
                             None => Arc::clone(right_plan),
@@ -1044,15 +1048,17 @@ impl Unparser<'_> {
 
                 // Table-scan filters extracted from the inputs must land in the
                 // outer query. EXISTS-style joins have no outer `ON` clause, so
-                // all such filters go to the outer `WHERE`; regular joins split
-                // them between `ON` and `WHERE`.
+                // all such filters go to the outer `WHERE` (only the preserved
+                // side is transformed above, so `right_scan_filters` is empty);
+                // regular joins split them between `ON` and `WHERE`.
                 let (join_filters, where_filters) = if is_exists_join {
-                    (join.filter.clone(), table_scan_filters)
+                    (join.filter.clone(), left_scan_filters)
                 } else {
                     Self::split_join_on_and_where_filters(
                         join.join_type,
                         &join.filter,
-                        table_scan_filters,
+                        left_scan_filters,
+                        right_scan_filters,
                     )
                 };
                 for filter in where_filters {
@@ -2254,31 +2260,55 @@ impl Unparser<'_> {
         Ok(select.build()?)
     }
 
-    /// Decides where extracted table-scan filters belong in the unparsed SQL:
-    /// in the `JOIN ON` clause or in `WHERE`.
+    /// Decides where the table-scan filters extracted from a join's two inputs
+    /// belong in the unparsed SQL: in the `JOIN ON` clause or in `WHERE`.
     ///
-    /// For inner joins the two are semantically equivalent, so filters go to
-    /// `WHERE` (some dialects reject subqueries inside `JOIN ON`).
-    /// For outer joins the filters are AND-folded into `ON` to preserve correctness.
+    /// The answer depends on the join type *and* on which input the filter came
+    /// from — a filter on a preserved side means something different in `ON`
+    /// than in `WHERE`. Filters routed to `ON` are AND-folded onto the join's
+    /// own filter.
     ///
     /// Returns `(on_filter, where_filters)`.
     fn split_join_on_and_where_filters(
         join_type: JoinType,
         join_filter: &Option<Expr>,
-        table_scan_filters: Vec<Expr>,
+        left_scan_filters: Vec<Expr>,
+        right_scan_filters: Vec<Expr>,
     ) -> (Option<Expr>, Vec<Expr>) {
-        if table_scan_filters.is_empty() {
-            return (join_filter.clone(), vec![]);
+        // Which clause preserves a filter's meaning depends on the side it came
+        // from:
+        //
+        // * Inner — ON and WHERE are equivalent, so both sides go to WHERE
+        //   (some dialects reject subqueries inside JOIN ON).
+        // * Left/Right — the preserved side keeps every row whatever ON says,
+        //   so folding its filter into ON would filter nothing at all; it has
+        //   to go to WHERE. The non-preserved side is the mirror image: WHERE
+        //   would discard the null-extended rows and silently turn the outer
+        //   join into an inner join, so its filter has to stay in ON.
+        // * Full — both sides are preserved, so neither clause preserves either
+        //   side's filter; only a derived table would. Left in ON as before.
+        let (on_scan_filters, where_scan_filters) = match join_type {
+            JoinType::Inner => (vec![], [left_scan_filters, right_scan_filters].concat()),
+            JoinType::Left => (right_scan_filters, left_scan_filters),
+            JoinType::Right => (left_scan_filters, right_scan_filters),
+            // Semi/anti/mark joins do not reach this function: their filters
+            // are routed by the EXISTS branch of `select_to_sql_recursively`.
+            JoinType::Full
+            | JoinType::LeftSemi
+            | JoinType::RightSemi
+            | JoinType::LeftAnti
+            | JoinType::RightAnti
+            | JoinType::LeftMark
+            | JoinType::RightMark => {
+                ([left_scan_filters, right_scan_filters].concat(), vec![])
+            }
+        };
+
+        if on_scan_filters.is_empty() {
+            return (join_filter.clone(), where_scan_filters);
         }
 
-        if join_type == JoinType::Inner {
-            // ON and WHERE are equivalent for inner joins; prefer WHERE
-            // because some dialects reject subqueries inside JOIN ON.
-            return (join_filter.clone(), table_scan_filters);
-        }
-
-        // Outer joins: fold table-scan filters into ON to preserve semantics.
-        let combined = table_scan_filters.into_iter().reduce(|acc, filter| {
+        let combined = on_scan_filters.into_iter().reduce(|acc, filter| {
             Expr::BinaryExpr(BinaryExpr {
                 left: Box::new(acc),
                 op: Operator::And,
@@ -2297,7 +2327,7 @@ impl Unparser<'_> {
             (None, None) => None,
         };
 
-        (on_filter, vec![])
+        (on_filter, where_scan_filters)
     }
 }
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -448,6 +448,40 @@ impl Unparser<'_> {
         }
     }
 
+    /// Isolates a `FULL JOIN` input's table-scan filters in a derived table:
+    /// `(SELECT ... FROM t WHERE ...) AS t`. A `FULL JOIN` preserves both
+    /// sides, so a filter on just one input cannot be expressed by folding it
+    /// into `ON` (filtered-out rows would reappear as unmatched) or by moving
+    /// it to `WHERE` (the other side's unmatched rows would be discarded);
+    /// pre-filtering that side in its own subquery is the only clause that
+    /// preserves the original meaning.
+    ///
+    /// `clean_plan` is the `TableScan`/`SubqueryAlias` produced by
+    /// `try_transform_to_simple_table_scan_with_filters`, and `scan_filters`
+    /// are the filters it extracted. `relation` already holds the plain
+    /// table reference built for this side; it is overwritten with the
+    /// derived subquery.
+    fn derive_full_join_side(
+        &self,
+        clean_plan: &LogicalPlan,
+        scan_filters: Vec<Expr>,
+        relation: &mut RelationBuilder,
+    ) -> Result<()> {
+        let Some(combined) = scan_filters.into_iter().reduce(Expr::and) else {
+            return Ok(());
+        };
+        let filtered_plan = LogicalPlanBuilder::from(clean_plan.clone())
+            .filter(combined)?
+            .build()?;
+        let alias = match clean_plan {
+            LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
+            LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
+            _ => None,
+        }
+        .map(|table_ref| self.new_table_alias(table_ref.table().to_string(), vec![]));
+        self.derive(&filtered_plan, relation, alias, false)
+    }
+
     /// Projection unparsing when [`super::dialect::Dialect::unnest_as_lateral_flatten`] is enabled:
     /// Snowflake-style `LATERAL FLATTEN` for unnest (not other dialect spellings).
     ///
@@ -1019,6 +1053,20 @@ impl Unparser<'_> {
                     relation,
                 )?;
 
+                // A FULL JOIN preserves both sides, so neither `ON` nor
+                // `WHERE` can express a filter that came from just one
+                // side's `TableScan` (see `split_join_on_and_where_filters`).
+                // Isolate that side in a derived table instead, and drop the
+                // filters from `left_scan_filters` so they are not also
+                // routed to `ON`/`WHERE` below.
+                if join.join_type == JoinType::Full && !left_scan_filters.is_empty() {
+                    self.derive_full_join_side(
+                        left_plan.as_ref(),
+                        std::mem::take(&mut left_scan_filters),
+                        relation,
+                    )?;
+                }
+
                 let hoisted_from_left = if left_is_null_extended {
                     let contributed = select.take_selection();
                     select.selection(outer_selection);
@@ -1069,6 +1117,14 @@ impl Unparser<'_> {
                         select,
                         &mut right_relation,
                     )?;
+                    if join.join_type == JoinType::Full && !right_scan_filters.is_empty()
+                    {
+                        self.derive_full_join_side(
+                            right_plan.as_ref(),
+                            std::mem::take(&mut right_scan_filters),
+                            &mut right_relation,
+                        )?;
+                    }
                     right_plan
                 };
 
@@ -2358,7 +2414,9 @@ impl Unparser<'_> {
         //   would discard the null-extended rows and silently turn the outer
         //   join into an inner join, so its filter has to stay in ON.
         // * Full — both sides are preserved, so neither clause preserves either
-        //   side's filter; only a derived table would. Left in ON as before.
+        //   side's filter; only a derived table does. The caller isolates a
+        //   `FULL JOIN`'s filtered side in one before reaching this function,
+        //   so `left_scan_filters`/`right_scan_filters` are always empty here.
         let (on_scan_filters, where_scan_filters) = match join_type {
             JoinType::Inner => (
                 vec![],

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1001,8 +1001,11 @@ impl Unparser<'_> {
                 // aside, see what the left subtree adds, and fold that into
                 // this join's `ON` instead (where, for the non-preserved side,
                 // it means the same thing).
-                let left_is_null_extended =
-                    matches!(join.join_type, JoinType::Right | JoinType::Full);
+                // This relocation is only valid when the left input is not
+                // preserved. A FULL JOIN also null-extends its left input, but
+                // preserves left rows, so moving the predicate into ON would
+                // make filtered-out left rows reappear as unmatched rows.
+                let left_is_null_extended = matches!(join.join_type, JoinType::Right);
                 let outer_selection = if left_is_null_extended {
                     select.take_selection()
                 } else {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2059,6 +2059,122 @@ fn test_join_with_table_scan_filters() -> Result<()> {
 }
 
 #[test]
+fn test_outer_join_with_table_scan_filters() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let left_with_filter = || {
+        table_scan_with_filters(
+            Some("left_table"),
+            &schema_left,
+            Some(vec![0, 1]),
+            vec![col("left_table.id").eq(lit("a"))],
+        )?
+        .build()
+    };
+    let right_with_filter = || {
+        table_scan_with_filters(
+            Some("right_table"),
+            &schema_right,
+            Some(vec![0, 1]),
+            vec![col("right_table.age").gt(lit(10))],
+        )?
+        .build()
+    };
+    let plain_left =
+        || table_scan(Some("left_table"), &schema_left, Some(vec![0, 1]))?.build();
+    let plain_right =
+        || table_scan(Some("right_table"), &schema_right, Some(vec![0, 1]))?.build();
+
+    // LEFT JOIN, filter on the preserved (left) side: it must land in WHERE.
+    // Folding it into `ON` would not remove a single row, because a LEFT JOIN
+    // preserves every left row regardless of the `ON` predicate.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            plain_right()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN right_table ON left_table.id = right_table.id WHERE (left_table.id = 'a')"#
+    );
+
+    // LEFT JOIN, filter on the non-preserved (right) side: it must stay in
+    // `ON`. Moving it to WHERE would discard the null-extended rows and turn
+    // the LEFT JOIN into an INNER JOIN.
+    let plan = LogicalPlanBuilder::from(plain_left()?)
+        .join(
+            right_with_filter()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN right_table ON left_table.id = right_table.id AND (right_table.age > 10)"#
+    );
+
+    // LEFT JOIN with a filter on each side: the two are routed to different
+    // clauses, and neither is dropped.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            right_with_filter()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN right_table ON left_table.id = right_table.id AND (right_table.age > 10) WHERE (left_table.id = 'a')"#
+    );
+
+    // RIGHT JOIN is the mirror image: the right side is preserved.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            right_with_filter()?,
+            datafusion_expr::JoinType::Right,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table RIGHT OUTER JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a') WHERE (right_table.age > 10)"#
+    );
+
+    // FULL OUTER JOIN preserves both sides, so neither `ON` nor `WHERE`
+    // expresses either side's filter; a derived table would be needed. The
+    // existing `ON` placement is kept unchanged — this case is still wrong and
+    // is tracked separately.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            plain_right()?,
+            datafusion_expr::JoinType::Full,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a')"#
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_interval_lhs_eq() {
     let statement = generate_round_trip_statement(
         GenericDialect {},

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2155,9 +2155,9 @@ fn test_outer_join_with_table_scan_filters() -> Result<()> {
     );
 
     // FULL OUTER JOIN preserves both sides, so neither `ON` nor `WHERE`
-    // expresses either side's filter; a derived table would be needed. The
-    // existing `ON` placement is kept unchanged — this case is still wrong and
-    // is tracked separately.
+    // expresses an input filter correctly. Isolate the filtered input in a
+    // derived table so rows rejected by the filter cannot reappear as unmatched
+    // rows from the FULL JOIN.
     let plan = LogicalPlanBuilder::from(left_with_filter()?)
         .join(
             plain_right()?,
@@ -2168,7 +2168,7 @@ fn test_outer_join_with_table_scan_filters() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a')"#
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM (SELECT left_table.id, left_table."name" FROM left_table WHERE (left_table.id = 'a')) AS left_table FULL JOIN right_table ON left_table.id = right_table.id"#
     );
 
     // The aliased form: the filter is rewritten to the alias on its way out of
@@ -4477,6 +4477,48 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
             datafusion_expr::JoinType::Full,
         )?,
         @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id FULL JOIN c ON a.id = c.id WHERE (a.id = 'x')"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_join_filter_nested_under_right_join_using() -> Result<()> {
+    // USING cannot carry the predicate contributed by the non-preserved left
+    // input. It must be downgraded to an equivalent ON constraint before the
+    // predicate is appended; returning the predicate to the SELECT-global
+    // WHERE would discard unmatched rows from the preserved right input.
+    let id_schema = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
+    let b_schema = Schema::new(vec![Field::new("b_id", DataType::Utf8, false)]);
+    let a = table_scan_with_filters(
+        Some("a"),
+        &id_schema,
+        Some(vec![0]),
+        vec![col("a.id").eq(lit("x"))],
+    )?
+    .build()?;
+    let b = table_scan(Some("b"), &b_schema, Some(vec![0]))?.build()?;
+    let c = table_scan(Some("c"), &id_schema, Some(vec![0]))?.build()?;
+
+    let inner = LogicalPlanBuilder::from(a)
+        .join(
+            b,
+            datafusion_expr::JoinType::Inner,
+            (vec!["a.id"], vec!["b.b_id"]),
+            None,
+        )?
+        .build()?;
+    let outer = LogicalPlanBuilder::from(inner)
+        .join_using(
+            c,
+            datafusion_expr::JoinType::Right,
+            vec![Column::new_unqualified("id")],
+        )?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&outer)?,
+        @"SELECT a.id, b.b_id, c.id FROM a INNER JOIN b ON a.id = b.b_id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4416,10 +4416,11 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
 
 #[test]
 fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
-    // A predicate extracted from a nested join's input must not reach the
-    // SELECT-global `WHERE` when an enclosing join null-extends that input:
-    // `WHERE` runs after every join and would discard the rows the enclosing
-    // join is there to preserve. It belongs in the enclosing join's `ON`.
+    // When an enclosing RIGHT JOIN null-extends a nested left input, a predicate
+    // from that input must not reach the SELECT-global `WHERE`: `WHERE` runs
+    // after every join and would discard the preserved right-side rows. It
+    // belongs in the enclosing join's `ON` because the left input is not
+    // preserved. FULL JOIN differs because it preserves both inputs.
     let schema = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
     let a = table_scan_with_filters(
         Some("a"),
@@ -4431,7 +4432,7 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
     let b = table_scan(Some("b"), &schema, Some(vec![0]))?.build()?;
     let c = table_scan(Some("c"), &schema, Some(vec![0]))?.build()?;
 
-    let nested_under_right = |inner_join_type| -> Result<String> {
+    let nested_under_outer = |inner_join_type, outer_join_type| -> Result<String> {
         let inner = LogicalPlanBuilder::from(a.clone())
             .join(
                 b.clone(),
@@ -4443,7 +4444,7 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
         let outer = LogicalPlanBuilder::from(inner)
             .join(
                 c.clone(),
-                datafusion_expr::JoinType::Right,
+                outer_join_type,
                 (vec!["a.id"], vec!["c.id"]),
                 None,
             )?
@@ -4452,12 +4453,30 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
     };
 
     assert_snapshot!(
-        nested_under_right(datafusion_expr::JoinType::Inner)?,
+        nested_under_outer(
+            datafusion_expr::JoinType::Inner,
+            datafusion_expr::JoinType::Right,
+        )?,
         @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
     );
     assert_snapshot!(
-        nested_under_right(datafusion_expr::JoinType::Left)?,
+        nested_under_outer(
+            datafusion_expr::JoinType::Left,
+            datafusion_expr::JoinType::Right,
+        )?,
         @"SELECT a.id, b.id, c.id FROM a LEFT OUTER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+
+    // A FULL JOIN also null-extends its left input, but unlike a RIGHT JOIN it
+    // preserves that input. Hoisting the predicate into ON would therefore
+    // make filtered-out left rows reappear as unmatched rows. Keep the prior
+    // WHERE placement until FULL JOIN inputs can be emitted as derived tables.
+    assert_snapshot!(
+        nested_under_outer(
+            datafusion_expr::JoinType::Inner,
+            datafusion_expr::JoinType::Full,
+        )?,
+        @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id FULL JOIN c ON a.id = c.id WHERE (a.id = 'x')"
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2171,6 +2171,29 @@ fn test_outer_join_with_table_scan_filters() -> Result<()> {
         @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a')"#
     );
 
+    // The aliased form: the filter is rewritten to the alias on its way out of
+    // the scan, and must still land in WHERE.
+    let aliased_left = table_scan_with_filters(
+        Some("left_table"),
+        &schema_left,
+        Some(vec![0, 1]),
+        vec![col("left_table.id").eq(lit("a"))],
+    )?
+    .alias("l")?
+    .build()?;
+    let plan = LogicalPlanBuilder::from(aliased_left)
+        .join(
+            plain_right()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["l.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT l.id, l."name", right_table.id, right_table.age FROM left_table AS l LEFT OUTER JOIN right_table ON l.id = right_table.id WHERE (l.id = 'a')"#
+    );
+
     Ok(())
 }
 
@@ -4388,5 +4411,54 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
         sql,
         @r#"SELECT DISTINCT * FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "left" WHERE EXISTS (SELECT 1 FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "right" WHERE ("left"."first_name" = "right"."first_name") AND ("left"."order_id" = "right"."order_id")) AND EXISTS (SELECT 1 FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id") WHERE ("left"."first_name" = "p"."first_name") AND ("left"."order_id" = "o"."order_id"))"#
     );
+    Ok(())
+}
+
+#[test]
+fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
+    // A predicate extracted from a nested join's input must not reach the
+    // SELECT-global `WHERE` when an enclosing join null-extends that input:
+    // `WHERE` runs after every join and would discard the rows the enclosing
+    // join is there to preserve. It belongs in the enclosing join's `ON`.
+    let schema = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
+    let a = table_scan_with_filters(
+        Some("a"),
+        &schema,
+        Some(vec![0]),
+        vec![col("a.id").eq(lit("x"))],
+    )?
+    .build()?;
+    let b = table_scan(Some("b"), &schema, Some(vec![0]))?.build()?;
+    let c = table_scan(Some("c"), &schema, Some(vec![0]))?.build()?;
+
+    let nested_under_right = |inner_join_type| -> Result<String> {
+        let inner = LogicalPlanBuilder::from(a.clone())
+            .join(
+                b.clone(),
+                inner_join_type,
+                (vec!["a.id"], vec!["b.id"]),
+                None,
+            )?
+            .build()?;
+        let outer = LogicalPlanBuilder::from(inner)
+            .join(
+                c.clone(),
+                datafusion_expr::JoinType::Right,
+                (vec!["a.id"], vec!["c.id"]),
+                None,
+            )?
+            .build()?;
+        Ok(plan_to_sql(&outer)?.to_string())
+    };
+
+    assert_snapshot!(
+        nested_under_right(datafusion_expr::JoinType::Inner)?,
+        @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+    assert_snapshot!(
+        nested_under_right(datafusion_expr::JoinType::Left)?,
+        @"SELECT a.id, b.id, c.id FROM a LEFT OUTER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Problem

When the optimizer pushes a predicate into a `TableScan`, the unparser pulls it back out with `try_transform_to_simple_table_scan_with_filters` and has to decide where to re-emit it. For any non-inner join it AND-folded every extracted filter into the `JOIN ON` clause, no matter which input it came from. 

**Example**: A `LEFT JOIN` keeps every left row regardless of the `ON` condition. If a filter is from the LHS, it does not filtering. The plan

```sql
SELECT x, y, z 
FROM a
LEFT JOIN  b ON  a.id = b.id
WHERE a.id='foo'
```

Logical Plan
```
Left Join: a.id = b.id
  Filter: a.id = 'x'
    TableScan: a
  TableScan: b
```

Unparsed to

```sql
SELECT  x, y, z  
FROM a 
LEFT OUTER JOIN b 
ON 
  a.id = b.id AND 
  (a.id = 'x')
```

which returns all rows from `a` (due to being a left join). Equivalent problem for RHS filters and right join.

Inner joins were addressed in #21694 (upstream apache/datafusion#13156 tracks the general problem and explicitly left outer joins as future work).

## Changes

The two inputs' extracted filters are now tracked separately and routed by join type:

| join type | preserved side | filters from the left input | filters from the right input |
|---|---|---|---|
| `Inner` | — | `WHERE` | `WHERE` |
| `Left` | left | **`WHERE`** | `ON` |
| `Right` | right | `ON` | **`WHERE`** |
| `Full` | both | derived subquery | derived subquery |

Important notes:
 - Moving a non-preserved-side filter to `WHERE` would discard the null-extended rows.
 - Neither `ON` nor `WHERE` can express a  single side's filter for a `Full` join type (must filter the table prior to join - using a subquery).

## Second commit: the SELECT-global `WHERE`
This implementation uncovered an issue for this second order JOIN type.

A `LogicalPlan` of:
```
Right Join: (a INNER JOIN b) preserved=c, non-preserved=(a JOIN b)
    Inner Join: a.id = b.id
      Filter: a.id = 'x'
        TableScan: a
      TableScan: b
    TableScan: c
```

become unparsed incorrectly
```
SELECT ... FROM a INNER JOIN b ON a.id = b.id
                  RIGHT OUTER JOIN c 
                  ON ...
           WHERE a.id = 'x'
```
But we should 
```
SELECT ... FROM a INNER JOIN b ON a.id = b.id
                    RIGHT OUTER JOIN c 
                    ON ... AND a.id = 'x'
```

The fix is that at every Right join, keep filter predicates from LHS as ON clauses for the Join (not the largest/overall WHERE).