### PR TITLE
fix(common): report a cancelled task as an error, not an unreachable arm

### DIFF
--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -31,7 +31,9 @@ use arrow::compute::{and, filter_record_batch};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::error::Result;
-use datafusion_common::{Constraints, DFSchema, SchemaExt, not_impl_err, plan_err};
+use datafusion_common::{
+    Constraints, DFSchema, DataFusionError, SchemaExt, not_impl_err, plan_err,
+};
 use datafusion_common_runtime::JoinSet;
 use datafusion_datasource::memory::{MemSink, MemorySourceConfig};
 use datafusion_datasource::sink::DataSinkExec;
@@ -166,13 +168,7 @@ impl MemTable {
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok(res) => data.push(res?),
-                Err(e) => {
-                    if e.is_panic() {
-                        std::panic::resume_unwind(e.into_panic());
-                    } else {
-                        unreachable!();
-                    }
-                }
+                Err(e) => return Err(DataFusionError::from_join_error(e)),
             }
         }
 

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -453,7 +453,7 @@ impl TableProvider for MemTable {
                     let column_name = field.name();
                     let original_column =
                         batch.column_by_name(column_name).ok_or_else(|| {
-                            datafusion_common::DataFusionError::Internal(format!(
+                            DataFusionError::Internal(format!(
                                 "Column '{column_name}' not found in batch"
                             ))
                         })?;
@@ -517,7 +517,7 @@ fn evaluate_filters_to_mask(
             .as_any()
             .downcast_ref::<BooleanArray>()
             .ok_or_else(|| {
-                datafusion_common::DataFusionError::Internal(
+                DataFusionError::Internal(
                     "Filter did not evaluate to boolean".to_string(),
                 )
             })?

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -1547,8 +1547,9 @@ mod test {
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("build a current-thread runtime");
+        let task = rt.spawn(async { panic!("task payload") });
         let err = rt
-            .block_on(async { tokio::spawn(async { panic!("task payload") }).await })
+            .block_on(task)
             .expect_err("a panicking task cannot succeed");
         assert!(err.is_panic(), "precondition: the task panicked");
 

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -132,7 +132,15 @@ pub enum DataFusionError {
     Execution(String),
     /// [`JoinError`] during execution of the query.
     ///
-    /// This error can't occur for unjoined tasks, such as execution shutdown.
+    /// Only a task that is actually joined can report a [`JoinError`], so a task
+    /// that is spawned and never awaited never reaches this variant. A joined
+    /// task that was **cancelled** does: it was aborted, or the runtime it was
+    /// spawned on shut down while it was still queued. The `JoinError` stays
+    /// reachable as the error's source so a caller can still ask
+    /// [`JoinError::is_cancelled`].
+    ///
+    /// Construct this with [`DataFusionError::from_join_error`], which reports a
+    /// **panicking** task by resuming its panic rather than returning it here.
     ExecutionJoin(Box<JoinError>),
     /// Error when resources (such as memory of scratch disk space) are exhausted.
     ///

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -418,6 +418,31 @@ impl DataFusionError {
     /// The separator between the error message and the backtrace
     pub const BACK_TRACE_SEP: &'static str = "\n\nbacktrace: ";
 
+    /// Convert a [`JoinError`] observed while joining a task into a
+    /// `DataFusionError`.
+    ///
+    /// A [`JoinError`] reports one of exactly two outcomes, and they are not
+    /// interchangeable:
+    ///
+    /// * The task **panicked**. The panic is resumed on the calling thread, so it
+    ///   surfaces where the caller can see it instead of being downgraded to an
+    ///   ordinary error. This function does not return in that case.
+    /// * The task was **cancelled** — it was aborted, or the runtime it was spawned
+    ///   on shut down while it was still queued. That is returned as
+    ///   [`DataFusionError::ExecutionJoin`], which keeps the `JoinError` as the
+    ///   error's source so a caller can still ask [`JoinError::is_cancelled`].
+    ///
+    /// Draining a `JoinSet` is the usual caller: every task the set yields an
+    /// `Err` for is one of these two cases.
+    pub fn from_join_error(e: JoinError) -> Self {
+        if e.is_panic() {
+            // Resume on this thread so the panic is not turned into an error that
+            // loses the payload and the original backtrace.
+            std::panic::resume_unwind(e.into_panic());
+        }
+        Self::ExecutionJoin(Box::new(e))
+    }
+
     /// Get deepest underlying [`DataFusionError`]
     ///
     /// [`DataFusionError`]s sometimes form a chain, such as `DataFusionError::ArrowError()` in order to conform
@@ -1135,6 +1160,7 @@ mod test {
     use super::*;
 
     use std::mem::size_of;
+    use std::panic::AssertUnwindSafe;
     use std::sync::Arc;
 
     use arrow::error::ArrowError;
@@ -1481,5 +1507,60 @@ mod test {
         assert_eq!(errs[0].strip_backtrace(), "Error during planning: a");
         assert_eq!(errs[1].strip_backtrace(), "Error during planning: b");
         assert_eq!(errs[2].strip_backtrace(), "Error during planning: c");
+    }
+
+    /// A `JoinError` for a task that was aborted rather than left to panic.
+    fn cancelled_join_error() -> JoinError {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build a current-thread runtime");
+        // The runtime is never driven before `abort`, so the task cannot have run.
+        let task = rt.spawn(std::future::pending::<()>());
+        task.abort();
+        rt.block_on(task)
+            .expect_err("an aborted task cannot succeed")
+    }
+
+    #[test]
+    fn from_join_error_reports_a_cancelled_task_as_execution_join() {
+        let err = cancelled_join_error();
+        assert!(err.is_cancelled(), "precondition: the task was cancelled");
+
+        let err = DataFusionError::from_join_error(err);
+
+        // The variant carries the `JoinError`, so a caller can still tell a
+        // cancellation apart from any other execution failure.
+        match &err {
+            DataFusionError::ExecutionJoin(join_error) => {
+                assert!(join_error.is_cancelled());
+            }
+            other => panic!("expected ExecutionJoin, got {other:?}"),
+        }
+        assert!(
+            Error::source(&err).is_some(),
+            "the JoinError must remain reachable as the error's source"
+        );
+    }
+
+    #[test]
+    fn from_join_error_resumes_a_panicking_task_instead_of_returning() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build a current-thread runtime");
+        let err = rt
+            .block_on(async { tokio::spawn(async { panic!("task payload") }).await })
+            .expect_err("a panicking task cannot succeed");
+        assert!(err.is_panic(), "precondition: the task panicked");
+
+        let resumed = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            DataFusionError::from_join_error(err)
+        }));
+
+        let payload = resumed.expect_err("the panic must not be downgraded to an error");
+        assert_eq!(
+            payload.downcast_ref::<&str>().copied(),
+            Some("task payload"),
+            "the original panic payload must be carried through"
+        );
     }
 }

--- a/datafusion/datasource-arrow/src/file_format.rs
+++ b/datafusion/datasource-arrow/src/file_format.rs
@@ -323,13 +323,7 @@ impl FileSink for ArrowFileSink {
                 Ok(r) => {
                     row_count += r?;
                 }
-                Err(e) => {
-                    if e.is_panic() {
-                        std::panic::resume_unwind(e.into_panic());
-                    } else {
-                        unreachable!();
-                    }
-                }
+                Err(e) => return Err(DataFusionError::from_join_error(e)),
             }
         }
 

--- a/datafusion/datasource-csv/src/source.rs
+++ b/datafusion/datasource-csv/src/source.rs
@@ -490,13 +490,7 @@ pub async fn plan_to_csv(
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(res) => res?, // propagate DataFusion error
-            Err(e) => {
-                if e.is_panic() {
-                    std::panic::resume_unwind(e.into_panic());
-                } else {
-                    unreachable!();
-                }
-            }
+            Err(e) => return Err(DataFusionError::from_join_error(e)),
         }
     }
 

--- a/datafusion/datasource-json/src/source.rs
+++ b/datafusion/datasource-json/src/source.rs
@@ -511,13 +511,7 @@ pub async fn plan_to_json(
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(res) => res?, // propagate DataFusion error
-            Err(e) => {
-                if e.is_panic() {
-                    std::panic::resume_unwind(e.into_panic());
-                } else {
-                    unreachable!();
-                }
-            }
+            Err(e) => return Err(DataFusionError::from_join_error(e)),
         }
     }
 

--- a/datafusion/datasource-parquet/src/sink.rs
+++ b/datafusion/datasource-parquet/src/sink.rs
@@ -375,13 +375,7 @@ impl FileSink for ParquetSink {
                         .map_err(|e| internal_datafusion_err!("duplicate entry detected for partitioned file {path}: {e}"))?;
                     drop(written_files);
                 }
-                Err(e) => {
-                    if e.is_panic() {
-                        std::panic::resume_unwind(e.into_panic());
-                    } else {
-                        unreachable!();
-                    }
-                }
+                Err(e) => return Err(DataFusionError::from_join_error(e)),
             }
         }
 

