### PR TITLE
fix(unparser): scope a limited input so a filter above it is not evaluated first

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -330,6 +330,24 @@ impl SelectBuilder {
 
         self
     }
+
+    /// Whether this `SELECT` already carries a `WHERE` predicate.
+    pub fn has_selection(&self) -> bool {
+        self.selection.is_some()
+    }
+
+    /// Whether this `SELECT` already carries a predicate that can only be
+    /// stated alongside the grouping or windowing it filters — `HAVING` or
+    /// `QUALIFY`.
+    ///
+    /// Both are evaluated before `LIMIT`/`OFFSET`, like `WHERE`, but unlike
+    /// `WHERE` they cannot simply be lifted into an enclosing query: the
+    /// aggregate or window expression they reference is only nameable in the
+    /// `SELECT` that computes it.
+    pub fn has_grouped_predicate(&self) -> bool {
+        self.having.is_some() || self.qualify.is_some()
+    }
+
     pub fn group_by(&mut self, value: ast::GroupByExpr) -> &mut Self {
         self.group_by = Some(value);
         self

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1251,9 +1251,9 @@ impl Unparser<'_> {
             && let Some(at_tz) = self
                 .dialect
                 .timestamp_at_time_zone_to_sql(inner_expr.clone(), tz.as_ref())
-            {
-                return Ok(at_tz);
-            }
+        {
+            return Ok(at_tz);
+        }
         match inner_expr {
             ast::Expr::Value(_) => match data_type {
                 DataType::Dictionary(_, _) | DataType::Binary | DataType::BinaryView

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -451,19 +451,32 @@ impl Unparser<'_> {
     /// Whether the subtree carrying a row limit needs a `SELECT` of its own.
     ///
     /// The walk is top-down, so any predicate already on `select` came from a
-    /// node *above* the one being unparsed. `WHERE`, `HAVING` and `QUALIFY`
-    /// are all evaluated before `LIMIT`/`OFFSET`, while the plan says the
-    /// opposite: the limit runs first and the predicate filters what it
-    /// produced. Keeping both in one `SELECT` therefore states the reverse of
-    /// the plan, and can return rows the plan excludes.
+    /// node visited earlier. `WHERE`, `HAVING` and `QUALIFY` are all evaluated
+    /// before `LIMIT`/`OFFSET`, while a plan that puts a filter above a limit
+    /// says the opposite: the limit runs first and the predicate filters what
+    /// it produced. Keeping both in one `SELECT` therefore states the reverse
+    /// of the plan, and can return rows the plan excludes.
     ///
-    /// A `WHERE` can be left behind in an enclosing query while the limited
-    /// subtree moves into a derived table. `HAVING` and `QUALIFY` cannot: they
-    /// reference an aggregate or window expression that only the `SELECT`
-    /// computing it can name. Refuse those rather than emit either the
-    /// reversed form or a predicate with nothing to bind to.
-    fn row_limit_needs_own_scope(select: &SelectBuilder) -> Result<bool> {
-        if select.has_grouped_predicate() {
+    /// A `WHERE` can stay in the enclosing query while the limited subtree
+    /// moves into a derived table. `HAVING` and `QUALIFY` cannot: they name an
+    /// aggregate or window expression that only the `SELECT` computing it can
+    /// name. Refuse those rather than emit the reversed form — but only when
+    /// the grouping they filter is in fact below this limit. Join inputs are
+    /// walked with one shared `SelectBuilder`, so a predicate on it may have
+    /// come from a sibling input rather than from an ancestor of this node.
+    fn row_limit_needs_own_scope(
+        plan: &LogicalPlan,
+        select: &SelectBuilder,
+    ) -> Result<bool> {
+        if select.has_grouped_predicate()
+            && (find_agg_node_within_select(plan, select.already_projected()).is_some()
+                || find_window_nodes_within_select(
+                    plan,
+                    None,
+                    select.already_projected(),
+                )
+                .is_some())
+        {
             return not_impl_err!(
                 "Unparsing a HAVING or QUALIFY predicate that is applied after a row limit is not supported"
             );
@@ -471,36 +484,59 @@ impl Unparser<'_> {
         Ok(select.has_selection())
     }
 
-    /// Unparses `plan` — a `Limit`, or a `Sort` carrying a `fetch` — as a
-    /// derived table, so the predicate already on the enclosing `SELECT`
-    /// applies to the limited rows rather than to the rows feeding the limit.
+    /// Unparses a `Limit` as a derived table, so the `WHERE` already on the
+    /// enclosing `SELECT` applies to the limited rows rather than to the rows
+    /// feeding the limit.
     ///
-    /// The derived table takes the name of the relation the subtree reads,
-    /// because the predicate staying outside is still qualified by it. A
-    /// subtree reading more than one relation has no such name to take: every
-    /// qualifier the predicate could carry would be gone from scope, so the
-    /// query is refused rather than rendered unbindable.
+    /// The derived table takes the name of the relation it reads, because the
+    /// predicate staying outside is still qualified by that name, and its
+    /// columns are listed explicitly: a wildcard would expand to every
+    /// relation in the enclosing `FROM`, not to this one's contribution.
+    ///
+    /// Both of those need the derived table's output columns to be exactly the
+    /// relation's own columns, under their own names — which is why only a
+    /// scan, and the clauses that can wrap one without renaming anything, are
+    /// accepted here. A projection may emit a column the derived query never
+    /// names (an unaliased expression) or two columns that differ only by a
+    /// qualifier SQL cannot carry across the boundary; a join, union or
+    /// aggregate has no single name for the alias to take. Those are refused,
+    /// which costs the pushdown but never the rows.
     fn derive_row_limited_scope(
         &self,
         plan: &LogicalPlan,
         select: &mut SelectBuilder,
         relation: &mut RelationBuilder,
     ) -> Result<()> {
-        let Some(table_ref) = Self::sole_relation_of(plan) else {
+        let Some(table_ref) = Self::scanned_relation_of(plan) else {
             return not_impl_err!(
-                "Unparsing a filter applied after a row limit is not supported when the limited input reads more than one relation"
+                "Unparsing a filter applied after a row limit is only supported when the limited input is a single table scan"
             );
         };
 
+        // Only the last component survives as an alias, so a predicate spelled
+        // with the full path would be left pointing at a name that is gone.
+        if self.dialect.full_qualified_col() && table_ref.to_vec().len() > 1 {
+            return not_impl_err!(
+                "Unparsing a filter applied after a row limit is not supported for a qualified table name on a dialect that spells columns in full"
+            );
+        }
+
+        // A scan can project no columns at all, which every other empty
+        // projection in this unparser renders as `SELECT 1`. There is no
+        // column list to name a derived table's output with here, so refuse.
+        // (Two columns of one name cannot arrive: `DFSchema` rejects a scan
+        // with a duplicate qualified field.)
+        let fields = plan.schema().fields();
+        if fields.is_empty() {
+            return not_impl_err!(
+                "Unparsing a filter applied after a row limit is not supported for an input projecting no columns"
+            );
+        }
+
         // The subtree moves into a statement of its own, so this `SELECT` no
-        // longer receives a projection from the nodes below. Name the derived
-        // table's columns explicitly, as the scan underneath would have: a
-        // wildcard here would expand to every relation in the enclosing `FROM`
-        // — every column of a join, not this side's contribution to it.
+        // longer receives a projection from the nodes below it.
         if !select.already_projected() {
-            let items = plan
-                .schema()
-                .fields()
+            let items = fields
                 .iter()
                 .map(|field| {
                     self.select_item_to_sql(&Expr::Column(Column::new(
@@ -520,22 +556,24 @@ impl Unparser<'_> {
         )
     }
 
-    /// The single relation a subtree reads from, if it reads exactly one.
+    /// The relation a subtree scans, when the subtree is one scan under
+    /// clauses that neither rename nor add columns and neither reorder nor
+    /// combine rows from elsewhere.
     ///
-    /// Only the shapes that can sit between a limit and its source are walked
-    /// through; anything else (a join, a union, a set operation) has no single
-    /// name to answer with, and neither does a subtree reading two tables.
-    fn sole_relation_of(plan: &LogicalPlan) -> Option<TableReference> {
+    /// A `Sort` is deliberately not walked through. It is the one such clause
+    /// whose effect does not survive being wrapped: SQL does not carry a
+    /// derived table's row order into the query selecting from it.
+    fn scanned_relation_of(plan: &LogicalPlan) -> Option<TableReference> {
         match plan {
             LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
-            LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
-            LogicalPlan::Limit(limit) => Self::sole_relation_of(limit.input.as_ref()),
-            LogicalPlan::Filter(filter) => Self::sole_relation_of(filter.input.as_ref()),
-            LogicalPlan::Sort(sort) => Self::sole_relation_of(sort.input.as_ref()),
-            LogicalPlan::Projection(projection) => {
-                Self::sole_relation_of(projection.input.as_ref())
+            LogicalPlan::SubqueryAlias(alias) => {
+                Self::scanned_relation_of(alias.input.as_ref())
+                    .map(|_| alias.alias.clone())
             }
-            LogicalPlan::Distinct(distinct) => Self::sole_relation_of(distinct.input()),
+            LogicalPlan::Limit(limit) => Self::scanned_relation_of(limit.input.as_ref()),
+            LogicalPlan::Filter(filter) => {
+                Self::scanned_relation_of(filter.input.as_ref())
+            }
             _ => None,
         }
     }
@@ -894,7 +932,7 @@ impl Unparser<'_> {
                     );
                 }
                 if (limit.fetch.is_some() || limit.skip.is_some())
-                    && Self::row_limit_needs_own_scope(select)?
+                    && Self::row_limit_needs_own_scope(plan, select)?
                 {
                     return self.derive_row_limited_scope(plan, select, relation);
                 }
@@ -940,10 +978,16 @@ impl Unparser<'_> {
                 }
                 // A `Sort` carrying a `fetch` renders that fetch as this
                 // query's `LIMIT`, so it reorders against a predicate above it
-                // exactly as a `Limit` node does. A sort without one does not:
-                // `ORDER BY` is evaluated after `WHERE` either way.
-                if sort.fetch.is_some() && Self::row_limit_needs_own_scope(select)? {
-                    return self.derive_row_limited_scope(plan, select, relation);
+                // exactly as a `Limit` node does — but it cannot be moved into
+                // a derived table the way a `Limit` can, because SQL does not
+                // carry a derived table's row order out to the query selecting
+                // from it. (A sort without a fetch reorders nothing: `ORDER BY`
+                // is evaluated after `WHERE` either way.)
+                if sort.fetch.is_some() && Self::row_limit_needs_own_scope(plan, select)?
+                {
+                    return not_impl_err!(
+                        "Unparsing a filter applied after a sort's fetch is not supported"
+                    );
                 }
 
                 let Some(query_ref) = query else {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -448,6 +448,98 @@ impl Unparser<'_> {
         }
     }
 
+    /// Whether the subtree carrying a row limit needs a `SELECT` of its own.
+    ///
+    /// The walk is top-down, so any predicate already on `select` came from a
+    /// node *above* the one being unparsed. `WHERE`, `HAVING` and `QUALIFY`
+    /// are all evaluated before `LIMIT`/`OFFSET`, while the plan says the
+    /// opposite: the limit runs first and the predicate filters what it
+    /// produced. Keeping both in one `SELECT` therefore states the reverse of
+    /// the plan, and can return rows the plan excludes.
+    ///
+    /// A `WHERE` can be left behind in an enclosing query while the limited
+    /// subtree moves into a derived table. `HAVING` and `QUALIFY` cannot: they
+    /// reference an aggregate or window expression that only the `SELECT`
+    /// computing it can name. Refuse those rather than emit either the
+    /// reversed form or a predicate with nothing to bind to.
+    fn row_limit_needs_own_scope(select: &SelectBuilder) -> Result<bool> {
+        if select.has_grouped_predicate() {
+            return not_impl_err!(
+                "Unparsing a HAVING or QUALIFY predicate that is applied after a row limit is not supported"
+            );
+        }
+        Ok(select.has_selection())
+    }
+
+    /// Unparses `plan` — a `Limit`, or a `Sort` carrying a `fetch` — as a
+    /// derived table, so the predicate already on the enclosing `SELECT`
+    /// applies to the limited rows rather than to the rows feeding the limit.
+    ///
+    /// The derived table takes the name of the relation the subtree reads,
+    /// because the predicate staying outside is still qualified by it. A
+    /// subtree reading more than one relation has no such name to take: every
+    /// qualifier the predicate could carry would be gone from scope, so the
+    /// query is refused rather than rendered unbindable.
+    fn derive_row_limited_scope(
+        &self,
+        plan: &LogicalPlan,
+        select: &mut SelectBuilder,
+        relation: &mut RelationBuilder,
+    ) -> Result<()> {
+        let Some(table_ref) = Self::sole_relation_of(plan) else {
+            return not_impl_err!(
+                "Unparsing a filter applied after a row limit is not supported when the limited input reads more than one relation"
+            );
+        };
+
+        // The subtree moves into a statement of its own, so this `SELECT` no
+        // longer receives a projection from the nodes below. Name the derived
+        // table's columns explicitly, as the scan underneath would have: a
+        // wildcard here would expand to every relation in the enclosing `FROM`
+        // — every column of a join, not this side's contribution to it.
+        if !select.already_projected() {
+            let items = plan
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| {
+                    self.select_item_to_sql(&Expr::Column(Column::new(
+                        Some(table_ref.clone()),
+                        field.name(),
+                    )))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            select.projection(items);
+        }
+
+        self.derive(
+            plan,
+            relation,
+            Some(self.new_table_alias(table_ref.table().to_string(), vec![])),
+            false,
+        )
+    }
+
+    /// The single relation a subtree reads from, if it reads exactly one.
+    ///
+    /// Only the shapes that can sit between a limit and its source are walked
+    /// through; anything else (a join, a union, a set operation) has no single
+    /// name to answer with, and neither does a subtree reading two tables.
+    fn sole_relation_of(plan: &LogicalPlan) -> Option<TableReference> {
+        match plan {
+            LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
+            LogicalPlan::SubqueryAlias(alias) => Some(alias.alias.clone()),
+            LogicalPlan::Limit(limit) => Self::sole_relation_of(limit.input.as_ref()),
+            LogicalPlan::Filter(filter) => Self::sole_relation_of(filter.input.as_ref()),
+            LogicalPlan::Sort(sort) => Self::sole_relation_of(sort.input.as_ref()),
+            LogicalPlan::Projection(projection) => {
+                Self::sole_relation_of(projection.input.as_ref())
+            }
+            LogicalPlan::Distinct(distinct) => Self::sole_relation_of(distinct.input()),
+            _ => None,
+        }
+    }
+
     /// Projection unparsing when [`super::dialect::Dialect::unnest_as_lateral_flatten`] is enabled:
     /// Snowflake-style `LATERAL FLATTEN` for unnest (not other dialect spellings).
     ///
@@ -801,6 +893,11 @@ impl Unparser<'_> {
                         vec![],
                     );
                 }
+                if (limit.fetch.is_some() || limit.skip.is_some())
+                    && Self::row_limit_needs_own_scope(select)?
+                {
+                    return self.derive_row_limited_scope(plan, select, relation);
+                }
                 if let Some(fetch) = &limit.fetch {
                     let Some(query) = query.as_mut() else {
                         return internal_err!(
@@ -840,6 +937,13 @@ impl Unparser<'_> {
                         false,
                         vec![],
                     );
+                }
+                // A `Sort` carrying a `fetch` renders that fetch as this
+                // query's `LIMIT`, so it reorders against a predicate above it
+                // exactly as a `Limit` node does. A sort without one does not:
+                // `ORDER BY` is evaluated after `WHERE` either way.
+                if sort.fetch.is_some() && Self::row_limit_needs_own_scope(select)? {
+                    return self.derive_row_limited_scope(plan, select, relation);
                 }
 
                 let Some(query_ref) = query else {
@@ -1025,7 +1129,8 @@ impl Unparser<'_> {
                     Arc::clone(right_plan)
                 } else {
                     let right_plan =
-                        match try_transform_to_simple_table_scan_with_filters(right_plan)? {
+                        match try_transform_to_simple_table_scan_with_filters(right_plan)?
+                        {
                             Some((plan, filters)) => {
                                 table_scan_filters.extend(filters);
                                 Arc::new(plan)

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -322,7 +322,11 @@ pub(crate) fn unproject_sort_expr(
     // PostgreSQL and similar dialects reject output-column aliases inside
     // expressions. That path is handled by the recursive `transform` below,
     // which is only reached when `sort_expr.expr` is not a bare column.
-    if let Expr::Column(Column{relation: None, name, .. }) = &sort_expr.expr
+    if let Expr::Column(Column {
+        relation: None,
+        name,
+        ..
+    }) = &sort_expr.expr
         && let LogicalPlan::Projection(Projection { expr, schema, .. }) = input
         && let Some(idx) = schema.index_of_column_by_name(None, name)
         && let Some(Expr::Alias(_)) = expr.get(idx)
@@ -339,20 +343,21 @@ pub(crate) fn unproject_sort_expr(
                 // Qualified columns reference FROM relations directly; only
                 // unqualified columns can name aggregate/projection outputs
                 // that need unprojecting below.
-                Expr::Column(Column { relation: Some(_), .. }) => {
-                    Ok(Transformed::no(sub_expr))
-                }
+                Expr::Column(Column {
+                    relation: Some(_), ..
+                }) => Ok(Transformed::no(sub_expr)),
                 // In case of aggregation there could be columns containing aggregation functions we need to unproject
-                Expr::Column(col) if let Some(agg) = agg
-                    && agg.schema.is_column_from_schema(&col) => {
-                        return Ok(Transformed::yes(unproject_agg_exprs(
-                            Expr::Column(col),
-                            agg,
-                            None,
-                        )?));
-                    }
+                Expr::Column(col)
+                    if let Some(agg) = agg
+                        && agg.schema.is_column_from_schema(&col) =>
+                {
+                    return Ok(Transformed::yes(unproject_agg_exprs(
+                        Expr::Column(col),
+                        agg,
+                        None,
+                    )?));
+                }
                 Expr::Column(col) => {
-
                     // When an expression in the `ORDER BY` contains an alias from the `SELECT`
                     // we need to transform it back to the actual expression so that it is
                     // valid SQL in all positions inside ORDER BY (PostgreSQL only allows bare

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4307,16 +4307,28 @@ fn test_filter_above_limit_gets_its_own_scope() -> Result<()> {
         @r#"SELECT t.id, t."name" FROM (SELECT * FROM t OFFSET 3) AS t WHERE (t.id = 'a')"#
     );
 
-    // A `Sort` carrying a `fetch` renders that fetch as the query's `LIMIT`,
-    // so it needs the same treatment as a `Limit` node.
+    Ok(())
+}
+
+/// A `Sort` carrying a `fetch` renders that fetch as the query's `LIMIT`, so a
+/// predicate above it reorders in the same way. It cannot take the same fix: a
+/// derived table's row order is not carried out to the query selecting from
+/// it, so moving the sort inside one would repair the row set and lose the
+/// ordering the plan promises.
+#[test]
+fn test_filter_above_a_sort_fetch_is_refused() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
     let plan = table_scan(Some("t"), &schema, None)?
         .sort_with_limit(vec![col("id").sort(true, false)], Some(5))?
         .filter(col("id").eq(lit("a")))?
         .build()?;
-    assert_snapshot!(
-        plan_to_sql(&plan)?,
-        @r#"SELECT t.id, t."name" FROM (SELECT * FROM t ORDER BY t.id ASC NULLS LAST LIMIT 5) AS t WHERE (t.id = 'a')"#
-    );
+    let error =
+        plan_to_sql(&plan).expect_err("a filter above a sort fetch cannot be unparsed");
+    assert_contains!(error.to_string(), "after a sort\'s fetch");
 
     Ok(())
 }
@@ -4494,7 +4506,7 @@ fn test_filter_above_limit_over_a_join_is_refused() -> Result<()> {
         .build()?;
     let error = plan_to_sql(&plan)
         .expect_err("a filter above a limit over a join cannot be unparsed");
-    assert_contains!(error.to_string(), "reads more than one relation");
+    assert_contains!(error.to_string(), "limited input is a single table scan");
 
     Ok(())
 }
@@ -4552,6 +4564,143 @@ fn test_filter_above_a_limited_join_input_keeps_the_join_schema() -> Result<()> 
         plan_to_sql(&plan)?,
         @r#"SELECT a.id, a."name", b.id, b.age FROM (SELECT a.id, a."name" FROM a LIMIT 5) AS a INNER JOIN b ON a.id = b.id WHERE (a."name" = 'x')"#
     );
+
+    Ok(())
+}
+
+/// The derived table's columns are named by the enclosing query, which only
+/// works if the derived query names them the same way. A projection breaks
+/// that: an unaliased expression is a column the derived query never names,
+/// and two aliases differing only by a qualifier collapse onto one SQL name.
+#[test]
+fn test_filter_above_limit_over_a_projection_is_refused() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+
+    let plan = table_scan(Some("t"), &schema, None)?
+        .project(vec![col("a").add(col("b"))])?
+        .limit(0, Some(5))?
+        .filter(col("t.a + t.b").gt(lit(1i32)))?
+        .build()?;
+    let error = plan_to_sql(&plan)
+        .expect_err("a filter above a limited projection cannot be unparsed");
+    assert_contains!(error.to_string(), "limited input is a single table scan");
+
+    Ok(())
+}
+
+/// A sort below the limit orders what the plan returns just as surely as one
+/// above it, and a derived table does not carry its row order out. It is the
+/// one clause that may wrap a scan and still not be safe to move inside.
+#[test]
+fn test_filter_above_a_limited_sort_is_refused() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let plan = table_scan(Some("t"), &schema, None)?
+        .sort(vec![col("id").sort(true, false)])?
+        .limit(0, Some(5))?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    let error =
+        plan_to_sql(&plan).expect_err("a filter above a limited sort cannot be unparsed");
+    assert_contains!(error.to_string(), "limited input is a single table scan");
+
+    Ok(())
+}
+
+/// A dialect that spells columns in full leaves the outer predicate qualified
+/// by every part of the table's path, while a derived table can only be
+/// aliased by one identifier. The predicate would be left naming a path that
+/// is no longer in scope.
+#[test]
+fn test_filter_above_limit_is_refused_for_a_fully_qualified_column() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .with_identifier_quote_style('"')
+        .build();
+
+    let plan = table_scan(Some("catalog.schema.t"), &schema, None)?
+        .limit(0, Some(5))?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    let error = Unparser::new(&dialect)
+        .plan_to_sql(&plan)
+        .expect_err("a fully qualified predicate cannot survive the alias");
+    assert_contains!(error.to_string(), "dialect that spells columns in full");
+
+    // A bare table name has nothing to lose, so the same dialect renders it.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .limit(0, Some(5))?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    assert_snapshot!(
+        Unparser::new(&dialect).plan_to_sql(&plan)?,
+        @r#"SELECT "t"."id", "t"."name" FROM (SELECT * FROM "t" LIMIT 5) AS "t" WHERE ("t"."id" = 'a')"#
+    );
+
+    Ok(())
+}
+
+/// Join inputs are walked with one shared `SelectBuilder`, so a predicate on
+/// it need not be an ancestor of the node being unparsed. A `HAVING` from one
+/// input must not make the other input's limit unrenderable.
+#[test]
+fn test_a_sibling_having_does_not_refuse_the_other_inputs_limit() -> Result<()> {
+    let left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let grouped_left = table_scan(Some("a"), &left, None)?
+        .aggregate(vec![col("id")], vec![count(col("name"))])?
+        .filter(col("COUNT(a.name)").gt(lit(1i64)))?
+        .build()?;
+    let limited_right = table_scan(Some("b"), &right, Some(vec![0, 1]))?
+        .limit(0, Some(5))?
+        .build()?;
+    let plan = LogicalPlanBuilder::from(grouped_left)
+        .join(
+            limited_right,
+            datafusion_expr::JoinType::Inner,
+            (vec!["a.id"], vec!["b.id"]),
+            None,
+        )?
+        .build()?;
+
+    plan_to_sql(&plan).expect("a sibling's HAVING is not this limit's predicate");
+
+    Ok(())
+}
+
+/// A scan can project no columns, and then there is no column list to name
+/// the derived table's output with.
+#[test]
+fn test_filter_above_limit_over_an_empty_projection_is_refused() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let plan = table_scan(Some("t"), &schema, Some(vec![]))?
+        .limit(0, Some(5))?
+        .filter(lit(true))?
+        .build()?;
+    let error = plan_to_sql(&plan)
+        .expect_err("a limited scan with no columns cannot be unparsed");
+    assert_contains!(error.to_string(), "projecting no columns");
 
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -23,7 +23,7 @@ use datafusion_common::{
 };
 use datafusion_expr::expr::{WindowFunction, WindowFunctionParams};
 use datafusion_expr::test::function_stub::{
-    count_udaf, max, max_udaf, min_udaf, sum, sum_udaf,
+    count, count_udaf, max, max_udaf, min_udaf, sum, sum_udaf,
 };
 use datafusion_expr::{
     ColumnarValue, EmptyRelation, Expr, Extension, LogicalPlan, LogicalPlanBuilder,
@@ -4272,5 +4272,286 @@ fn test_unparse_chained_intersect_build_side_is_self_contained() -> Result<()> {
         sql,
         @r#"SELECT DISTINCT * FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "left" WHERE EXISTS (SELECT 1 FROM (SELECT DISTINCT "p"."first_name", "o"."order_id" FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id")) AS "right" WHERE ("left"."first_name" = "right"."first_name") AND ("left"."order_id" = "right"."order_id")) AND EXISTS (SELECT 1 FROM "person" AS "p" INNER JOIN "orders" AS "o" ON ("p"."id" = "o"."customer_id") WHERE ("left"."first_name" = "p"."first_name") AND ("left"."order_id" = "o"."order_id"))"#
     );
+    Ok(())
+}
+
+/// A `Filter` above a row limit must not be flattened into the same `SELECT`
+/// as that limit: SQL evaluates `WHERE` before `LIMIT`, so the flattened form
+/// means the opposite of the plan and can return rows the plan excludes.
+#[test]
+fn test_filter_above_limit_gets_its_own_scope() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    // Take 5 rows, then keep the matching ones. The limit belongs in a derived
+    // table, named after the relation the surviving predicate is qualified by.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .limit(0, Some(5))?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT t.id, t."name" FROM (SELECT * FROM t LIMIT 5) AS t WHERE (t.id = 'a')"#
+    );
+
+    // An OFFSET is evaluated at the same point as a LIMIT, so a skip-only
+    // limit reorders against the predicate in exactly the same way.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .limit(3, None)?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT t.id, t."name" FROM (SELECT * FROM t OFFSET 3) AS t WHERE (t.id = 'a')"#
+    );
+
+    // A `Sort` carrying a `fetch` renders that fetch as the query's `LIMIT`,
+    // so it needs the same treatment as a `Limit` node.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .sort_with_limit(vec![col("id").sort(true, false)], Some(5))?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT t.id, t."name" FROM (SELECT * FROM t ORDER BY t.id ASC NULLS LAST LIMIT 5) AS t WHERE (t.id = 'a')"#
+    );
+
+    Ok(())
+}
+
+/// The two predicate sources around a limit are applied at different times: a
+/// `TableScan`'s own filters run before the scan's rows reach the limit, a
+/// `Filter` node above the limit runs after. Both are accumulated into the
+/// same `WHERE` while the walk is inside one `SELECT`, so the split has to
+/// come from where each one is unparsed, not from the clause it lands in.
+#[test]
+fn test_scan_filter_stays_below_the_limit_it_precedes() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let plan = table_scan_with_filters(
+        Some("t"),
+        &schema,
+        None,
+        vec![col("name").eq(lit("z"))],
+    )?
+    .limit(0, Some(5))?
+    .filter(col("id").eq(lit("a")))?
+    .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT t.id, t."name" FROM (SELECT * FROM t WHERE (t."name" = 'z') LIMIT 5) AS t WHERE (t.id = 'a')"#
+    );
+
+    Ok(())
+}
+
+/// The new scope is only for a predicate that sits *above* the limit. A
+/// predicate below it is already in the order SQL evaluates, and a limit with
+/// no predicate above it has nothing to reorder against — neither may grow a
+/// derived table.
+#[test]
+fn test_limit_without_a_predicate_above_it_stays_flat() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    // Filter below the limit: keep the matching rows, then take 5 of them —
+    // which is what a single `SELECT ... WHERE ... LIMIT` already means.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .filter(col("id").eq(lit("a")))?
+        .limit(0, Some(5))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT * FROM t WHERE (t.id = 'a') LIMIT 5"#
+    );
+
+    // No predicate at all.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .limit(0, Some(5))?
+        .build()?;
+    assert_snapshot!(plan_to_sql(&plan)?, @r#"SELECT * FROM t LIMIT 5"#);
+
+    // A sort without a fetch contributes no limit, so a predicate above it is
+    // still evaluated first either way.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .sort(vec![col("id").sort(true, false)])?
+        .filter(col("id").eq(lit("a")))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT * FROM t WHERE (t.id = 'a') ORDER BY t.id ASC NULLS LAST"#
+    );
+
+    Ok(())
+}
+
+/// `HAVING` is evaluated before `LIMIT` too, so an aggregate-referencing
+/// filter above a limit reorders in the same way a `WHERE` does — but it
+/// cannot be lifted out the way a `WHERE` can, because the aggregate it
+/// references is only nameable in the `SELECT` that computes it. Refusing is
+/// the only answer that is neither reversed nor unbindable.
+#[test]
+fn test_having_above_limit_is_refused() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let plan = table_scan(Some("t"), &schema, None)?
+        .aggregate(vec![col("name")], vec![count(col("id"))])?
+        .limit(0, Some(5))?
+        .filter(col("COUNT(t.id)").gt(lit(1i64)))?
+        .build()?;
+    let error =
+        plan_to_sql(&plan).expect_err("a HAVING above a limit cannot be unparsed");
+    assert_contains!(
+        error.to_string(),
+        "HAVING or QUALIFY predicate that is applied after a row limit"
+    );
+
+    // The same aggregate with the limit above the filter is the order SQL
+    // already means, and still unparses.
+    let plan = table_scan(Some("t"), &schema, None)?
+        .aggregate(vec![col("name")], vec![count(col("id"))])?
+        .filter(col("COUNT(t.id)").gt(lit(1i64)))?
+        .limit(0, Some(5))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT COUNT(t.id), t."name" FROM t GROUP BY t."name" HAVING (COUNT(t.id) > 1) LIMIT 5"#
+    );
+
+    Ok(())
+}
+
+/// The generated SQL has to mean what the plan meant, and the derived table
+/// has to be addressable by the predicate left outside it. Planning the SQL
+/// back proves both: an unresolvable qualifier would fail to plan, and a
+/// reordered one would come back with the limit above the filter.
+#[test]
+fn test_filter_above_limit_round_trips() -> Result<()> {
+    let schema = Schema::new(vec![Field::new("id", DataType::UInt32, false)]);
+    let plan = table_scan(Some("person"), &schema, None)?
+        .limit(0, Some(5))?
+        .filter(col("id").gt(lit(5u32)))?
+        .build()?;
+
+    let sql = plan_to_sql(&plan)?;
+    let statement = Parser::new(&GenericDialect {})
+        .try_with_sql(&sql.to_string())?
+        .parse_statement()?;
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let replanned = SqlToRel::new(&context).sql_statement_to_plan(statement)?;
+
+    let displayed = replanned.display_indent().to_string();
+    let filter_at = displayed
+        .find("Filter:")
+        .expect("re-planned SQL should still filter");
+    let limit_at = displayed
+        .find("Limit:")
+        .expect("re-planned SQL should still limit");
+    assert!(
+        filter_at < limit_at,
+        "the limit must stay below the filter, got:\n{displayed}"
+    );
+
+    Ok(())
+}
+
+/// A limited subtree that reads two relations cannot become a derived table
+/// the outer predicate can still address: both qualifiers leave scope, and no
+/// single name replaces them. Refuse, rather than reverse the two or emit a
+/// predicate with nothing to bind to.
+#[test]
+fn test_filter_above_limit_over_a_join_is_refused() -> Result<()> {
+    let left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let plan = LogicalPlanBuilder::from(table_scan(Some("a"), &left, None)?.build()?)
+        .join(
+            table_scan(Some("b"), &right, None)?.build()?,
+            datafusion_expr::JoinType::Inner,
+            (vec!["a.id"], vec!["b.id"]),
+            None,
+        )?
+        .limit(0, Some(5))?
+        .filter(col("a.name").eq(lit("x")))?
+        .build()?;
+    let error = plan_to_sql(&plan)
+        .expect_err("a filter above a limit over a join cannot be unparsed");
+    assert_contains!(error.to_string(), "reads more than one relation");
+
+    Ok(())
+}
+
+/// A `SubqueryAlias` under the limit already supplies the name the outer
+/// predicate is qualified by, so it is the name the derived table takes.
+#[test]
+fn test_filter_above_limit_keeps_a_subquery_alias() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+
+    let plan = table_scan(Some("t"), &schema, None)?
+        .alias("x")?
+        .limit(0, Some(5))?
+        .filter(col("x.name").eq(lit("q")))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT x.id, x."name" FROM (SELECT * FROM t AS x LIMIT 5) AS x WHERE (x."name" = 'q')"#
+    );
+
+    Ok(())
+}
+
+/// A limit on one join input is that input's own, and the derived table it
+/// becomes contributes only that input's columns to the enclosing `SELECT`
+/// list. A wildcard there would expand to every relation in the `FROM`,
+/// returning the other side's columns twice.
+#[test]
+fn test_filter_above_a_limited_join_input_keeps_the_join_schema() -> Result<()> {
+    let left = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+    ]);
+    let right = Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let limited_left = table_scan(Some("a"), &left, Some(vec![0, 1]))?
+        .limit(0, Some(5))?
+        .build()?;
+    let plan = LogicalPlanBuilder::from(limited_left)
+        .join(
+            table_scan(Some("b"), &right, Some(vec![0, 1]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            (vec!["a.id"], vec!["b.id"]),
+            None,
+        )?
+        .filter(col("a.name").eq(lit("x")))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT a.id, a."name", b.id, b.age FROM (SELECT a.id, a."name" FROM a LIMIT 5) AS a INNER JOIN b ON a.id = b.id WHERE (a."name" = 'x')"#
+    );
+
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -4328,7 +4328,7 @@ fn test_filter_above_a_sort_fetch_is_refused() -> Result<()> {
         .build()?;
     let error =
         plan_to_sql(&plan).expect_err("a filter above a sort fetch cannot be unparsed");
-    assert_contains!(error.to_string(), "after a sort\'s fetch");
+    assert_contains!(error.to_string(), "after a sort's fetch");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`plan_to_sql` rendered a `Filter` sitting **above** a `Limit` as a single `SELECT` carrying both a `WHERE` and a `LIMIT`. SQL evaluates `WHERE` before `LIMIT`, so the generated SQL means the opposite of the plan: the plan takes n rows and keeps the matching ones, the SQL keeps the matching rows and takes n. The result can contain rows the plan excludes, and more rows than the plan can produce.

```
Filter: t.id = Utf8("a")
  Limit: skip=0, fetch=5
    TableScan: t
```

before → `SELECT * FROM t WHERE (t.id = 'a') LIMIT 5`
after  → `SELECT t.id, t."name" FROM (SELECT * FROM t LIMIT 5) AS t WHERE (t.id = 'a')`

Reported as spiceai/spiceai#12591. `OFFSET` has the same problem, and a `Sort` carrying a `fetch` renders the same `LIMIT`.

## Changes

- **The limited subtree becomes a derived table**, named after the relation it reads — the predicate that stays outside is still qualified by that name — with its columns listed explicitly rather than as `*`. A wildcard would expand to every relation in the enclosing `FROM`; on a join that returns the other side's columns twice.
- **A `TableScan`'s own filters stay inside that scope.** Both predicate sources accumulate into one `WHERE` while the walk is in one `SELECT`, but the plan applies them at different times: a scan's filters before its fetch, a `Filter` node above the limit after it. The split comes from where each is unparsed, not from the clause it lands in.
- **Shapes with no faithful rendering are refused** with `not_impl_err` rather than reversed. Each costs a pushdown and never the rows:
  - anything but a scan under clauses that rename nothing — a projection can emit a column the derived query never names (an unaliased expression) or two columns differing only by a qualifier SQL cannot carry across the boundary; a join, union or aggregate has no single name for the alias to take;
  - a `Sort`, above or below the limit — SQL does not carry a derived table's row order out to the query selecting from it, so wrapping one would repair the row set and lose the ordering the plan promises;
  - a `HAVING`/`QUALIFY` predicate, which names an aggregate or window expression only the `SELECT` computing it can name;
  - a qualified table name on a dialect that spells columns in full, where no single-identifier alias keeps the predicate's path in scope;
  - a scan projecting no columns, which has no column list to name the derived output with.

The `HAVING`/`QUALIFY` refusal fires only when the grouping it filters is below this limit: join inputs are walked with one shared `SelectBuilder`, so a predicate on it may belong to a sibling input, and one input's `HAVING` must not make the other input's limit unrenderable.

## Reachability

A `Filter` directly above a `Limit` normally comes from an explicit subquery or from a rewrite that inserts a filter above a fetch, not from the standard optimizer, which pushes filters down past limits. A plan with a `Projection` above the filter already took the existing `derived_limit` path and was never reversed.

## Not addressed here

- A derived table on the pre-existing `already_projected()` path is still aliased by a generated name or none at all, so a qualified outer predicate can fail to bind (spiceai/spiceai#12594). Unchanged by this PR.
- `Filter -> Limit -> Projection(<unaliased expression>)` was already unrenderable before this change — the outer predicate referenced a column the inner `SELECT` does not name. It is now a refusal instead of SQL the engine rejects.

## Test plan

`cargo test -p datafusion-sql` — 511 pass, 14 new. The 22 failures are byte-identical to the pre-existing set on `spiceai-54` (same names, same assertion output); the two fetch-related ones among them were diffed before/after to confirm nothing regressed behind an already-red test. `cargo test -p datafusion --test core_integration -- sql::unparser sql::joins` passes, including the TPC-H and ClickBench unparser round-trips. `rustfmt --check` and `cargo clippy -p datafusion-sql --all-features --tests` report nothing on the changed lines.

New tests: the reported plan and its `OFFSET` form; a scan filter staying below the limit while the `Filter` node's predicate goes outside; a `SubqueryAlias` supplying the derived name; a limit on one join input keeping the join's schema; a round-trip that re-plans the generated SQL and asserts the filter is still above the limit (which also proves the alias binds); each of the five refusals; and a sibling `HAVING` that must *not* refuse the other input's limit. A negative set pins that a filter below the limit, a limit with no predicate above it, and a sort without a fetch all stay flat.

A 13-neuter matrix was run against those tests — every neuter (dropping either arm, treating `skip` as a no-op, deriving instead of refusing in each of the five cases, dropping the alias, using a wildcard projection, ignoring a `SubqueryAlias`, walking through a `Sort`, and stubbing `has_selection`) is caught by at least one test.
