### PR TITLE
fix(unparser): keep a fetch pushed into a join input, in its own scope

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -330,6 +330,13 @@ impl SelectBuilder {
 
         self
     }
+
+    /// Removes the `WHERE` predicate accumulated so far and returns it, so a
+    /// caller can tell what a sub-plan contributed and re-place it elsewhere.
+    pub fn take_selection(&mut self) -> Option<ast::Expr> {
+        self.selection.take()
+    }
+
     pub fn group_by(&mut self, value: ast::GroupByExpr) -> &mut Self {
         self.group_by = Some(value);
         self

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -462,40 +462,62 @@ impl Unparser<'_> {
     ///   output, not one input's contribution to it.
     ///
     /// Pre-filtering that side in its own subquery is the only clause that
-    /// preserves the original meaning. Note that whenever a `fetch` is
-    /// isolated the filters must come with it: filtering after the limit
-    /// returns fewer rows than the plan asked for.
+    /// preserves the original meaning.
+    ///
+    /// The filters go on the side of the limit they came from. The scan's own
+    /// filters run before its `fetch`; a `Filter` node above the scan runs
+    /// after it, and needs a second scope of its own — the same `SELECT`
+    /// cannot express it, because `WHERE` is evaluated before `LIMIT`.
     ///
     /// `clean_plan` is the `TableScan`/`SubqueryAlias` produced by
-    /// `try_transform_to_simple_table_scan_with_filters`, and `scan_filters`
-    /// and `fetch` are what it extracted. `relation` already holds the plain
-    /// table reference built for this side; it is overwritten with the
-    /// derived subquery.
+    /// `try_transform_to_simple_table_scan_with_filters`; `filters` is
+    /// everything it extracted and `scan_filters` the subset belonging to the
+    /// scan. `relation` already holds the plain table reference built for this
+    /// side; it is overwritten with the derived subquery.
     fn derive_join_side(
         &self,
         clean_plan: &LogicalPlan,
-        scan_filters: Vec<Expr>,
+        filters: Vec<Expr>,
+        scan_filters: &[Expr],
         fetch: Option<usize>,
         relation: &mut RelationBuilder,
     ) -> Result<()> {
-        let combined = scan_filters.into_iter().reduce(Expr::and);
-        if combined.is_none() && fetch.is_none() {
+        if filters.is_empty() && fetch.is_none() {
             return Ok(());
         }
+        let table_ref = match clean_plan {
+            LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
+            LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
+            _ => None,
+        };
+        let (below_fetch, above_fetch): (Vec<Expr>, Vec<Expr>) = if fetch.is_some() {
+            filters
+                .into_iter()
+                .partition(|filter| scan_filters.contains(filter))
+        } else {
+            // Without a limit between them the two sets commute, so keep them
+            // in one `WHERE` in the order they were collected.
+            (filters, vec![])
+        };
+
         let mut builder = LogicalPlanBuilder::from(clean_plan.clone());
-        if let Some(combined) = combined {
+        if let Some(combined) = below_fetch.into_iter().reduce(Expr::and) {
             builder = builder.filter(combined)?;
         }
         if let Some(fetch) = fetch {
             builder = builder.limit(0, Some(fetch))?;
         }
-        let derived_plan = builder.build()?;
-        let alias = match clean_plan {
-            LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
-            LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
-            _ => None,
+        if let Some(combined) = above_fetch.into_iter().reduce(Expr::and) {
+            // The alias both scopes the limit in its own `SELECT` and keeps the
+            // predicate's column references resolvable against it.
+            if let Some(table_ref) = table_ref.clone() {
+                builder = builder.alias(table_ref)?;
+            }
+            builder = builder.filter(combined)?;
         }
-        .map(|table_ref| self.new_table_alias(table_ref.table().to_string(), vec![]));
+        let derived_plan = builder.build()?;
+        let alias = table_ref
+            .map(|table_ref| self.new_table_alias(table_ref.table().to_string(), vec![]));
         self.derive(&derived_plan, relation, alias, false)
     }
 
@@ -1037,10 +1059,12 @@ impl Unparser<'_> {
                 let already_projected = select.already_projected();
 
                 let mut left_scan_fetch = None;
+                let mut left_scan_only_filters = vec![];
                 let left_plan =
                     match try_transform_to_simple_table_scan_with_filters(left_plan)? {
                         Some(scan) => {
                             left_scan_filters.extend(scan.filters);
+                            left_scan_only_filters = scan.scan_filters;
                             left_scan_fetch = scan.fetch;
                             Arc::new(scan.plan)
                         }
@@ -1085,6 +1109,7 @@ impl Unparser<'_> {
                     self.derive_join_side(
                         left_plan.as_ref(),
                         std::mem::take(&mut left_scan_filters),
+                        &left_scan_only_filters,
                         left_scan_fetch,
                         relation,
                     )?;
@@ -1126,11 +1151,13 @@ impl Unparser<'_> {
                     Arc::clone(right_plan)
                 } else {
                     let mut right_scan_fetch = None;
+                    let mut right_scan_only_filters = vec![];
                     let right_plan =
                         match try_transform_to_simple_table_scan_with_filters(right_plan)?
                         {
                             Some(scan) => {
                                 right_scan_filters.extend(scan.filters);
+                                right_scan_only_filters = scan.scan_filters;
                                 right_scan_fetch = scan.fetch;
                                 Arc::new(scan.plan)
                             }
@@ -1150,6 +1177,7 @@ impl Unparser<'_> {
                         self.derive_join_side(
                             right_plan.as_ref(),
                             std::mem::take(&mut right_scan_filters),
+                            &right_scan_only_filters,
                             right_scan_fetch,
                             &mut right_relation,
                         )?;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2344,7 +2344,13 @@ impl Unparser<'_> {
         // * Full — both sides are preserved, so neither clause preserves either
         //   side's filter; only a derived table would. Left in ON as before.
         let (on_scan_filters, where_scan_filters) = match join_type {
-            JoinType::Inner => (vec![], [left_scan_filters, right_scan_filters].concat()),
+            JoinType::Inner => (
+                vec![],
+                left_scan_filters
+                    .into_iter()
+                    .chain(right_scan_filters)
+                    .collect(),
+            ),
             JoinType::Left => (right_scan_filters, left_scan_filters),
             JoinType::Right => (left_scan_filters, right_scan_filters),
             // Semi/anti/mark joins do not reach this function: their filters
@@ -2355,9 +2361,13 @@ impl Unparser<'_> {
             | JoinType::LeftAnti
             | JoinType::RightAnti
             | JoinType::LeftMark
-            | JoinType::RightMark => {
-                ([left_scan_filters, right_scan_filters].concat(), vec![])
-            }
+            | JoinType::RightMark => (
+                left_scan_filters
+                    .into_iter()
+                    .chain(right_scan_filters)
+                    .collect(),
+                vec![],
+            ),
         };
 
         if on_scan_filters.is_empty() {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1092,16 +1092,29 @@ impl Unparser<'_> {
                     select.selection(Some(filter_expr));
                 }
 
-                let join_constraint = self.join_constraint_to_sql(
+                let mut join_constraint = self.join_constraint_to_sql(
                     join.join_constraint,
                     &join.on,
                     join_filters.as_ref(),
                 )?;
+                // `USING`/`NATURAL` cannot carry an extra predicate. Normally
+                // the predicate goes back where it was, since nothing is
+                // gained by mangling the join — but a predicate hoisted from
+                // the non-preserved side of a null-extending join has nowhere
+                // else to go: returning it to the SELECT-global `WHERE` would
+                // discard unmatched rows from the preserved side. Downgrade
+                // to an equivalent `ON` constraint so it can be appended.
+                if hoisted_from_left.is_some()
+                    && matches!(
+                        join_constraint,
+                        ast::JoinConstraint::Using(_) | ast::JoinConstraint::Natural
+                    )
+                {
+                    join_constraint =
+                        self.join_conditions_to_sql_on(&join.on, join_filters.as_ref())?;
+                }
                 let (join_constraint, unhoistable) =
                     Self::and_into_join_constraint(join_constraint, hoisted_from_left);
-                // `USING`/`NATURAL` cannot carry an extra predicate. Nothing is
-                // gained by mangling the join, so the predicate goes back where
-                // it was.
                 select.selection(unhoistable);
 
                 let right_projection: Option<Vec<ast::SelectItem>> =

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -994,12 +994,35 @@ impl Unparser<'_> {
                         None => Arc::clone(left_plan),
                     };
 
+                // A join that null-extends its left input must not let a
+                // predicate from that subtree reach the SELECT-global `WHERE`:
+                // `WHERE` is evaluated after this join and would discard the
+                // very rows this join preserves. Set the accumulated predicate
+                // aside, see what the left subtree adds, and fold that into
+                // this join's `ON` instead (where, for the non-preserved side,
+                // it means the same thing).
+                let left_is_null_extended =
+                    matches!(join.join_type, JoinType::Right | JoinType::Full);
+                let outer_selection = if left_is_null_extended {
+                    select.take_selection()
+                } else {
+                    None
+                };
+
                 self.select_to_sql_recursively(
                     left_plan.as_ref(),
                     query,
                     select,
                     relation,
                 )?;
+
+                let hoisted_from_left = if left_is_null_extended {
+                    let contributed = select.take_selection();
+                    select.selection(outer_selection);
+                    contributed
+                } else {
+                    None
+                };
 
                 let left_projection: Option<Vec<ast::SelectItem>> = if !already_projected
                 {
@@ -1071,6 +1094,12 @@ impl Unparser<'_> {
                     &join.on,
                     join_filters.as_ref(),
                 )?;
+                let (join_constraint, unhoistable) =
+                    Self::and_into_join_constraint(join_constraint, hoisted_from_left);
+                // `USING`/`NATURAL` cannot carry an extra predicate. Nothing is
+                // gained by mangling the join, so the predicate goes back where
+                // it was.
+                select.selection(unhoistable);
 
                 let right_projection: Option<Vec<ast::SelectItem>> =
                     if !already_projected && !is_exists_join {
@@ -2258,6 +2287,33 @@ impl Unparser<'_> {
         let mut select = SelectBuilder::default();
         select.push_from(from);
         Ok(select.build()?)
+    }
+
+    /// AND-folds `predicate` into a join's `ON` clause.
+    ///
+    /// Returns the constraint together with the predicate it could not take:
+    /// `USING` and `NATURAL` joins have nowhere to put one.
+    fn and_into_join_constraint(
+        constraint: ast::JoinConstraint,
+        predicate: Option<ast::Expr>,
+    ) -> (ast::JoinConstraint, Option<ast::Expr>) {
+        let Some(predicate) = predicate else {
+            return (constraint, None);
+        };
+
+        match constraint {
+            ast::JoinConstraint::On(existing) => (
+                ast::JoinConstraint::On(ast::Expr::BinaryOp {
+                    left: Box::new(existing),
+                    op: ast::BinaryOperator::And,
+                    right: Box::new(predicate),
+                }),
+                None,
+            ),
+            ast::JoinConstraint::None => (ast::JoinConstraint::On(predicate), None),
+            constraint @ (ast::JoinConstraint::Using(_)
+            | ast::JoinConstraint::Natural) => (constraint, Some(predicate)),
+        }
     }
 
     /// Decides where the table-scan filters extracted from a join's two inputs

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -253,23 +253,26 @@ impl Unparser<'_> {
 
         // Ensure that the projection contains references to sources that actually exist
         let mut projection = select_builder.get_projection();
-        projection
-            .iter_mut()
-            .for_each(|select_item| if let ast::SelectItem::UnnamedExpr(ast::Expr::CompoundIdentifier(idents)) = select_item {
+        projection.iter_mut().for_each(|select_item| {
+            if let ast::SelectItem::UnnamedExpr(ast::Expr::CompoundIdentifier(idents)) =
+                select_item
+            {
                 remove_dangling_identifiers(idents, &all_idents);
-            });
+            }
+        });
 
         // Check the order by as well
         if let Some(query) = query.as_mut()
-            && let Some(OrderByKind::Expressions(mut order_by)) = query.get_order_by() {
-                order_by.iter_mut().for_each(|sort_item| {
-                    if let ast::Expr::CompoundIdentifier(idents) = &mut sort_item.expr {
-                        remove_dangling_identifiers(idents, &all_idents);
-                    }
-                });
+            && let Some(OrderByKind::Expressions(mut order_by)) = query.get_order_by()
+        {
+            order_by.iter_mut().for_each(|sort_item| {
+                if let ast::Expr::CompoundIdentifier(idents) = &mut sort_item.expr {
+                    remove_dangling_identifiers(idents, &all_idents);
+                }
+            });
 
-                query.order_by(OrderByKind::Expressions(order_by));
-            }
+            query.order_by(OrderByKind::Expressions(order_by));
+        }
 
         // Order by could be a sort in the select builder
         let mut sort = select_builder.get_sort_by();
@@ -622,6 +625,24 @@ impl Unparser<'_> {
             LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
             _ => None,
         };
+
+        // A derived table's alias is a single identifier, so only the last
+        // component of a qualified name survives it. Where the dialect spells
+        // columns in full, the enclosing query's `ON` and `WHERE` still name
+        // every component, leaving them qualified by a relation that is no
+        // longer in scope. Refuse rather than emit that, which costs the
+        // pushdown but never the rows — the same trade
+        // `derive_row_limited_scope` makes for the limit it scopes.
+        if self.dialect.full_qualified_col()
+            && table_ref
+                .as_ref()
+                .is_some_and(|table_ref| table_ref.to_vec().len() > 1)
+        {
+            return not_impl_err!(
+                "Unparsing a join input's fetch or FULL JOIN filters is not supported for a qualified table name on a dialect that spells columns in full"
+            );
+        }
+
         let (below_fetch, above_fetch): (Vec<Expr>, Vec<Expr>) = if fetch.is_some() {
             filters
                 .into_iter()
@@ -1092,10 +1113,14 @@ impl Unparser<'_> {
                 };
 
                 let agg = find_agg_node_within_select(plan, select.already_projected());
-                let window_nodes =
-                    find_window_nodes_within_select(plan, None, select.already_projected());
-                let windows: Option<Vec<&Window>> =
-                    window_nodes.as_deref().map(|ws| ws.iter().copied().collect());
+                let window_nodes = find_window_nodes_within_select(
+                    plan,
+                    None,
+                    select.already_projected(),
+                );
+                let windows: Option<Vec<&Window>> = window_nodes
+                    .as_deref()
+                    .map(|ws| ws.iter().copied().collect());
                 // unproject sort expressions
                 let sort_exprs: Vec<SortExpr> = sort
                     .expr

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -448,38 +448,55 @@ impl Unparser<'_> {
         }
     }
 
-    /// Isolates a `FULL JOIN` input's table-scan filters in a derived table:
-    /// `(SELECT ... FROM t WHERE ...) AS t`. A `FULL JOIN` preserves both
-    /// sides, so a filter on just one input cannot be expressed by folding it
-    /// into `ON` (filtered-out rows would reappear as unmatched) or by moving
-    /// it to `WHERE` (the other side's unmatched rows would be discarded);
-    /// pre-filtering that side in its own subquery is the only clause that
-    /// preserves the original meaning.
+    /// Isolates what a join input's `TableScan` did in a derived table:
+    /// `(SELECT ... FROM t WHERE ... LIMIT ...) AS t`.
+    ///
+    /// Two things a scan can carry have no faithful home in the enclosing
+    /// query:
+    ///
+    /// * A `FULL JOIN` input's filters. A `FULL JOIN` preserves both sides, so
+    ///   a filter on just one input cannot be expressed by folding it into `ON`
+    ///   (filtered-out rows would reappear as unmatched) or by moving it to
+    ///   `WHERE` (the other side's unmatched rows would be discarded).
+    /// * A `fetch`, for any join type. The join's own `LIMIT` bounds its
+    ///   output, not one input's contribution to it.
+    ///
+    /// Pre-filtering that side in its own subquery is the only clause that
+    /// preserves the original meaning. Note that whenever a `fetch` is
+    /// isolated the filters must come with it: filtering after the limit
+    /// returns fewer rows than the plan asked for.
     ///
     /// `clean_plan` is the `TableScan`/`SubqueryAlias` produced by
     /// `try_transform_to_simple_table_scan_with_filters`, and `scan_filters`
-    /// are the filters it extracted. `relation` already holds the plain
+    /// and `fetch` are what it extracted. `relation` already holds the plain
     /// table reference built for this side; it is overwritten with the
     /// derived subquery.
-    fn derive_full_join_side(
+    fn derive_join_side(
         &self,
         clean_plan: &LogicalPlan,
         scan_filters: Vec<Expr>,
+        fetch: Option<usize>,
         relation: &mut RelationBuilder,
     ) -> Result<()> {
-        let Some(combined) = scan_filters.into_iter().reduce(Expr::and) else {
+        let combined = scan_filters.into_iter().reduce(Expr::and);
+        if combined.is_none() && fetch.is_none() {
             return Ok(());
-        };
-        let filtered_plan = LogicalPlanBuilder::from(clean_plan.clone())
-            .filter(combined)?
-            .build()?;
+        }
+        let mut builder = LogicalPlanBuilder::from(clean_plan.clone());
+        if let Some(combined) = combined {
+            builder = builder.filter(combined)?;
+        }
+        if let Some(fetch) = fetch {
+            builder = builder.limit(0, Some(fetch))?;
+        }
+        let derived_plan = builder.build()?;
         let alias = match clean_plan {
             LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
             LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
             _ => None,
         }
         .map(|table_ref| self.new_table_alias(table_ref.table().to_string(), vec![]));
-        self.derive(&filtered_plan, relation, alias, false)
+        self.derive(&derived_plan, relation, alias, false)
     }
 
     /// Projection unparsing when [`super::dialect::Dialect::unnest_as_lateral_flatten`] is enabled:
@@ -1019,11 +1036,13 @@ impl Unparser<'_> {
                 // The outer projection plan will handle projecting the correct columns.
                 let already_projected = select.already_projected();
 
+                let mut left_scan_fetch = None;
                 let left_plan =
                     match try_transform_to_simple_table_scan_with_filters(left_plan)? {
-                        Some((plan, filters)) => {
-                            left_scan_filters.extend(filters);
-                            Arc::new(plan)
+                        Some(scan) => {
+                            left_scan_filters.extend(scan.filters);
+                            left_scan_fetch = scan.fetch;
+                            Arc::new(scan.plan)
                         }
                         None => Arc::clone(left_plan),
                     };
@@ -1055,14 +1074,18 @@ impl Unparser<'_> {
 
                 // A FULL JOIN preserves both sides, so neither `ON` nor
                 // `WHERE` can express a filter that came from just one
-                // side's `TableScan` (see `split_join_on_and_where_filters`).
-                // Isolate that side in a derived table instead, and drop the
-                // filters from `left_scan_filters` so they are not also
-                // routed to `ON`/`WHERE` below.
-                if join.join_type == JoinType::Full && !left_scan_filters.is_empty() {
-                    self.derive_full_join_side(
+                // side's `TableScan` (see `split_join_on_and_where_filters`),
+                // and no clause of the enclosing query can express one input's
+                // `fetch`. Isolate that side in a derived table instead, and
+                // drop the filters from `left_scan_filters` so they are not
+                // also routed to `ON`/`WHERE` below.
+                if left_scan_fetch.is_some()
+                    || (join.join_type == JoinType::Full && !left_scan_filters.is_empty())
+                {
+                    self.derive_join_side(
                         left_plan.as_ref(),
                         std::mem::take(&mut left_scan_filters),
+                        left_scan_fetch,
                         relation,
                     )?;
                 }
@@ -1102,11 +1125,14 @@ impl Unparser<'_> {
                 let right_plan: Arc<LogicalPlan> = if is_exists_join {
                     Arc::clone(right_plan)
                 } else {
+                    let mut right_scan_fetch = None;
                     let right_plan =
-                        match try_transform_to_simple_table_scan_with_filters(right_plan)? {
-                            Some((plan, filters)) => {
-                                right_scan_filters.extend(filters);
-                                Arc::new(plan)
+                        match try_transform_to_simple_table_scan_with_filters(right_plan)?
+                        {
+                            Some(scan) => {
+                                right_scan_filters.extend(scan.filters);
+                                right_scan_fetch = scan.fetch;
+                                Arc::new(scan.plan)
                             }
                             None => Arc::clone(right_plan),
                         };
@@ -1117,11 +1143,14 @@ impl Unparser<'_> {
                         select,
                         &mut right_relation,
                     )?;
-                    if join.join_type == JoinType::Full && !right_scan_filters.is_empty()
+                    if right_scan_fetch.is_some()
+                        || (join.join_type == JoinType::Full
+                            && !right_scan_filters.is_empty())
                     {
-                        self.derive_full_join_side(
+                        self.derive_join_side(
                             right_plan.as_ref(),
                             std::mem::take(&mut right_scan_filters),
+                            right_scan_fetch,
                             &mut right_relation,
                         )?;
                     }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -969,7 +969,11 @@ impl Unparser<'_> {
                 self.select_to_sql_recursively(input, query, select, relation)
             }
             LogicalPlan::Join(join) => {
-                let mut table_scan_filters = vec![];
+                // Kept apart by input: where a filter may be re-emitted depends
+                // on which side of the join it came from (see
+                // `split_join_on_and_where_filters`).
+                let mut left_scan_filters = vec![];
+                let mut right_scan_filters = vec![];
                 let (left_plan, right_plan) = match join.join_type {
                     JoinType::RightSemi | JoinType::RightAnti => {
                         (&join.right, &join.left)
@@ -984,7 +988,7 @@ impl Unparser<'_> {
                 let left_plan =
                     match try_transform_to_simple_table_scan_with_filters(left_plan)? {
                         Some((plan, filters)) => {
-                            table_scan_filters.extend(filters);
+                            left_scan_filters.extend(filters);
                             Arc::new(plan)
                         }
                         None => Arc::clone(left_plan),
@@ -1027,7 +1031,7 @@ impl Unparser<'_> {
                     let right_plan =
                         match try_transform_to_simple_table_scan_with_filters(right_plan)? {
                             Some((plan, filters)) => {
-                                table_scan_filters.extend(filters);
+                                right_scan_filters.extend(filters);
                                 Arc::new(plan)
                             }
                             None => Arc::clone(right_plan),
@@ -1044,15 +1048,17 @@ impl Unparser<'_> {
 
                 // Table-scan filters extracted from the inputs must land in the
                 // outer query. EXISTS-style joins have no outer `ON` clause, so
-                // all such filters go to the outer `WHERE`; regular joins split
-                // them between `ON` and `WHERE`.
+                // all such filters go to the outer `WHERE` (only the preserved
+                // side is transformed above, so `right_scan_filters` is empty);
+                // regular joins split them between `ON` and `WHERE`.
                 let (join_filters, where_filters) = if is_exists_join {
-                    (join.filter.clone(), table_scan_filters)
+                    (join.filter.clone(), left_scan_filters)
                 } else {
                     Self::split_join_on_and_where_filters(
                         join.join_type,
                         &join.filter,
-                        table_scan_filters,
+                        left_scan_filters,
+                        right_scan_filters,
                     )
                 };
                 for filter in where_filters {
@@ -2254,31 +2260,55 @@ impl Unparser<'_> {
         Ok(select.build()?)
     }
 
-    /// Decides where extracted table-scan filters belong in the unparsed SQL:
-    /// in the `JOIN ON` clause or in `WHERE`.
+    /// Decides where the table-scan filters extracted from a join's two inputs
+    /// belong in the unparsed SQL: in the `JOIN ON` clause or in `WHERE`.
     ///
-    /// For inner joins the two are semantically equivalent, so filters go to
-    /// `WHERE` (some dialects reject subqueries inside `JOIN ON`).
-    /// For outer joins the filters are AND-folded into `ON` to preserve correctness.
+    /// The answer depends on the join type *and* on which input the filter came
+    /// from — a filter on a preserved side means something different in `ON`
+    /// than in `WHERE`. Filters routed to `ON` are AND-folded onto the join's
+    /// own filter.
     ///
     /// Returns `(on_filter, where_filters)`.
     fn split_join_on_and_where_filters(
         join_type: JoinType,
         join_filter: &Option<Expr>,
-        table_scan_filters: Vec<Expr>,
+        left_scan_filters: Vec<Expr>,
+        right_scan_filters: Vec<Expr>,
     ) -> (Option<Expr>, Vec<Expr>) {
-        if table_scan_filters.is_empty() {
-            return (join_filter.clone(), vec![]);
+        // Which clause preserves a filter's meaning depends on the side it came
+        // from:
+        //
+        // * Inner — ON and WHERE are equivalent, so both sides go to WHERE
+        //   (some dialects reject subqueries inside JOIN ON).
+        // * Left/Right — the preserved side keeps every row whatever ON says,
+        //   so folding its filter into ON would filter nothing at all; it has
+        //   to go to WHERE. The non-preserved side is the mirror image: WHERE
+        //   would discard the null-extended rows and silently turn the outer
+        //   join into an inner join, so its filter has to stay in ON.
+        // * Full — both sides are preserved, so neither clause preserves either
+        //   side's filter; only a derived table would. Left in ON as before.
+        let (on_scan_filters, where_scan_filters) = match join_type {
+            JoinType::Inner => (vec![], [left_scan_filters, right_scan_filters].concat()),
+            JoinType::Left => (right_scan_filters, left_scan_filters),
+            JoinType::Right => (left_scan_filters, right_scan_filters),
+            // Semi/anti/mark joins do not reach this function: their filters
+            // are routed by the EXISTS branch of `select_to_sql_recursively`.
+            JoinType::Full
+            | JoinType::LeftSemi
+            | JoinType::RightSemi
+            | JoinType::LeftAnti
+            | JoinType::RightAnti
+            | JoinType::LeftMark
+            | JoinType::RightMark => {
+                ([left_scan_filters, right_scan_filters].concat(), vec![])
+            }
+        };
+
+        if on_scan_filters.is_empty() {
+            return (join_filter.clone(), where_scan_filters);
         }
 
-        if join_type == JoinType::Inner {
-            // ON and WHERE are equivalent for inner joins; prefer WHERE
-            // because some dialects reject subqueries inside JOIN ON.
-            return (join_filter.clone(), table_scan_filters);
-        }
-
-        // Outer joins: fold table-scan filters into ON to preserve semantics.
-        let combined = table_scan_filters.into_iter().reduce(|acc, filter| {
+        let combined = on_scan_filters.into_iter().reduce(|acc, filter| {
             Expr::BinaryExpr(BinaryExpr {
                 left: Box::new(acc),
                 op: Operator::And,
@@ -2297,7 +2327,7 @@ impl Unparser<'_> {
             (None, None) => None,
         };
 
-        (on_filter, vec![])
+        (on_filter, where_scan_filters)
     }
 }
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -448,6 +448,40 @@ impl Unparser<'_> {
         }
     }
 
+    /// Isolates a `FULL JOIN` input's table-scan filters in a derived table:
+    /// `(SELECT ... FROM t WHERE ...) AS t`. A `FULL JOIN` preserves both
+    /// sides, so a filter on just one input cannot be expressed by folding it
+    /// into `ON` (filtered-out rows would reappear as unmatched) or by moving
+    /// it to `WHERE` (the other side's unmatched rows would be discarded);
+    /// pre-filtering that side in its own subquery is the only clause that
+    /// preserves the original meaning.
+    ///
+    /// `clean_plan` is the `TableScan`/`SubqueryAlias` produced by
+    /// `try_transform_to_simple_table_scan_with_filters`, and `scan_filters`
+    /// are the filters it extracted. `relation` already holds the plain
+    /// table reference built for this side; it is overwritten with the
+    /// derived subquery.
+    fn derive_full_join_side(
+        &self,
+        clean_plan: &LogicalPlan,
+        scan_filters: Vec<Expr>,
+        relation: &mut RelationBuilder,
+    ) -> Result<()> {
+        let Some(combined) = scan_filters.into_iter().reduce(Expr::and) else {
+            return Ok(());
+        };
+        let filtered_plan = LogicalPlanBuilder::from(clean_plan.clone())
+            .filter(combined)?
+            .build()?;
+        let alias = match clean_plan {
+            LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
+            LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
+            _ => None,
+        }
+        .map(|table_ref| self.new_table_alias(table_ref.table().to_string(), vec![]));
+        self.derive(&filtered_plan, relation, alias, false)
+    }
+
     /// Projection unparsing when [`super::dialect::Dialect::unnest_as_lateral_flatten`] is enabled:
     /// Snowflake-style `LATERAL FLATTEN` for unnest (not other dialect spellings).
     ///
@@ -1019,6 +1053,20 @@ impl Unparser<'_> {
                     relation,
                 )?;
 
+                // A FULL JOIN preserves both sides, so neither `ON` nor
+                // `WHERE` can express a filter that came from just one
+                // side's `TableScan` (see `split_join_on_and_where_filters`).
+                // Isolate that side in a derived table instead, and drop the
+                // filters from `left_scan_filters` so they are not also
+                // routed to `ON`/`WHERE` below.
+                if join.join_type == JoinType::Full && !left_scan_filters.is_empty() {
+                    self.derive_full_join_side(
+                        left_plan.as_ref(),
+                        std::mem::take(&mut left_scan_filters),
+                        relation,
+                    )?;
+                }
+
                 let hoisted_from_left = if left_is_null_extended {
                     let contributed = select.take_selection();
                     select.selection(outer_selection);
@@ -1069,6 +1117,14 @@ impl Unparser<'_> {
                         select,
                         &mut right_relation,
                     )?;
+                    if join.join_type == JoinType::Full && !right_scan_filters.is_empty()
+                    {
+                        self.derive_full_join_side(
+                            right_plan.as_ref(),
+                            std::mem::take(&mut right_scan_filters),
+                            &mut right_relation,
+                        )?;
+                    }
                     right_plan
                 };
 
@@ -2358,7 +2414,9 @@ impl Unparser<'_> {
         //   would discard the null-extended rows and silently turn the outer
         //   join into an inner join, so its filter has to stay in ON.
         // * Full — both sides are preserved, so neither clause preserves either
-        //   side's filter; only a derived table would. Left in ON as before.
+        //   side's filter; only a derived table does. The caller isolates a
+        //   `FULL JOIN`'s filtered side in one before reaching this function,
+        //   so `left_scan_filters`/`right_scan_filters` are always empty here.
         let (on_scan_filters, where_scan_filters) = match join_type {
             JoinType::Inner => (
                 vec![],

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1001,8 +1001,11 @@ impl Unparser<'_> {
                 // aside, see what the left subtree adds, and fold that into
                 // this join's `ON` instead (where, for the non-preserved side,
                 // it means the same thing).
-                let left_is_null_extended =
-                    matches!(join.join_type, JoinType::Right | JoinType::Full);
+                // This relocation is only valid when the left input is not
+                // preserved. A FULL JOIN also null-extends its left input, but
+                // preserves left rows, so moving the predicate into ON would
+                // make filtered-out left rows reappear as unmatched rows.
+                let left_is_null_extended = matches!(join.join_type, JoinType::Right);
                 let outer_selection = if left_is_null_extended {
                     select.take_selection()
                 } else {

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -411,25 +411,40 @@ pub(crate) fn unproject_sort_expr(
     Ok(sort_expr)
 }
 
+/// What [`try_transform_to_simple_table_scan_with_filters`] peeled off a join input.
+pub(crate) struct SimpleTableScan {
+    /// The `TableScan` (optionally under a `SubqueryAlias`) with the filters and the
+    /// `fetch` removed.
+    pub plan: LogicalPlan,
+    /// The filters collected from the `Filter` nodes and from the scan itself.
+    pub filters: Vec<Expr>,
+    /// The scan's row limit.
+    pub fetch: Option<usize>,
+}
+
 /// Iterates through the children of a [LogicalPlan] to find a TableScan node before encountering
 /// a Projection or any unexpected node that indicates the presence of a Projection (SELECT) in the plan.
-/// If a TableScan node is found, returns the TableScan node without filters, along with the collected filters separately.
+/// If a TableScan node is found, returns the TableScan node without filters, along with the collected
+/// filters and the scan's `fetch` separately.
 /// If the plan contains a Projection, returns None.
+///
+/// The returned plan carries neither the filters nor the `fetch`: both are the caller's to re-emit,
+/// and a caller that ignores either one silently widens the scan.
 ///
 /// Note: If a table alias is present, TableScan filters are rewritten to reference the alias.
 ///
 /// LogicalPlan example:
 ///   Filter: ta.j1_id < 5
 ///     Alias:  ta
-///       TableScan: j1, j1_id > 10
+///       TableScan: j1, j1_id > 10, fetch=5
 ///
 /// Will return LogicalPlan below:
 ///     Alias:  ta
 ///       TableScan: j1
-/// And filters: [ta.j1_id < 5, ta.j1_id > 10]
+/// And filters: [ta.j1_id < 5, ta.j1_id > 10], fetch: Some(5)
 pub(crate) fn try_transform_to_simple_table_scan_with_filters(
     plan: &LogicalPlan,
-) -> Result<Option<(LogicalPlan, Vec<Expr>)>> {
+) -> Result<Option<SimpleTableScan>> {
     let mut filters: IndexSet<Expr> = IndexSet::new();
     let mut plan_stack = vec![plan];
     let mut table_alias = None;
@@ -498,7 +513,11 @@ pub(crate) fn try_transform_to_simple_table_scan_with_filters(
                 let plan = builder.build()?;
                 let filters = filters.into_iter().collect();
 
-                return Ok(Some((plan, filters)));
+                return Ok(Some(SimpleTableScan {
+                    plan,
+                    filters,
+                    fetch: table_scan.fetch,
+                }));
             }
             _ => {
                 return Ok(None);

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -416,8 +416,13 @@ pub(crate) struct SimpleTableScan {
     /// The `TableScan` (optionally under a `SubqueryAlias`) with the filters and the
     /// `fetch` removed.
     pub plan: LogicalPlan,
-    /// The filters collected from the `Filter` nodes and from the scan itself.
+    /// Every filter collected, from the `Filter` nodes and from the scan itself, in the
+    /// order they were found.
     pub filters: Vec<Expr>,
+    /// The subset of `filters` that came from the scan itself. The scan applies these
+    /// *before* its `fetch`, while a `Filter` node above it applies afterwards — a
+    /// distinction that only matters when there is a `fetch` to sit between them.
+    pub scan_filters: Vec<Expr>,
     /// The scan's row limit.
     pub fetch: Option<usize>,
 }
@@ -494,6 +499,7 @@ pub(crate) fn try_transform_to_simple_table_scan_with_filters(
                     })
                     .collect::<Result<Vec<_>, DataFusionError>>()?;
 
+                let scan_filters = table_scan_filters.clone();
                 for table_scan_filter in table_scan_filters {
                     if !filters.contains(&table_scan_filter) {
                         filters.insert(table_scan_filter);
@@ -516,6 +522,7 @@ pub(crate) fn try_transform_to_simple_table_scan_with_filters(
                 return Ok(Some(SimpleTableScan {
                     plan,
                     filters,
+                    scan_filters,
                     fetch: table_scan.fetch,
                 }));
             }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2059,6 +2059,122 @@ fn test_join_with_table_scan_filters() -> Result<()> {
 }
 
 #[test]
+fn test_outer_join_with_table_scan_filters() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let left_with_filter = || {
+        table_scan_with_filters(
+            Some("left_table"),
+            &schema_left,
+            Some(vec![0, 1]),
+            vec![col("left_table.id").eq(lit("a"))],
+        )?
+        .build()
+    };
+    let right_with_filter = || {
+        table_scan_with_filters(
+            Some("right_table"),
+            &schema_right,
+            Some(vec![0, 1]),
+            vec![col("right_table.age").gt(lit(10))],
+        )?
+        .build()
+    };
+    let plain_left =
+        || table_scan(Some("left_table"), &schema_left, Some(vec![0, 1]))?.build();
+    let plain_right =
+        || table_scan(Some("right_table"), &schema_right, Some(vec![0, 1]))?.build();
+
+    // LEFT JOIN, filter on the preserved (left) side: it must land in WHERE.
+    // Folding it into `ON` would not remove a single row, because a LEFT JOIN
+    // preserves every left row regardless of the `ON` predicate.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            plain_right()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN right_table ON left_table.id = right_table.id WHERE (left_table.id = 'a')"#
+    );
+
+    // LEFT JOIN, filter on the non-preserved (right) side: it must stay in
+    // `ON`. Moving it to WHERE would discard the null-extended rows and turn
+    // the LEFT JOIN into an INNER JOIN.
+    let plan = LogicalPlanBuilder::from(plain_left()?)
+        .join(
+            right_with_filter()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN right_table ON left_table.id = right_table.id AND (right_table.age > 10)"#
+    );
+
+    // LEFT JOIN with a filter on each side: the two are routed to different
+    // clauses, and neither is dropped.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            right_with_filter()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN right_table ON left_table.id = right_table.id AND (right_table.age > 10) WHERE (left_table.id = 'a')"#
+    );
+
+    // RIGHT JOIN is the mirror image: the right side is preserved.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            right_with_filter()?,
+            datafusion_expr::JoinType::Right,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table RIGHT OUTER JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a') WHERE (right_table.age > 10)"#
+    );
+
+    // FULL OUTER JOIN preserves both sides, so neither `ON` nor `WHERE`
+    // expresses either side's filter; a derived table would be needed. The
+    // existing `ON` placement is kept unchanged — this case is still wrong and
+    // is tracked separately.
+    let plan = LogicalPlanBuilder::from(left_with_filter()?)
+        .join(
+            plain_right()?,
+            datafusion_expr::JoinType::Full,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a')"#
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_interval_lhs_eq() {
     let statement = generate_round_trip_statement(
         GenericDialect {},

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2155,9 +2155,9 @@ fn test_outer_join_with_table_scan_filters() -> Result<()> {
     );
 
     // FULL OUTER JOIN preserves both sides, so neither `ON` nor `WHERE`
-    // expresses either side's filter; a derived table would be needed. The
-    // existing `ON` placement is kept unchanged — this case is still wrong and
-    // is tracked separately.
+    // expresses an input filter correctly. Isolate the filtered input in a
+    // derived table so rows rejected by the filter cannot reappear as unmatched
+    // rows from the FULL JOIN.
     let plan = LogicalPlanBuilder::from(left_with_filter()?)
         .join(
             plain_right()?,
@@ -2168,7 +2168,7 @@ fn test_outer_join_with_table_scan_filters() -> Result<()> {
         .build()?;
     assert_snapshot!(
         plan_to_sql(&plan)?,
-        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a')"#
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM (SELECT left_table.id, left_table."name" FROM left_table WHERE (left_table.id = 'a')) AS left_table FULL JOIN right_table ON left_table.id = right_table.id"#
     );
 
     // The aliased form: the filter is rewritten to the alias on its way out of
@@ -4477,6 +4477,48 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
             datafusion_expr::JoinType::Full,
         )?,
         @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id FULL JOIN c ON a.id = c.id WHERE (a.id = 'x')"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_join_filter_nested_under_right_join_using() -> Result<()> {
+    // USING cannot carry the predicate contributed by the non-preserved left
+    // input. It must be downgraded to an equivalent ON constraint before the
+    // predicate is appended; returning the predicate to the SELECT-global
+    // WHERE would discard unmatched rows from the preserved right input.
+    let id_schema = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
+    let b_schema = Schema::new(vec![Field::new("b_id", DataType::Utf8, false)]);
+    let a = table_scan_with_filters(
+        Some("a"),
+        &id_schema,
+        Some(vec![0]),
+        vec![col("a.id").eq(lit("x"))],
+    )?
+    .build()?;
+    let b = table_scan(Some("b"), &b_schema, Some(vec![0]))?.build()?;
+    let c = table_scan(Some("c"), &id_schema, Some(vec![0]))?.build()?;
+
+    let inner = LogicalPlanBuilder::from(a)
+        .join(
+            b,
+            datafusion_expr::JoinType::Inner,
+            (vec!["a.id"], vec!["b.b_id"]),
+            None,
+        )?
+        .build()?;
+    let outer = LogicalPlanBuilder::from(inner)
+        .join_using(
+            c,
+            datafusion_expr::JoinType::Right,
+            vec![Column::new_unqualified("id")],
+        )?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&outer)?,
+        @"SELECT a.id, b.b_id, c.id FROM a INNER JOIN b ON a.id = b.b_id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -5755,3 +5755,56 @@ fn test_filter_on_unnamed_volatile_projection_output_is_not_inlined() -> Result<
     assert_snapshot!(sql, @r#"SELECT random() FROM t WHERE ("random()" > 0.5)"#);
     Ok(())
 }
+
+#[test]
+fn test_qualified_join_input_fetch_refused_on_full_qualified_col_dialect() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("value", DataType::Utf8, false),
+    ]);
+    let other = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
+
+    let join_with_fetched_input = |name: &str| -> Result<LogicalPlan> {
+        LogicalPlanBuilder::from(
+            table_scan_with_filter_and_fetch(
+                Some(name),
+                &schema,
+                Some(vec![0, 1]),
+                vec![],
+                Some(5),
+            )?
+            .build()?,
+        )
+        .join(
+            table_scan(Some("other"), &other, Some(vec![0]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            (vec![format!("{name}.id")], vec!["other.id".to_string()]),
+            None,
+        )?
+        .build()
+    };
+
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .build();
+    let unparser = Unparser::new(&dialect);
+
+    // The derived table can only be aliased `table`, while this dialect spells
+    // the join condition `catalog.schema.table.id` — a relation the derived
+    // table no longer brings into scope.
+    let err = unparser
+        .plan_to_sql(&join_with_fetched_input("catalog.schema.table")?)
+        .expect_err("a qualified name must not unparse to an unresolvable alias");
+    assert_contains!(
+        err.to_string(),
+        "not supported for a qualified table name on a dialect that spells columns in full"
+    );
+
+    // A single-component name loses nothing to the alias, so the guard must
+    // not fire on it even on this dialect.
+    assert_snapshot!(
+        unparser.plan_to_sql(&join_with_fetched_input("t")?)?,
+        @"SELECT t.id, t.value, other.id FROM (SELECT t.id, t.value FROM t LIMIT 5) AS t INNER JOIN other ON t.id = other.id"
+    );
+    Ok(())
+}

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1342,7 +1342,10 @@ fn table_scan_with_empty_projection_and_none_projection_helper(
 // yielding `Projection: <empty> -> TableScan`. It must not be unparsed as an
 // empty `SELECT` list for dialects that reject `SELECT FROM t` (e.g. DuckDB):
 // fall back to `SELECT 1` just like the bare empty-projection `TableScan`.
-fn empty_projection_over_table_helper(table_name: &str, table_schema: Schema) -> LogicalPlan {
+fn empty_projection_over_table_helper(
+    table_name: &str,
+    table_schema: Schema,
+) -> LogicalPlan {
     project(
         table_scan(Some(table_name), &table_schema, None)
             .unwrap()
@@ -4519,6 +4522,262 @@ fn test_join_filter_nested_under_right_join_using() -> Result<()> {
     assert_snapshot!(
         plan_to_sql(&outer)?,
         @"SELECT a.id, b.b_id, c.id FROM a INNER JOIN b ON a.id = b.b_id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+
+    Ok(())
+}
+
+/// A `fetch` pushed into a join input bounds that input, not the join's output,
+/// so it has to be emitted as a derived table. Dropping it asks the remote
+/// engine for the whole table and joins over it.
+#[test]
+fn test_join_input_with_pushed_down_fetch() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let scan_with_fetch = |name: &'static str, schema: &Schema, filters: Vec<Expr>| {
+        table_scan_with_filter_and_fetch(
+            Some(name),
+            schema,
+            Some(vec![0, 1]),
+            filters,
+            Some(5),
+        )
+    };
+
+    // Left input: filter and fetch both move into the subquery. Keeping the
+    // filter outside would apply it after the limit, which returns fewer rows.
+    let plan = LogicalPlanBuilder::from(
+        scan_with_fetch(
+            "left_table",
+            &schema_left,
+            vec![col("left_table.id").eq(lit("a"))],
+        )?
+        .build()?,
+    )
+    .join(
+        table_scan(Some("right_table"), &schema_right, Some(vec![0, 1]))?.build()?,
+        datafusion_expr::JoinType::Inner,
+        (vec!["left_table.id"], vec!["right_table.id"]),
+        None,
+    )?
+    .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM (SELECT left_table.id, left_table."name" FROM left_table WHERE (left_table.id = 'a') LIMIT 5) AS left_table INNER JOIN right_table ON left_table.id = right_table.id"#
+    );
+
+    // Right input: the same, on the other side of the join.
+    let plan = LogicalPlanBuilder::from(
+        table_scan(Some("left_table"), &schema_left, Some(vec![0, 1]))?.build()?,
+    )
+    .join(
+        scan_with_fetch(
+            "right_table",
+            &schema_right,
+            vec![col("right_table.age").gt(lit(30))],
+        )?
+        .build()?,
+        datafusion_expr::JoinType::Inner,
+        (vec!["left_table.id"], vec!["right_table.id"]),
+        None,
+    )?
+    .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table INNER JOIN (SELECT right_table.id, right_table.age FROM right_table WHERE (right_table.age > 30) LIMIT 5) AS right_table ON left_table.id = right_table.id"#
+    );
+
+    // A fetch with no filter still needs the subquery.
+    let plan = LogicalPlanBuilder::from(
+        scan_with_fetch("left_table", &schema_left, vec![])?.build()?,
+    )
+    .join(
+        table_scan(Some("right_table"), &schema_right, Some(vec![0, 1]))?.build()?,
+        datafusion_expr::JoinType::Inner,
+        (vec!["left_table.id"], vec!["right_table.id"]),
+        None,
+    )?
+    .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM (SELECT left_table.id, left_table."name" FROM left_table LIMIT 5) AS left_table INNER JOIN right_table ON left_table.id = right_table.id"#
+    );
+
+    // Both inputs limited: each gets its own subquery.
+    let plan = LogicalPlanBuilder::from(
+        scan_with_fetch("left_table", &schema_left, vec![])?.build()?,
+    )
+    .join(
+        scan_with_fetch("right_table", &schema_right, vec![])?.build()?,
+        datafusion_expr::JoinType::Inner,
+        (vec!["left_table.id"], vec!["right_table.id"]),
+        None,
+    )?
+    .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM (SELECT left_table.id, left_table."name" FROM left_table LIMIT 5) AS left_table INNER JOIN (SELECT right_table.id, right_table.age FROM right_table LIMIT 5) AS right_table ON left_table.id = right_table.id"#
+    );
+
+    Ok(())
+}
+
+/// The clause a filter belongs in depends on the join type, but a limited input
+/// is always its own subquery — including on a side whose filter would
+/// otherwise have to stay in `ON`, and on a side of a `FULL JOIN`.
+#[test]
+fn test_outer_join_input_with_pushed_down_fetch() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let mut rendered = String::new();
+    for join_type in [
+        datafusion_expr::JoinType::Left,
+        datafusion_expr::JoinType::Right,
+        datafusion_expr::JoinType::Full,
+    ] {
+        let plan = LogicalPlanBuilder::from(
+            table_scan(Some("left_table"), &schema_left, Some(vec![0, 1]))?.build()?,
+        )
+        .join(
+            table_scan_with_filter_and_fetch(
+                Some("right_table"),
+                &schema_right,
+                Some(vec![0, 1]),
+                vec![col("right_table.age").gt(lit(30))],
+                Some(5),
+            )?
+            .build()?,
+            join_type,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+
+        rendered.push_str(&plan_to_sql(&plan)?.to_string());
+        rendered.push('\n');
+    }
+
+    // In all three the filter and the limit are inside the subquery: nothing is
+    // left for the enclosing `ON` or `WHERE` to re-apply after the limit.
+    assert_snapshot!(
+        rendered,
+        @r#"
+    SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table LEFT OUTER JOIN (SELECT right_table.id, right_table.age FROM right_table WHERE (right_table.age > 30) LIMIT 5) AS right_table ON left_table.id = right_table.id
+    SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table RIGHT OUTER JOIN (SELECT right_table.id, right_table.age FROM right_table WHERE (right_table.age > 30) LIMIT 5) AS right_table ON left_table.id = right_table.id
+    SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN (SELECT right_table.id, right_table.age FROM right_table WHERE (right_table.age > 30) LIMIT 5) AS right_table ON left_table.id = right_table.id
+    "#
+    );
+
+    Ok(())
+}
+
+/// An aliased scan keeps its alias, so the columns the enclosing query
+/// references still resolve.
+#[test]
+fn test_aliased_join_input_with_pushed_down_fetch() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let plan = LogicalPlanBuilder::from(
+        table_scan_with_filter_and_fetch(
+            Some("left_table"),
+            &schema_left,
+            Some(vec![0, 1]),
+            vec![col("left_table.id").eq(lit("a"))],
+            Some(5),
+        )?
+        .alias("l")?
+        .build()?,
+    )
+    .join(
+        table_scan(Some("right_table"), &schema_right, Some(vec![0, 1]))?.build()?,
+        datafusion_expr::JoinType::Inner,
+        (vec!["l.id"], vec!["right_table.id"]),
+        None,
+    )?
+    .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT l.id, l."name", right_table.id, right_table.age FROM (SELECT l.id, l."name" FROM left_table AS l WHERE (l.id = 'a') LIMIT 5) AS l INNER JOIN right_table ON l.id = right_table.id"#
+    );
+
+    Ok(())
+}
+
+/// Text alone does not prove the limit survived: plan the generated SQL back
+/// and check that the limit is still bound to the one input, above that scan
+/// and below the join.
+#[test]
+fn test_join_input_fetch_survives_replanning() -> Result<()> {
+    let schema_j1 = Schema::new(vec![
+        Field::new("j1_id", DataType::Int32, false),
+        Field::new("j1_string", DataType::Utf8, false),
+    ]);
+    let schema_j2 = Schema::new(vec![
+        Field::new("j2_id", DataType::Int32, false),
+        Field::new("j2_string", DataType::Utf8, false),
+    ]);
+
+    let plan = LogicalPlanBuilder::from(
+        table_scan_with_filter_and_fetch(
+            Some("j1"),
+            &schema_j1,
+            Some(vec![0, 1]),
+            vec![col("j1.j1_id").gt(lit(1))],
+            Some(5),
+        )?
+        .build()?,
+    )
+    .join(
+        table_scan(Some("j2"), &schema_j2, Some(vec![0, 1]))?.build()?,
+        datafusion_expr::JoinType::Inner,
+        (vec!["j1.j1_id"], vec!["j2.j2_id"]),
+        None,
+    )?
+    .build()?;
+
+    let sql = plan_to_sql(&plan)?;
+    let statement = Parser::new(&GenericDialect {})
+        .try_with_sql(&sql.to_string())?
+        .parse_statement()?;
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let replanned = SqlToRel::new(&context).sql_statement_to_plan(statement)?;
+
+    assert_snapshot!(
+        replanned,
+        @r"
+    Projection: j1.j1_id, j1.j1_string, j2.j2_id, j2.j2_string
+      Inner Join:  Filter: j1.j1_id = j2.j2_id
+        SubqueryAlias: j1
+          Limit: skip=0, fetch=5
+            Projection: j1.j1_id, j1.j1_string
+              Filter: j1.j1_id > Int64(1)
+                TableScan: j1
+        TableScan: j2
+    "
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4416,10 +4416,11 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
 
 #[test]
 fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
-    // A predicate extracted from a nested join's input must not reach the
-    // SELECT-global `WHERE` when an enclosing join null-extends that input:
-    // `WHERE` runs after every join and would discard the rows the enclosing
-    // join is there to preserve. It belongs in the enclosing join's `ON`.
+    // When an enclosing RIGHT JOIN null-extends a nested left input, a predicate
+    // from that input must not reach the SELECT-global `WHERE`: `WHERE` runs
+    // after every join and would discard the preserved right-side rows. It
+    // belongs in the enclosing join's `ON` because the left input is not
+    // preserved. FULL JOIN differs because it preserves both inputs.
     let schema = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
     let a = table_scan_with_filters(
         Some("a"),
@@ -4431,7 +4432,7 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
     let b = table_scan(Some("b"), &schema, Some(vec![0]))?.build()?;
     let c = table_scan(Some("c"), &schema, Some(vec![0]))?.build()?;
 
-    let nested_under_right = |inner_join_type| -> Result<String> {
+    let nested_under_outer = |inner_join_type, outer_join_type| -> Result<String> {
         let inner = LogicalPlanBuilder::from(a.clone())
             .join(
                 b.clone(),
@@ -4443,7 +4444,7 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
         let outer = LogicalPlanBuilder::from(inner)
             .join(
                 c.clone(),
-                datafusion_expr::JoinType::Right,
+                outer_join_type,
                 (vec!["a.id"], vec!["c.id"]),
                 None,
             )?
@@ -4452,12 +4453,30 @@ fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
     };
 
     assert_snapshot!(
-        nested_under_right(datafusion_expr::JoinType::Inner)?,
+        nested_under_outer(
+            datafusion_expr::JoinType::Inner,
+            datafusion_expr::JoinType::Right,
+        )?,
         @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
     );
     assert_snapshot!(
-        nested_under_right(datafusion_expr::JoinType::Left)?,
+        nested_under_outer(
+            datafusion_expr::JoinType::Left,
+            datafusion_expr::JoinType::Right,
+        )?,
         @"SELECT a.id, b.id, c.id FROM a LEFT OUTER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+
+    // A FULL JOIN also null-extends its left input, but unlike a RIGHT JOIN it
+    // preserves that input. Hoisting the predicate into ON would therefore
+    // make filtered-out left rows reappear as unmatched rows. Keep the prior
+    // WHERE placement until FULL JOIN inputs can be emitted as derived tables.
+    assert_snapshot!(
+        nested_under_outer(
+            datafusion_expr::JoinType::Inner,
+            datafusion_expr::JoinType::Full,
+        )?,
+        @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id FULL JOIN c ON a.id = c.id WHERE (a.id = 'x')"
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2171,6 +2171,29 @@ fn test_outer_join_with_table_scan_filters() -> Result<()> {
         @r#"SELECT left_table.id, left_table."name", right_table.id, right_table.age FROM left_table FULL JOIN right_table ON left_table.id = right_table.id AND (left_table.id = 'a')"#
     );
 
+    // The aliased form: the filter is rewritten to the alias on its way out of
+    // the scan, and must still land in WHERE.
+    let aliased_left = table_scan_with_filters(
+        Some("left_table"),
+        &schema_left,
+        Some(vec![0, 1]),
+        vec![col("left_table.id").eq(lit("a"))],
+    )?
+    .alias("l")?
+    .build()?;
+    let plan = LogicalPlanBuilder::from(aliased_left)
+        .join(
+            plain_right()?,
+            datafusion_expr::JoinType::Left,
+            (vec!["l.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT l.id, l."name", right_table.id, right_table.age FROM left_table AS l LEFT OUTER JOIN right_table ON l.id = right_table.id WHERE (l.id = 'a')"#
+    );
+
     Ok(())
 }
 
@@ -4388,5 +4411,54 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
         sql,
         @r#"SELECT DISTINCT * FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "left" WHERE EXISTS (SELECT 1 FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "right" WHERE ("left"."first_name" = "right"."first_name") AND ("left"."order_id" = "right"."order_id")) AND EXISTS (SELECT 1 FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id") WHERE ("left"."first_name" = "p"."first_name") AND ("left"."order_id" = "o"."order_id"))"#
     );
+    Ok(())
+}
+
+#[test]
+fn test_join_filter_nested_under_null_extending_join() -> Result<()> {
+    // A predicate extracted from a nested join's input must not reach the
+    // SELECT-global `WHERE` when an enclosing join null-extends that input:
+    // `WHERE` runs after every join and would discard the rows the enclosing
+    // join is there to preserve. It belongs in the enclosing join's `ON`.
+    let schema = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
+    let a = table_scan_with_filters(
+        Some("a"),
+        &schema,
+        Some(vec![0]),
+        vec![col("a.id").eq(lit("x"))],
+    )?
+    .build()?;
+    let b = table_scan(Some("b"), &schema, Some(vec![0]))?.build()?;
+    let c = table_scan(Some("c"), &schema, Some(vec![0]))?.build()?;
+
+    let nested_under_right = |inner_join_type| -> Result<String> {
+        let inner = LogicalPlanBuilder::from(a.clone())
+            .join(
+                b.clone(),
+                inner_join_type,
+                (vec!["a.id"], vec!["b.id"]),
+                None,
+            )?
+            .build()?;
+        let outer = LogicalPlanBuilder::from(inner)
+            .join(
+                c.clone(),
+                datafusion_expr::JoinType::Right,
+                (vec!["a.id"], vec!["c.id"]),
+                None,
+            )?
+            .build()?;
+        Ok(plan_to_sql(&outer)?.to_string())
+    };
+
+    assert_snapshot!(
+        nested_under_right(datafusion_expr::JoinType::Inner)?,
+        @"SELECT a.id, b.id, c.id FROM a INNER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+    assert_snapshot!(
+        nested_under_right(datafusion_expr::JoinType::Left)?,
+        @"SELECT a.id, b.id, c.id FROM a LEFT OUTER JOIN b ON a.id = b.id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
+    );
+
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4782,3 +4782,45 @@ fn test_join_input_fetch_survives_replanning() -> Result<()> {
 
     Ok(())
 }
+
+/// The scan applies its own filters before its `fetch`; a `Filter` node above
+/// the scan applies afterwards. Both end up in the derived table, but they
+/// cannot share one `SELECT` — `WHERE` is evaluated before `LIMIT`, so a
+/// single scope would silently filter first.
+#[test]
+fn test_join_input_filter_above_pushed_down_fetch() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("v", DataType::Int32, false),
+    ]);
+    let schema_right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let left = table_scan_with_filter_and_fetch(
+        Some("left_table"),
+        &schema_left,
+        Some(vec![0, 1]),
+        vec![col("left_table.v").gt(lit(1))],
+        Some(5),
+    )?
+    .filter(col("left_table.id").eq(lit("a")))?
+    .build()?;
+
+    let plan = LogicalPlanBuilder::from(left)
+        .join(
+            table_scan(Some("right_table"), &schema_right, Some(vec![0, 1]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, left_table.v, right_table.id, right_table.age FROM (SELECT * FROM (SELECT left_table.id, left_table.v FROM left_table WHERE (left_table.v > 1) LIMIT 5) AS left_table WHERE (left_table.id = 'a')) AS left_table INNER JOIN right_table ON left_table.id = right_table.id"#
+    );
+
+    Ok(())
+}

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4824,3 +4824,40 @@ fn test_join_input_filter_above_pushed_down_fetch() -> Result<()> {
 
     Ok(())
 }
+
+/// A scan filter may name a column the projection prunes. Rebuilding the input
+/// keeps the original projection and lets the filter reference the wider source
+/// schema, which is what SQL allows too.
+#[test]
+fn test_join_input_fetch_with_pruned_filter_column() -> Result<()> {
+    let schema_left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let schema_right = Schema::new(vec![Field::new("id", DataType::Utf8, false)]);
+
+    let left = table_scan_with_filter_and_fetch(
+        Some("left_table"),
+        &schema_left,
+        Some(vec![0]),
+        vec![col("left_table.name").eq(lit("x"))],
+        Some(5),
+    )?
+    .build()?;
+
+    let plan = LogicalPlanBuilder::from(left)
+        .join(
+            table_scan(Some("right_table"), &schema_right, Some(vec![0]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            (vec!["left_table.id"], vec!["right_table.id"]),
+            None,
+        )?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT left_table.id, right_table.id FROM (SELECT left_table.id FROM left_table WHERE (left_table."name" = 'x') LIMIT 5) AS left_table INNER JOIN right_table ON left_table.id = right_table.id"#
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

A `fetch` the optimizer pushes into a `TableScan` used as a join input is dropped when the join is
unparsed, so the generated SQL asks the remote engine for the whole table and evaluates the join
over it. The query can return more rows than the plan it came from.

`try_transform_to_simple_table_scan_with_filters` rebuilds a join input's scan from `table_name`,
`source` and `projection` only. `TableScan.fetch` is not carried over and nothing re-adds it —
unlike the ordinary scan path, where `unparse_table_scan_pushdown` re-emits it as `LIMIT`.

Before:

```
Left Join: a.id = b.id
  TableScan: a projection=[id], full_filters=[a.id = Utf8("x")], fetch=5
  TableScan: b projection=[id]
```
```sql
SELECT a.id, b.id FROM a LEFT OUTER JOIN b ON a.id = b.id WHERE (a.id = 'x')
```

After:

```sql
SELECT a.id, b.id FROM (SELECT a.id FROM a WHERE (a.id = 'x') LIMIT 5) AS a LEFT OUTER JOIN b ON a.id = b.id
```

Fixes spiceai/spiceai#12406.

## Changes

- `try_transform_to_simple_table_scan_with_filters` returns the scan's `fetch`, and reports which
  of the extracted predicates came from the scan itself, in a named `SimpleTableScan` struct rather
  than a widening tuple.
- `derive_full_join_side` becomes `derive_join_side`, which also takes the fetch. A join input is
  isolated in a derived table aliased to its own name when it carries a `fetch` (any join type), or
  when it carries filters on a side of a `FULL JOIN` (the case the helper already handled).

Three properties the implementation rests on, each pinned by a test:

- **No clause of the enclosing query can express one input's limit.** The join's own `LIMIT` bounds
  the join's output, not one side's contribution to it, so the input has to become a subquery. The
  alias is the input's own table name, which keeps the outer references (`a.id`, `ON a.id = b.id`)
  resolvable.
- **The scan's filters must move into the subquery with the limit.** Leaving them in `ON`/`WHERE`
  would apply them after the limit and return fewer rows than the plan asks for. This is why the
  fetch case takes those filters out of the `ON`/`WHERE` routing even for an inner join, where the
  two clauses are otherwise equivalent.
- **A predicate from a `Filter` node above the scan is not one of them.** The scan applies its own
  filters before its `fetch`; a `Filter` above it applies afterwards. Both belong in the derived
  table, but not in the same `SELECT` — `WHERE` is evaluated before `LIMIT`, so one scope would
  silently reverse them. The post-fetch predicates get a scope of their own.

## Test plan

`cargo test -p datafusion-sql` — 506 pass, and the 22 failures are the pre-existing ones on
`spiceai-54` (identical set before and after this change; the two fetch-related ones,
`test_table_scan_pushdown` and `test_sort_with_scalar_fn_and_push_down_fetch`, produce
byte-identical output with and without this change, so nothing is hidden behind them).

Six new tests in `datafusion/sql/tests/cases/plan_to_sql.rs`:

- `test_join_input_with_pushed_down_fetch` — fetch on the left input, on the right input, without
  filters, and on both inputs at once.
- `test_outer_join_input_with_pushed_down_fetch` — `LEFT`/`RIGHT`/`FULL`, including the side whose
  filter would otherwise have to stay in `ON`.
- `test_join_input_filter_above_pushed_down_fetch` — a `Filter` above a fetched scan; asserts the
  two predicate sets land on opposite sides of the limit.
- `test_aliased_join_input_with_pushed_down_fetch` — an aliased scan keeps its alias.
- `test_join_input_fetch_with_pruned_filter_column` — a scan filter naming a column the projection
  prunes still renders, rather than failing to rebuild.
- `test_join_input_fetch_survives_replanning` — plans the generated SQL back and asserts the limit
  is still bound to that one input, above the scan and below the join. Text alone would not show
  that.

Neuter matrix, 8 mutations, all caught:

| mutation | tests failing |
|---|---|
| helper drops the fetch again | 6 |
| helper reports no filter as scan-level | 6 |
| left side derives only for `FULL` | 5 |
| right side derives only for `FULL` | 2 |
| filters left outside the limited subquery | 6 |
| every filter treated as pre-fetch | 1 |
| post-fetch filter shares the limit's `SELECT` | 1 |
| derived table loses its alias | 6 |

## Notes for review

- Based on `spiceai-54` but stacked on #193 — a cross-fork PR cannot base on a branch that only
  exists on the fork, so #193's commits appear in this diff until it merges, at which point this
  diff reduces to the last two. The dependency is real, not just ordering: this reuses and
  generalizes the derived-table helper #193 introduced for `FULL JOIN`.
- The post-fetch scope exists partly because of a separate defect: the unparser flattens a `Filter`
  above a `Limit` into one `SELECT ... WHERE ... LIMIT n`, reversing their order
  (spiceai/spiceai#12591). This PR does not depend on that being fixed — it inserts an alias so the
  limit keeps its own `SELECT` — but the flattening is why the extra layer is needed at all.
- Two limitations an adversarial review raised that are pre-existing and out of scope here, both
  filed: a `FULL JOIN` whose filtered input is a join rather than a bare scan still leaks its
  predicate to the outer `WHERE` (spiceai/spiceai#12593, the remainder #193's own comment records),
  and a derived table aliased by its bare name breaks fully qualified column references under
  `with_full_qualified_col(true)` (spiceai/spiceai#12594). The second is the unparser's existing
  alias convention everywhere, but this change does widen how many inputs become derived tables.
  A third, also filed: a `fetch` on the build side of a semi/anti/mark join is emitted inside the
  `EXISTS` correlation, where the limit does nothing (spiceai/spiceai#12595) — that path skips the
  simple-scan transform entirely, so it is untouched either way by this change.
- One review finding did not survive checking: rebuilding an input whose scan filter names a
  projection-pruned column was predicted to fail with `No field named …`. It does not — the filter
  resolves against the source schema, and SQL allows filtering on an unselected column. The case is
  now a test rather than a claim.
- Closing spiceai/spiceai#12406 also needs a pin bump there once this lands.

### Review gate on the unblocking commits

Attesting `f645d3f58` (the `spiceai-54` merge) and `f183eb6b9` (the `full_qualified_col` guard) — my commits on this PR, not the original work.

- **Adversarial review**: `codex`, scoped `upstream/spiceai-54...HEAD` — verdict **needs-attention**, one high-severity finding. Note the base is `upstream/`, not `origin/`: in this clone `origin` is the `claudespice` fork, and scoping against it silently reviews the wrong diff.
- **Tests**: 534 passed / 22 failed, and the 22 failing names are byte-identical to `upstream/spiceai-54` at `b23af4193` (527 / 22). `cargo fmt --check` reports the same 3 pre-existing diffs on both sides.

**The finding, and why it is not actioned here.** Codex reported that a fetched semi/anti/mark join build side correlates before its `LIMIT`: `build_exists_subquery` renders the scan's `fetch` as the `EXISTS` subquery's `LIMIT` and then ANDs the join predicates into that same `SELECT`'s `WHERE`, which is evaluated first. It is a real data-correctness defect and it is reachable:

```sql
SELECT outer_t.id FROM outer_t
WHERE EXISTS (SELECT 1 FROM inner_t WHERE (outer_t.id = inner_t.id) LIMIT 5)
```

Its recommendation was "do not ship". I checked that against the base before accepting it, and the scope does not hold:

| | `upstream/spiceai-54` (`b23af4193`) | this branch |
|---|---|---|
| `LeftSemi`, fetched build side | `EXISTS (… WHERE … LIMIT 5)` | **byte-identical** |
| `Inner`, fetched input | fetch **dropped silently** — no `LIMIT` at all | scoped in a derived table |

This branch does not touch the `is_exists_join` arm, so it neither introduces nor broadens that defect — and the case it *does* change was previously dropping a `LIMIT` outright, which is the worse of the two. Holding this PR would preserve a silently dropped limit in order to avoid shipping a partial fix to a different, pre-existing one.

Filed as **spiceai/spiceai#13017** with the mechanism, the reproduction, and the base comparison, rather than left as an unowned note.

<!-- fix-failing-prs: review gate recorded, 1 finding deferred to spiceai/spiceai#13017 -->