--- a/datafusion/datasource-parquet/src/writer.rs
+++ b/datafusion/datasource-parquet/src/writer.rs
@@ -74,13 +74,7 @@ pub async fn plan_to_parquet(
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(res) => res?,
-            Err(e) => {
-                if e.is_panic() {
-                    std::panic::resume_unwind(e.into_panic());
-                } else {
-                    unreachable!();
-                }
-            }
+            Err(e) => return Err(DataFusionError::from_join_error(e)),
         }
     }
 

--- a/datafusion/physical-plan/src/execution_plan.rs
+++ b/datafusion/physical-plan/src/execution_plan.rs
@@ -1315,13 +1315,7 @@ pub async fn collect_partitioned(
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok((idx, res)) => batches.push((idx, res?)),
-            Err(e) => {
-                if e.is_panic() {
-                    std::panic::resume_unwind(e.into_panic());
-                } else {
-                    unreachable!();
-                }
-            }
+            Err(e) => return Err(DataFusionError::from_join_error(e)),
         }
     }
 
@@ -1557,6 +1551,9 @@ mod tests {
 
     use super::*;
     use crate::{DisplayAs, DisplayFormatType, ExecutionPlan};
+
+    use std::future::Future;
+    use std::task::{Context as TaskPollContext, Waker};
 
     use arrow::array::{DictionaryArray, Int32Array, NullArray, RunArray};
     use arrow::datatypes::{DataType, Field, Schema};
@@ -1887,5 +1884,54 @@ mod tests {
             "Execution error: Invalid batch column at '0' has null but schema specifies non-nullable",
         );
         Ok(())
+    }
+
+    /// A `JoinError` reports either a panic or a cancellation, so the non-panic arm
+    /// of the drain loop is reachable and must yield an error rather than panicking.
+    ///
+    /// The cancellation is produced the way it arises in practice: the per-partition
+    /// tasks are spawned on one runtime while the collecting future is driven by
+    /// another, so shutting the first down cancels the tasks that the drain loop is
+    /// still awaiting. Separate runtimes for serving and for query execution are a
+    /// normal deployment shape, which is why this is not a hypothetical arm.
+    #[test]
+    fn collect_partitioned_reports_a_cancelled_task_as_an_error() {
+        // Never driven, so every task spawned onto it stays queued until it is
+        // dropped and they are cancelled.
+        let task_rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build the task runtime");
+        let driver_rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build the driver runtime");
+
+        let plan = crate::test::scan_partitioned(2);
+        let mut collect =
+            Box::pin(collect_partitioned(plan, Arc::new(TaskContext::default())));
+
+        // The first poll is what spawns the tasks, so it has to happen inside the
+        // task runtime's context.
+        {
+            let _guard = task_rt.enter();
+            let mut cx = TaskPollContext::from_waker(Waker::noop());
+            assert!(
+                collect.as_mut().poll(&mut cx).is_pending(),
+                "tasks on a runtime that is never driven cannot have completed"
+            );
+        }
+        drop(task_rt);
+
+        let err = driver_rt
+            .block_on(collect)
+            .expect_err("a cancelled task must not be reported as a successful collect");
+        match err {
+            DataFusionError::ExecutionJoin(join_error) => {
+                assert!(
+                    join_error.is_cancelled(),
+                    "expected a cancellation, got {join_error:?}"
+                );
+            }
+            other => panic!("expected ExecutionJoin, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

A `tokio::task::JoinError` reports one of exactly two outcomes: the task **panicked**, or it was
**cancelled**. Seven `JoinSet` drain loops resumed the panic and then called `unreachable!()` for
everything else — so the arm written for "this cannot happen" is precisely the arm a cancelled task
lands in. A cancellation became a panic on a Tokio worker thread instead of an error the caller
could surface.

A task is cancelled when it is aborted, or when the runtime it was spawned on shuts down while the
task is still queued. Running the serving path and the query-execution path on separate runtimes —
a normal deployment shape — makes the second case ordinary rather than hypothetical: the drain loop
is still being polled while the tasks it is waiting on are cancelled underneath it.

Reported as a panic out of `collect_partitioned`:

```
thread 'tokio-runtime-worker' panicked at datafusion/physical-plan/src/execution_plan.rs:
internal error: entered unreachable code
```

Fixes spiceai/spiceai#7030.

## Changes

`DataFusionError::from_join_error` resumes a panic on the calling thread — unchanged behaviour, so
a panicking task still surfaces with its payload and backtrace intact — and returns
`DataFusionError::ExecutionJoin` for a cancellation, keeping the `JoinError` as the error's `source`
so a caller can still ask `is_cancelled()`.

`ExecutionJoin(Box<JoinError>)` already existed for exactly this case, and is already used for it a
few lines away from two of the sites this changes (`datasource-arrow/src/file_format.rs:339`,
`datasource-parquet/src/sink.rs:391`). The inconsistency *within* those two functions is the
clearest evidence this was an oversight rather than a decision.

All seven sites now read `Err(e) => return Err(DataFusionError::from_join_error(e))`:

| crate | function |
|---|---|
| `physical-plan` | `collect_partitioned` (the reported one) |
| `catalog` | `MemTable::load` |
| `datasource-arrow` | `ArrowFileSink::spawn_writer_tasks_and_join` |
| `datasource-parquet` | `ParquetSink::spawn_writer_tasks_and_join` |
| `datasource-parquet` | `plan_to_parquet` |
| `datasource-csv` | `plan_to_csv` |
| `datasource-json` | `plan_to_json` |

Two properties worth a reviewer's attention:

- **The error returns immediately rather than continuing the drain.** Every one of these loops is
  accumulating something — batches, a row count, writers — and continuing past a cancelled task
  would report a partial result as a success. `return Err` discards the partial accumulation, which
  is what the old panic also did.
- **A shared helper rather than seven inline `else` branches.** The duplication had already drifted:
  two other drains in the tree handle the same case correctly and differently
  (`physical-plan/src/stream.rs` returns `exec_err!`, `common-runtime/src/common.rs` logs and
  returns the `JoinError`). Putting the decision next to the error type is also what makes it
  unit-testable. `datafusion-common-runtime::join_unwind` is the existing precedent for a shared
  function that resumes panics on the caller's behalf.

The rest of the tree was checked for the same class and is already correct:
`datasource/src/write/orchestration.rs` handles a cancelled task deliberately ("Don't panic, instead
try to clean up as many writers as possible"), `common-runtime/src/join_set.rs` is a pass-through
wrapper, and the remaining `unwrap()`ing drains are all test code. No `unreachable!()` in an
`is_panic()` else-branch remains anywhere in the workspace.

## Test plan

Three tests, each pinned by a neuter that makes it fail:

- `collect_partitioned_reports_a_cancelled_task_as_an_error` — calls the production
  `collect_partitioned` and reaches the arm the way it is reached in practice: the per-partition
  tasks are spawned on one runtime, that runtime is dropped, and a second runtime drives the
  collect. Restoring the `unreachable!()` fails it.
- `from_join_error_reports_a_cancelled_task_as_execution_join` — asserts the variant *and* that the
  `JoinError` survives as the error's source. Stringifying the cancellation instead fails it.
- `from_join_error_resumes_a_panicking_task_instead_of_returning` — asserts the panic is not
  downgraded to an error and the payload is carried through. Removing the `resume_unwind` fails it.

Each neuter fails exactly one of the three, so no test is standing in for another.

```
cargo test -p datafusion-common -p datafusion-catalog -p datafusion-physical-plan --lib
  8 passed / 462 passed / 1447 passed

cargo test -p datafusion-datasource-arrow -p datafusion-datasource-csv \
           -p datafusion-datasource-json -p datafusion-datasource-parquet --lib
  11 passed / 3 passed / 46 passed / 113 passed
  (16 pre-existing failures in datasource-parquet, all "failed to get parquet data dir:
   env PARQUET_TEST_DATA is undefined" — the parquet-testing submodule is not checked out
   locally; none reach the changed code)

cargo clippy --all-targets on all seven crates — no errors, and no warning in any changed file
cargo fmt on the seven touched crates
```

`cargo fmt --all` is not clean on this branch's base, so formatting was applied per-crate to keep
unrelated files out of the diff.

## Notes

This is also a live bug upstream — `apache/datafusion` `main` still has the `unreachable!()` in
`collect_partitioned`.

The runtime side of spiceai/spiceai#7030 needs the `datafusion` rev in `spiceai/spiceai`'s
`Cargo.toml` bumped after this merges; the issue stays open until that lands.
