### PR TITLE
fix(unparser): inline a predicate's reference to an unnamed projection output

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -27,9 +27,10 @@ use super::{
         subquery_alias_inner_query_and_columns,
     },
     utils::{
-        find_agg_node_within_select, find_unnest_node_within_select,
-        find_window_nodes_within_select, try_transform_to_simple_table_scan_with_filters,
-        unproject_sort_expr, unproject_unnest_expr,
+        find_agg_node_within_select, find_projection_node_within_select,
+        find_unnest_node_within_select, find_window_nodes_within_select,
+        try_transform_to_simple_table_scan_with_filters, unproject_sort_expr,
+        unproject_unnamed_projection_exprs, unproject_unnest_expr,
         unproject_unnest_expr_as_flatten_value, unproject_window_exprs,
     },
 };
@@ -813,7 +814,20 @@ impl Unparser<'_> {
                     let filter_expr = self.expr_to_sql(&unprojected)?;
                     select.having(Some(filter_expr));
                 } else {
-                    let filter_expr = self.expr_to_sql(&filter.predicate)?;
+                    // A predicate can reference a projection output that the
+                    // projection does not name, whose logical name is not an
+                    // identifier the emitted statement carries.
+                    let predicate = match find_projection_node_within_select(
+                        plan,
+                        select.already_projected(),
+                    ) {
+                        Some(projection) => unproject_unnamed_projection_exprs(
+                            filter.predicate.clone(),
+                            projection,
+                        )?,
+                        None => filter.predicate.clone(),
+                    };
+                    let filter_expr = self.expr_to_sql(&predicate)?;
                     select.selection(Some(filter_expr));
                 }
 

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -265,6 +265,84 @@ pub(crate) fn unproject_window_exprs(expr: Expr, windows: &[&Window]) -> Result<
     .map(|e| e.data)
 }
 
+/// Recursively searches children of [LogicalPlan] for the [Projection] that will be
+/// flattened into the same `SELECT` as `plan`, if there is one.
+///
+/// Stops at a node that opens a scope of its own: the columns of a relation, a
+/// subquery, or a derived table are addressable by name from outside, so a
+/// reference to one of them already binds.
+pub(crate) fn find_projection_node_within_select(
+    plan: &LogicalPlan,
+    already_projected: bool,
+) -> Option<&Projection> {
+    // A projection reached once the `SELECT` list is taken becomes a derived
+    // table rather than part of this statement, so it is not what a predicate
+    // here would be referring to.
+    if already_projected {
+        return None;
+    }
+    let input = plan.inputs();
+    if input.len() > 1 {
+        return None;
+    }
+    let input = input.first()?;
+    match input {
+        LogicalPlan::Projection(projection) => Some(projection),
+        // Stacked filters collapse into one `WHERE`, so keep looking through them.
+        LogicalPlan::Filter(_) => {
+            find_projection_node_within_select(input, already_projected)
+        }
+        _ => None,
+    }
+}
+
+/// Replaces a reference to a [Projection] output that the projection does not name
+/// with the expression that produces it.
+///
+/// The unparser names such an output by its logical name — `t.a + t.b` for
+/// `Projection: t.a + t.b` — which is a description of the expression, not an
+/// identifier the emitted statement carries. Emitting it as one yields SQL that
+/// no engine can bind, so the expression is inlined at the point of use instead,
+/// which needs no name at all.
+pub(crate) fn unproject_unnamed_projection_exprs(
+    expr: Expr,
+    projection: &Projection,
+) -> Result<Expr> {
+    expr.transform(|sub_expr| {
+        if let Expr::Column(c) = &sub_expr
+            && let Some(unprojected) = find_unnamed_projection_expr(projection, c)
+        {
+            return Ok(Transformed::yes(unprojected.clone()));
+        }
+        Ok(Transformed::no(sub_expr))
+    })
+    .map(|e| e.data)
+}
+
+/// The expression behind `column`, but only when the projection leaves it unnamed.
+///
+/// An alias names the output explicitly and a bare column carries the name it
+/// already had, so in both cases the emitted `SELECT` carries a name matching the
+/// reference and there is nothing to repair.
+///
+/// A volatile expression is left alone as well. Inlining evaluates it a second
+/// time, in a clause that may see a different value than the `SELECT` list did,
+/// which would answer the query with silently wrong rows. The unbindable
+/// reference this repairs is at least a loud failure, so it is the safer of the
+/// two to leave in place.
+fn find_unnamed_projection_expr<'a>(
+    projection: &'a Projection,
+    column: &Column,
+) -> Option<&'a Expr> {
+    let index = projection.schema.index_of_column(column).ok()?;
+    let expr = projection.expr.get(index)?;
+    if matches!(expr, Expr::Alias(_) | Expr::Column(_)) || expr.is_volatile() {
+        None
+    } else {
+        Some(expr)
+    }
+}
+
 fn find_agg_expr<'a>(agg: &'a Aggregate, column: &Column) -> Result<Option<&'a Expr>> {
     if let Ok(index) = agg.schema.index_of_column(column) {
         if matches!(agg.group_expr.as_slice(), [Expr::GroupingSet(_)]) {

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1342,7 +1342,10 @@ fn table_scan_with_empty_projection_and_none_projection_helper(
 // yielding `Projection: <empty> -> TableScan`. It must not be unparsed as an
 // empty `SELECT` list for dialects that reject `SELECT FROM t` (e.g. DuckDB):
 // fall back to `SELECT 1` just like the bare empty-projection `TableScan`.
-fn empty_projection_over_table_helper(table_name: &str, table_schema: Schema) -> LogicalPlan {
+fn empty_projection_over_table_helper(
+    table_name: &str,
+    table_schema: Schema,
+) -> LogicalPlan {
     project(
         table_scan(Some(table_name), &table_schema, None)
             .unwrap()
@@ -4521,5 +4524,114 @@ fn test_join_filter_nested_under_right_join_using() -> Result<()> {
         @"SELECT a.id, b.b_id, c.id FROM a INNER JOIN b ON a.id = b.b_id RIGHT OUTER JOIN c ON a.id = c.id AND (a.id = 'x')"
     );
 
+    Ok(())
+}
+
+#[test]
+fn test_filter_on_unnamed_projection_output_binds() -> Result<()> {
+    // A `Filter` whose predicate references a `Projection` output that the
+    // projection does not name. The projected expression carries the logical
+    // name `t.a + t.b`, which is not an identifier any relation exposes, so
+    // emitting it as one produces SQL no engine can bind.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b"))])?
+        .filter(col("t.a + t.b").gt(lit(1)))?
+        .build()?;
+
+    let sql = plan_to_sql(&plan)?;
+    assert_snapshot!(sql, @r#"SELECT (t.a + t.b) FROM t WHERE ((t.a + t.b) > 1)"#);
+    Ok(())
+}
+
+#[test]
+fn test_filter_on_named_projection_output_is_unchanged() -> Result<()> {
+    // An alias gives the output a name the emitted `SELECT` carries, and a bare
+    // column keeps the name it already had. Neither needs repairing, so neither
+    // is inlined.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+
+    let aliased = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b")).alias("s")])?
+        .filter(col("s").gt(lit(1)))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&aliased)?,
+        @r#"SELECT (t.a + t.b) AS s FROM t WHERE (s > 1)"#
+    );
+
+    let bare_column = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a")])?
+        .filter(col("t.a").gt(lit(1)))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&bare_column)?,
+        @r#"SELECT t.a FROM t WHERE (t.a > 1)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_filter_on_unnamed_projection_output_used_twice() -> Result<()> {
+    // Every reference to the output is inlined, not just the first.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b"))])?
+        .filter(
+            col("t.a + t.b")
+                .gt(lit(1))
+                .and(col("t.a + t.b").lt(lit(10))),
+        )?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT (t.a + t.b) FROM t WHERE (((t.a + t.b) > 1) AND ((t.a + t.b) < 10))"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_stacked_filters_on_unnamed_projection_output() -> Result<()> {
+    // Stacked filters collapse into one `WHERE`, so the projection is still the
+    // one this predicate refers to and both predicates are repaired.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b"))])?
+        .filter(col("t.a + t.b").gt(lit(1)))?
+        .filter(col("t.a + t.b").lt(lit(10)))?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT (t.a + t.b) FROM t WHERE ((t.a + t.b) < 10) AND ((t.a + t.b) > 1)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_filter_on_unnamed_volatile_projection_output_is_not_inlined() -> Result<()> {
+    // Inlining a volatile expression would evaluate it a second time, in a
+    // clause that can see a different value than the `SELECT` list did, turning
+    // an unbindable reference into silently wrong rows. The unbindable
+    // reference is the safer of the two, so it is left in place.
+    let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0]))?
+        .project(vec![datafusion_functions::math::random().call(vec![])])?
+        .filter(col("random()").gt(lit(0.5)))?
+        .build()?;
+
+    let sql = plan_to_sql(&plan)?;
+    assert_snapshot!(sql, @r#"SELECT random() FROM t WHERE ("random()" > 0.5)"#);
     Ok(())
 }


### PR DESCRIPTION
## Summary

When a `Filter` references a `Projection` output that the projection does not name, the unparser emitted the column's *logical* name as a quoted identifier:

```sql
SELECT (t.a + t.b) FROM t WHERE ("t.a + t.b" > 1)
```

`"t.a + t.b"` is a single quoted identifier. `t` has no such column and the `SELECT` list introduces none, so PostgreSQL answers 42703 and DuckDB a Binder Error. Federated pushdown of a filter over a computed column failed at the remote engine rather than at plan time.

## Root cause

The `LogicalPlan::Filter` arm of `select_to_sql_recursively` has an "unproject" step for the aggregate (`HAVING`) and window (`QUALIFY`) paths, but the plain `WHERE` path unparsed `filter.predicate` verbatim. A column referring to a projection output carries that output's logical name, which is a description of the expression rather than an identifier the emitted statement carries.

## Changes

- `find_projection_node_within_select` — locates the `Projection` that will be flattened into the same `SELECT`, mirroring the existing `find_agg_node_within_select`. Returns `None` once the `SELECT` list is taken, since a projection reached after that becomes a derived table whose columns *are* addressable from outside.
- `unproject_unnamed_projection_exprs` — replaces a reference to an unnamed projection output with the expression that produces it, so the predicate needs no name at all:

```sql
SELECT (t.a + t.b) FROM t WHERE ((t.a + t.b) > 1)
```

Deliberately left unchanged:

- **an aliased output** (`… AS s`) and **a bare column** — both already carry a name the emitted `SELECT` exposes, so a reference to one binds as written;
- **a volatile expression** — inlining would evaluate it a second time, in a clause that can see a different value than the `SELECT` list did. That trades a loud unbindable reference for silently wrong rows, so the loud failure is kept.

## Test plan

Five tests in `datafusion/sql/tests/cases/plan_to_sql.rs`:

| test | covers |
| --- | --- |
| `test_filter_on_unnamed_projection_output_binds` | the reported regression — fails before this change, passes after |
| `test_filter_on_named_projection_output_is_unchanged` | alias and bare-column outputs are not inlined |
| `test_filter_on_unnamed_projection_output_used_twice` | every reference is inlined, not just the first |
| `test_stacked_filters_on_unnamed_projection_output` | stacked filters collapsing into one `WHERE` |
| `test_filter_on_unnamed_volatile_projection_output_is_not_inlined` | the volatility guard |

`cargo test -p datafusion-sql` — **505 passed, 22 failed**, against a **500 passed, 22 failed** baseline on `spiceai-54` at `edd8861e6`. The 22 failures are identical in both runs (verified by diffing the failing-test sets) and pre-date this change; this PR adds 5 passing tests and regresses none.

`cargo clippy -p datafusion-sql --all-targets` and `cargo fmt --all -- --check` report nothing in the added code. Note that `spiceai-54` is not currently rustfmt-clean, so `cargo fmt --all` rewrites unrelated files; those were reverted to keep this diff in scope — including two hunks in `unproject_sort_expr` that PR #198 also touches.
