### PR TITLE
fix(unparser): scope a bounded EXISTS build side, so its limit selects rows

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -88,6 +88,19 @@ impl QueryBuilder {
     pub fn is_distinct_union(&self) -> bool {
         self.distinct_union
     }
+    /// Whether the query bounds *which* rows it returns rather than only
+    /// filtering them: `LIMIT`, `OFFSET`, `FETCH` or `LIMIT BY`.
+    ///
+    /// SQL evaluates all of these after the body's `WHERE`, so a predicate
+    /// added to that `WHERE` decides which rows the bound then keeps. A caller
+    /// that needs its predicate applied to the bounded result has to put the
+    /// bounded query in a scope of its own instead.
+    pub fn bounds_rows(&self) -> bool {
+        self.limit.is_some()
+            || self.offset.is_some()
+            || self.fetch.is_some()
+            || !self.limit_by.is_empty()
+    }
     pub fn build(&self) -> Result<ast::Query, BuilderError> {
         let order_by = self
             .order_by_kind

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2305,6 +2305,30 @@ impl Unparser<'_> {
             other => Box::new(Self::wrap_setexpr_as_derived_select(other)?),
         };
 
+        // A row bound on the build side (`LIMIT`/`OFFSET`/`FETCH`/`LIMIT BY`)
+        // is applied after that side's own `WHERE`, so a correlated predicate
+        // added there would decide which rows the bound keeps: the subquery
+        // would search the whole relation and report a match among rows the
+        // plan never read. A semi or mark join then reports a match it does
+        // not have and an anti join drops a row it should return — wrong rows
+        // rather than too many. Give the bounded body a scope of its own and
+        // correlate outside it.
+        //
+        // The rewrites below then belong to the outer select: inside the bound,
+        // both the projection and `DISTINCT` still decide which rows survive
+        // it, so neither is redundant there.
+        if let Some(scope_name) = Self::exists_scope_name(join)
+            && query_builder.bounds_rows()
+        {
+            query_builder.body(Box::new(SetExpr::Select(select)));
+            let bounded = query_builder.build()?;
+            let alias = self.new_table_alias(scope_name, vec![]);
+            select = Box::new(Self::wrap_query_as_derived_select(bounded, Some(alias))?);
+            // The bound now lives on the derived table; a second copy out here
+            // would re-apply it to the correlated result.
+            query_builder = QueryBuilder::default();
+        }
+
         // `EXISTS` only needs `SELECT 1`; DISTINCT would be redundant.
         select.projection = vec![ast::SelectItem::UnnamedExpr(ast::Expr::value(
             ast::Value::Number("1".to_string(), false),
@@ -2343,12 +2367,28 @@ impl Unparser<'_> {
     fn wrap_setexpr_as_derived_select(body: SetExpr) -> Result<ast::Select> {
         let mut subquery = QueryBuilder::default();
         subquery.body(Box::new(body));
+        let mut select = Self::wrap_query_as_derived_select(subquery.build()?, None)?;
+        // An unset projection renders as `SELECT FROM`. A caller that goes on
+        // to ask for `SELECT 1` overwrites this; one that wraps this select in
+        // a further scope needs it to expose the body's columns to that scope.
+        select.projection = vec![ast::SelectItem::Wildcard(
+            ast::WildcardAdditionalOptions::default(),
+        )];
+        Ok(select)
+    }
 
+    /// Wraps a complete query as a derived table inside a bare `SELECT`, so
+    /// clauses added to that `SELECT` are evaluated on the query's result
+    /// rather than alongside its own.
+    fn wrap_query_as_derived_select(
+        query: ast::Query,
+        alias: Option<ast::TableAlias>,
+    ) -> Result<ast::Select> {
         let mut derived = DerivedRelationBuilder::default();
         derived
             .lateral(false)
-            .alias(None)
-            .subquery(Box::new(subquery.build()?));
+            .alias(alias)
+            .subquery(Box::new(query));
 
         let mut relation = RelationBuilder::default();
         relation.derived(derived);
@@ -2359,6 +2399,67 @@ impl Unparser<'_> {
         let mut select = SelectBuilder::default();
         select.push_from(from);
         Ok(select.build()?)
+    }
+
+    /// The name a scope around the `EXISTS` build side has to answer to, so the
+    /// correlated predicates still resolve against it.
+    ///
+    /// The name has to come from the predicates rather than from the build
+    /// side's schema: a set operation's output carries no qualifier while the
+    /// join keys naming it still do, so the schema would have this scope
+    /// answer to a name nothing references.
+    ///
+    /// * One relation — the scope takes its name and every reference resolves.
+    /// * None — the correlation is by unqualified columns, which resolve
+    ///   against the only relation in scope whatever it is called. It still
+    ///   needs *a* name, since most dialects reject an unaliased derived table.
+    /// * Several — the build side is itself a join and the correlation names
+    ///   more than one of its inputs. A single scope can expose only one of
+    ///   those names, so `None` is returned and the caller leaves the plan
+    ///   alone rather than emitting references that cannot bind.
+    fn exists_scope_name(join: &Join) -> Option<String> {
+        // Match on the probe side's *qualifiers* rather than its columns: a
+        // correlated reference can name a probe-side column the probe's own
+        // projection dropped, and testing for the column would then read that
+        // reference as a build-side name.
+        let probe_relations: Vec<&TableReference> = join
+            .left
+            .schema()
+            .iter()
+            .filter_map(|(relation, _)| relation)
+            .collect();
+        let mut relations: Vec<TableReference> = Vec::new();
+        let mut names_a_probe_relation = false;
+        let mut collect = |expr: &Expr| {
+            for column in expr.column_refs() {
+                let Some(relation) = &column.relation else {
+                    continue;
+                };
+                if probe_relations.contains(&relation) {
+                    names_a_probe_relation = true;
+                } else if !relations.contains(relation) {
+                    relations.push(relation.clone());
+                }
+            }
+        };
+        for (_, right) in &join.on {
+            collect(right);
+        }
+        if let Some(filter) = &join.filter {
+            collect(filter);
+        }
+
+        match relations.as_slice() {
+            // Nothing to preserve, so any name will do — but only once the
+            // correlation has been shown to name nothing. A qualifier the probe
+            // side also answers to can be a build-side reference on a self-join,
+            // and renaming its scope would rebind it to the probe instead,
+            // turning the correlation into a comparison of the outer row with
+            // itself.
+            [] if !names_a_probe_relation => Some("derived_limit".to_string()),
+            [relation] => Some(relation.table().to_string()),
+            _ => None,
+        }
     }
 
     /// AND-folds `predicate` into a join's `ON` clause.

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1008,11 +1008,10 @@ impl Unparser<'_> {
                 // `split_join_on_and_where_filters`).
                 let mut left_scan_filters = vec![];
                 let mut right_scan_filters = vec![];
-                let (left_plan, right_plan) = match join.join_type {
-                    JoinType::RightSemi | JoinType::RightAnti => {
-                        (&join.right, &join.left)
-                    }
-                    _ => (&join.left, &join.right),
+                let (left_plan, right_plan) = if Self::swaps_join_inputs(join.join_type) {
+                    (&join.right, &join.left)
+                } else {
+                    (&join.left, &join.right)
                 };
                 // If there's an outer projection plan, it will already set up the projection.
                 // In that case, we don't need to worry about setting up the projection here.
@@ -2317,8 +2316,12 @@ impl Unparser<'_> {
         // The rewrites below then belong to the outer select: inside the bound,
         // both the projection and `DISTINCT` still decide which rows survive
         // it, so neither is redundant there.
-        if let Some(scope_name) = Self::exists_scope_name(join)
-            && query_builder.bounds_rows()
+        //
+        // `bounds_rows()` is tested first so the scope name is only demanded
+        // when a bound actually has to be moved: naming it can refuse the plan
+        // outright, and an unbounded build side has nothing to get wrong.
+        if query_builder.bounds_rows()
+            && let Some(scope_name) = self.exists_scope_name(join)?
         {
             query_builder.body(Box::new(SetExpr::Select(select)));
             let bounded = query_builder.build()?;
@@ -2401,6 +2404,18 @@ impl Unparser<'_> {
         Ok(select.build()?)
     }
 
+    /// Whether a join presents its inputs to the unparser the other way round
+    /// from the way the plan holds them: `RightSemi` and `RightAnti` correlate
+    /// `join.right` and build the `EXISTS` body from `join.left`.
+    ///
+    /// Read from here rather than restated, so that everything deciding which
+    /// side is which agrees — the join arm swaps the plans, and anything
+    /// reading `join.on` has to take the key from the matching side of each
+    /// pair or it will name the relation the correlation does not.
+    const fn swaps_join_inputs(join_type: JoinType) -> bool {
+        matches!(join_type, JoinType::RightSemi | JoinType::RightAnti)
+    }
+
     /// The name a scope around the `EXISTS` build side has to answer to, so the
     /// correlated predicates still resolve against it.
     ///
@@ -2417,13 +2432,25 @@ impl Unparser<'_> {
     ///   more than one of its inputs. A single scope can expose only one of
     ///   those names, so `None` is returned and the caller leaves the plan
     ///   alone rather than emitting references that cannot bind.
-    fn exists_scope_name(join: &Join) -> Option<String> {
+    ///
+    /// One shape is refused outright instead: a qualified name on a dialect
+    /// that spells columns in full. The scope cannot carry that name, and
+    /// unlike the `None` cases the unscoped form there *does* bind — so it
+    /// would run and quietly return the wrong rows rather than fail. Refusing
+    /// costs the pushdown, which is the trade `derive_row_limited_scope` makes
+    /// for the same reason.
+    fn exists_scope_name(&self, join: &Join) -> Result<Option<String>> {
+        // Which input is correlated against, and therefore which half of each
+        // `on` pair names the side being scoped, follows the same swap the join
+        // arm applies before it builds this subquery.
+        let swapped = Self::swaps_join_inputs(join.join_type);
+        let probe_plan = if swapped { &join.right } else { &join.left };
+
         // Match on the probe side's *qualifiers* rather than its columns: a
         // correlated reference can name a probe-side column the probe's own
         // projection dropped, and testing for the column would then read that
         // reference as a build-side name.
-        let probe_relations: Vec<&TableReference> = join
-            .left
+        let probe_relations: Vec<&TableReference> = probe_plan
             .schema()
             .iter()
             .filter_map(|(relation, _)| relation)
@@ -2442,8 +2469,8 @@ impl Unparser<'_> {
                 }
             }
         };
-        for (_, right) in &join.on {
-            collect(right);
+        for (left, right) in &join.on {
+            collect(if swapped { left } else { right });
         }
         if let Some(filter) = &join.filter {
             collect(filter);
@@ -2457,9 +2484,29 @@ impl Unparser<'_> {
             // already mis-emitted for an unrelated reason (the body's own
             // relation shadows the outer one), so declining does not repair it;
             // it only avoids trading that wrong answer for a different one.
-            [] if !names_a_probe_relation => Some("derived_limit".to_string()),
-            [relation] => Some(relation.table().to_string()),
-            _ => None,
+            [] if !names_a_probe_relation => Ok(Some("derived_limit".to_string())),
+            // A derived table's alias is a single identifier, so only the last
+            // component of a qualified name survives it, while a dialect that
+            // spells columns in full still writes every component in the
+            // correlated predicate — leaving it qualified by a relation that is
+            // no longer in scope.
+            //
+            // Refused rather than declined, which the other arms here are. They
+            // fall back to output that is wrong in the way this PR describes
+            // but *fails to bind*, so a database rejects it; this one would
+            // bind and run, silently answering from rows outside the bound. A
+            // wrong answer that executes is worse than one that does not, so
+            // this arm costs the pushdown instead — the trade
+            // `derive_row_limited_scope` makes for the limit it scopes.
+            [relation]
+                if self.dialect.full_qualified_col() && relation.to_vec().len() > 1 =>
+            {
+                not_impl_err!(
+                    "Unparsing a row bound on an EXISTS-style join's build side is not supported for a qualified table name on a dialect that spells columns in full"
+                )
+            }
+            [relation] => Ok(Some(relation.table().to_string())),
+            _ => Ok(None),
         }
     }
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2453,9 +2453,10 @@ impl Unparser<'_> {
             // Nothing to preserve, so any name will do — but only once the
             // correlation has been shown to name nothing. A qualifier the probe
             // side also answers to can be a build-side reference on a self-join,
-            // and renaming its scope would rebind it to the probe instead,
-            // turning the correlation into a comparison of the outer row with
-            // itself.
+            // where renaming the scope rebinds it to the probe. That shape is
+            // already mis-emitted for an unrelated reason (the body's own
+            // relation shadows the outer one), so declining does not repair it;
+            // it only avoids trading that wrong answer for a different one.
             [] if !names_a_probe_relation => Some("derived_limit".to_string()),
             [relation] => Some(relation.table().to_string()),
             _ => None,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3187,8 +3187,13 @@ fn test_unparse_left_semi_join_scopes_bounded_set_operation_build_side() -> Resu
 /// A correlation naming more than one of the build side's own inputs cannot be
 /// scoped: one derived table can answer to only one of those names, so the
 /// alternative to leaving the bound where it is would be emitting `t2`/`t3`
-/// references that no longer bind. Pins the documented decline — the `LIMIT`
-/// stays beside the correlation, which is what #12595 tracks for this shape.
+/// references that no longer bind.
+///
+/// The snapshot below is therefore **known-incorrect output**, recorded so the
+/// decline is visible rather than silent: the `LIMIT` still sits beside the
+/// correlation and still does nothing. Repairing it needs the correlation's
+/// qualifiers rewritten to the new scope, tracked by spiceai/spiceai#12840.
+/// Whoever implements that should expect this snapshot to change.
 #[test]
 fn test_unparse_left_semi_join_declines_multi_relation_build_side() -> Result<()> {
     let schema = exists_fetch_schema();
@@ -3222,10 +3227,16 @@ fn test_unparse_left_semi_join_declines_multi_relation_build_side() -> Result<()
 /// A correlation whose only qualifier is one the probe side also answers to
 /// cannot be scoped under an invented name: renaming the scope would rebind
 /// those references to the probe, turning the correlation into a comparison of
-/// the outer row with itself — which is true for every row and makes `EXISTS`
-/// report a match whenever the bounded side is non-empty. Declining leaves the
-/// bound where it was, which is wrong in the way #12595 describes but does not
-/// also silently drop the correlation.
+/// the outer row with itself.
+///
+/// The snapshot below is **known-incorrect output** and declining does not
+/// repair it — the subquery's own `FROM "t"` already shadows the outer `"t"`,
+/// so both sides of the predicate bind to the inner relation and the
+/// correlation is lost whatever the bound does. That shadowing is independent
+/// of this change and is tracked, with the rewrite that fixes it, by
+/// spiceai/spiceai#12840. What declining buys is only that the scope is not
+/// *also* renamed out from under the reference, which would swap one wrong
+/// answer for a different one.
 #[test]
 fn test_unparse_left_semi_join_declines_probe_qualified_correlation() -> Result<()> {
     let schema = exists_fetch_schema();

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3121,6 +3121,127 @@ fn test_unparse_left_mark_join_scopes_build_side_fetch() -> Result<()> {
     Ok(())
 }
 
+/// A right semi join swaps its inputs before the `EXISTS` body is built, so the
+/// side being scoped is `join.left` and the correlation names `join.right`. The
+/// scope's name has to follow that swap: taking it from the unswapped side
+/// aliases the bounded `t1` rows as `t2` and leaves the correlation naming a
+/// `t1` that is no longer in scope, so the subquery does not bind at all.
+#[test]
+fn test_unparse_right_semi_join_scopes_build_side_fetch() -> Result<()> {
+    let plan = exists_join_with_probe_side_fetch(datafusion_expr::JoinType::RightSemi)?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t2"."d" FROM "t2" WHERE EXISTS (SELECT 1 FROM (SELECT "t1"."c" FROM "t1" LIMIT 5) AS "t1" WHERE ("t1"."c" = "t2"."c"))"#
+    );
+    Ok(())
+}
+
+/// The right anti join takes the same swap, and inherits it from the same place.
+#[test]
+fn test_unparse_right_anti_join_scopes_build_side_fetch() -> Result<()> {
+    let plan = exists_join_with_probe_side_fetch(datafusion_expr::JoinType::RightAnti)?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t2"."d" FROM "t2" WHERE NOT EXISTS (SELECT 1 FROM (SELECT "t1"."c" FROM "t1" LIMIT 5) AS "t1" WHERE ("t1"."c" = "t2"."c"))"#
+    );
+    Ok(())
+}
+
+/// Builds `<join_type> Join: t1.c = t2.c` with the bound on `t1`, the input a
+/// right semi or anti join correlates *out of* — its build side.
+fn exists_join_with_probe_side_fetch(
+    join_type: datafusion_expr::JoinType,
+) -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let bounded = table_scan_with_filter_and_fetch(
+        Some("t1"),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        Some(5),
+    )?
+    .build()?;
+    let correlated = table_scan(Some("t2"), &schema, Some(vec![0, 1]))?.build()?;
+
+    LogicalPlanBuilder::from(bounded)
+        .join_on(correlated, join_type, vec![col("t1.c").eq(col("t2.c"))])?
+        .project(vec![col("t2.d")])?
+        .build()
+}
+
+/// Builds `LeftSemi Join: t1.c = s.t2.c` with the build side `s.t2` qualified,
+/// optionally bounded, for the fully-qualified-dialect cases below.
+fn qualified_build_side_semi_join(fetch: Option<usize>) -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan_with_filter_and_fetch(
+        Some(TableReference::partial("s", "t2")),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        fetch,
+    )?
+    .build()?;
+
+    LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("s.t2.c"))],
+        )?
+        .build()
+}
+
+/// A dialect that spells columns in full writes every component of a qualified
+/// name in the correlated predicate, but a derived table's alias is a single
+/// identifier and can only carry the last one, so the bound cannot be scoped.
+///
+/// This one is refused rather than declined. The other declines in
+/// `exists_scope_name` fall back to SQL that does not bind, which a database
+/// rejects; leaving the bound unscoped *here* would bind and run, silently
+/// answering from rows outside the bound. Losing the pushdown is the cheaper
+/// failure, and it is the trade `derive_row_limited_scope` already makes.
+#[test]
+fn test_unparse_semi_join_build_side_fetch_refuses_qualified_full_column_dialect()
+-> Result<()> {
+    let plan = qualified_build_side_semi_join(Some(5))?;
+
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .build();
+    let err = Unparser::new(&dialect)
+        .plan_to_sql(&plan)
+        .expect_err("a bound that cannot be scoped must not unparse");
+    assert_contains!(
+        err.to_string(),
+        "not supported for a qualified table name on a dialect that spells columns in full"
+    );
+    Ok(())
+}
+
+/// The refusal above is owed only to the bound. Without one there is nothing to
+/// scope and nothing to get wrong, so the same plan and dialect must still
+/// unparse — which is why the bound is tested for before the scope is named.
+#[test]
+fn test_unparse_semi_join_without_fetch_keeps_qualified_full_column_dialect() -> Result<()>
+{
+    let plan = qualified_build_side_semi_join(None)?;
+
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .build();
+    assert_snapshot!(
+        Unparser::new(&dialect).plan_to_sql(&plan)?,
+        @r#"SELECT t1.d FROM t1 WHERE EXISTS (SELECT 1 FROM s.t2 WHERE (t1.c = s.t2.c))"#
+    );
+    Ok(())
+}
+
 /// A `Limit` node above the build side bounds it just as a scan `fetch` does,
 /// and `OFFSET` picks *which* rows as much as `LIMIT` does — both belong inside
 /// the scope, with the correlation outside it.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1342,7 +1342,10 @@ fn table_scan_with_empty_projection_and_none_projection_helper(
 // yielding `Projection: <empty> -> TableScan`. It must not be unparsed as an
 // empty `SELECT` list for dialects that reject `SELECT FROM t` (e.g. DuckDB):
 // fall back to `SELECT 1` just like the bare empty-projection `TableScan`.
-fn empty_projection_over_table_helper(table_name: &str, table_schema: Schema) -> LogicalPlan {
+fn empty_projection_over_table_helper(
+    table_name: &str,
+    table_schema: Schema,
+) -> LogicalPlan {
     project(
         table_scan(Some(table_name), &table_schema, None)
             .unwrap()
@@ -3015,6 +3018,261 @@ fn test_unparse_left_semi_join() -> Result<()> {
     assert_snapshot!(
         sql,
         @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM "t2" AS "__correlated_sq_1" WHERE ("t1"."c" = "__correlated_sq_1"."c"))"#
+    );
+    Ok(())
+}
+
+/// The schema the bounded-`EXISTS` cases below join on.
+fn exists_fetch_schema() -> Schema {
+    Schema::new(vec![
+        Field::new("c", DataType::Int32, false),
+        Field::new("d", DataType::Int32, false),
+    ])
+}
+
+/// Builds `<join_type> Join: t1.c = t2.c` with `fetch` rows read from the
+/// build side, projecting `t1.d`.
+fn exists_join_with_build_side_fetch(
+    join_type: datafusion_expr::JoinType,
+    fetch: Option<usize>,
+) -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan_with_filter_and_fetch(
+        Some("t2"),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        fetch,
+    )?
+    .build()?;
+
+    LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(build, join_type, vec![col("t1.c").eq(col("t2.c"))])?
+        .build()
+}
+
+/// A `fetch` on a semi join's build side bounds how much of that side the join
+/// reads, so the correlation has to be applied to the bounded rows. Emitting it
+/// beside the correlation in the `EXISTS` body instead makes `LIMIT` a no-op —
+/// the body is non-empty whenever *any* `t2` row matches, not only when one of
+/// the read rows does — and the semi join reports matches the plan never read.
+#[test]
+fn test_unparse_left_semi_join_scopes_build_side_fetch() -> Result<()> {
+    let plan =
+        exists_join_with_build_side_fetch(datafusion_expr::JoinType::LeftSemi, Some(5))?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM (SELECT "t2"."c" FROM "t2" LIMIT 5) AS "t2" WHERE ("t1"."c" = "t2"."c"))"#
+    );
+    Ok(())
+}
+
+/// The anti join is the mirror image: the unscoped `LIMIT` makes the body
+/// non-empty for matches outside the read rows, so `NOT EXISTS` drops rows it
+/// should have returned.
+#[test]
+fn test_unparse_left_anti_join_scopes_build_side_fetch() -> Result<()> {
+    let plan =
+        exists_join_with_build_side_fetch(datafusion_expr::JoinType::LeftAnti, Some(5))?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE NOT EXISTS (SELECT 1 FROM (SELECT "t2"."c" FROM "t2" LIMIT 5) AS "t2" WHERE ("t1"."c" = "t2"."c"))"#
+    );
+    Ok(())
+}
+
+/// A mark join carries the same `EXISTS` body into the boolean it projects, so
+/// the bound needs the same scope there — an unscoped `LIMIT` marks a row true
+/// on the strength of a `t2` row the plan never read.
+#[test]
+fn test_unparse_left_mark_join_scopes_build_side_fetch() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan_with_filter_and_fetch(
+        Some("t2"),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        Some(5),
+    )?
+    .build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftMark,
+            vec![col("t1.c").eq(col("t2.c"))],
+        )?
+        .project(vec![col("t1.d")])?
+        .filter(col("mark").or(col("t1.d").lt(lit(0))))?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE (EXISTS (SELECT 1 FROM (SELECT "t2"."c" FROM "t2" LIMIT 5) AS "t2" WHERE ("t1"."c" = "t2"."c")) OR ("t1"."d" < 0))"#
+    );
+    Ok(())
+}
+
+/// A `Limit` node above the build side bounds it just as a scan `fetch` does,
+/// and `OFFSET` picks *which* rows as much as `LIMIT` does — both belong inside
+/// the scope, with the correlation outside it.
+#[test]
+fn test_unparse_left_semi_join_scopes_build_side_limit_node() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
+        .limit(2, Some(5))?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("t2.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM (SELECT "t2"."c" FROM "t2" LIMIT 5 OFFSET 2) AS "t2" WHERE ("t1"."c" = "t2"."c"))"#
+    );
+    Ok(())
+}
+
+/// A build side that is a set operation is already wrapped as a derived table
+/// to serve as the `EXISTS` body. Bounding it adds a second scope around that
+/// one, and the inner select then has to project the union's columns rather
+/// than the `SELECT 1` the outermost body wants.
+#[test]
+fn test_unparse_left_semi_join_scopes_bounded_set_operation_build_side() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
+        .union(table_scan(Some("t3"), &schema, Some(vec![0]))?.build()?)?
+        .limit(0, Some(5))?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("t2.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?.to_string();
+    assert!(
+        !sql.contains("SELECT  FROM") && !sql.contains("SELECT FROM"),
+        "the scoped body must project something: {sql}"
+    );
+    assert_snapshot!(
+        sql,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM (SELECT * FROM (SELECT "t2"."c" FROM "t2" UNION ALL SELECT "t3"."c" FROM "t3") LIMIT 5) AS "t2" WHERE ("t1"."c" = "t2"."c"))"#
+    );
+    Ok(())
+}
+
+/// A correlation naming more than one of the build side's own inputs cannot be
+/// scoped: one derived table can answer to only one of those names, so the
+/// alternative to leaving the bound where it is would be emitting `t2`/`t3`
+/// references that no longer bind. Pins the documented decline — the `LIMIT`
+/// stays beside the correlation, which is what #12595 tracks for this shape.
+#[test]
+fn test_unparse_left_semi_join_declines_multi_relation_build_side() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
+        .join_on(
+            table_scan(Some("t3"), &schema, Some(vec![0, 1]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            vec![col("t2.c").eq(col("t3.c"))],
+        )?
+        .limit(0, Some(5))?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("t2.c")), col("t1.d").eq(col("t3.d"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM "t2" INNER JOIN "t3" ON ("t2"."c" = "t3"."c") WHERE (("t1"."c" = "t2"."c") AND ("t1"."d" = "t3"."d")) LIMIT 5)"#
+    );
+    Ok(())
+}
+
+/// A correlation whose only qualifier is one the probe side also answers to
+/// cannot be scoped under an invented name: renaming the scope would rebind
+/// those references to the probe, turning the correlation into a comparison of
+/// the outer row with itself — which is true for every row and makes `EXISTS`
+/// report a match whenever the bounded side is non-empty. Declining leaves the
+/// bound where it was, which is wrong in the way #12595 describes but does not
+/// also silently drop the correlation.
+#[test]
+fn test_unparse_left_semi_join_declines_probe_qualified_correlation() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan_with_filter_and_fetch(
+        Some("t"),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        Some(5),
+    )?
+    .build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t.c").eq(col("t.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let sql = unparser.plan_to_sql(&plan)?.to_string();
+    assert!(
+        !sql.contains("derived_limit"),
+        "must not rename a scope the correlation still names: {sql}"
+    );
+    assert_snapshot!(
+        sql,
+        @r#"SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c") LIMIT 5)"#
+    );
+    Ok(())
+}
+
+/// An unbounded build side keeps the flat body: nothing decides which rows
+/// survive, so the correlation can stay in the body's own `WHERE` and the extra
+/// scope would be noise. Pins that the fix costs nothing when it is not needed.
+#[test]
+fn test_unparse_left_semi_join_without_fetch_stays_flat() -> Result<()> {
+    let plan =
+        exists_join_with_build_side_fetch(datafusion_expr::JoinType::LeftSemi, None)?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM "t2" WHERE ("t1"."c" = "t2"."c"))"#
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

A semi, anti or mark join unparses its build side as a correlated `EXISTS` subquery. A row bound on
that side is emitted **beside** the correlation predicate in the subquery body, where SQL applies it
after the `WHERE` — so the bound chooses among the rows the correlation already matched instead of
choosing which rows the correlation may see, and the subquery searches the whole relation.

Before:

```
LeftSemi Join: t1.c = t2.c
  Projection: t1.d
    TableScan: t1 projection=[c, d]
  TableScan: t2 projection=[c], fetch=5
```
```sql
SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM "t2" WHERE ("t1"."c" = "t2"."c") LIMIT 5)
```

`LIMIT 5` after a correlated equality is a no-op: the body is non-empty whenever *any* `t2` row
matches, not only when one of the five rows the plan reads does.

After:

```sql
SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM (SELECT "t2"."c" FROM "t2" LIMIT 5) AS "t2" WHERE ("t1"."c" = "t2"."c"))
```

This is a wrong-rows bug rather than a too-many-rows one: a semi or mark join reports a match on a
row the plan never read, and an anti join is the mirror image and drops a row it should return.

Fixes spiceai/spiceai#12595.

## Changes

- `QueryBuilder::bounds_rows` reports whether a query bounds *which* rows it returns — `LIMIT`,
  `OFFSET`, `FETCH` or `LIMIT BY`. All four are evaluated after the body's `WHERE`, so all four have
  the same problem; `OFFSET` alone picks rows as much as `LIMIT` does.
- `build_exists_subquery` gives a bounded body a scope of its own and correlates outside it. The
  `SELECT 1` and drop-`DISTINCT` rewrites move to the outer select with the correlation, because
  inside the bound both the projection and `DISTINCT` still decide which rows survive it.
- `wrap_setexpr_as_derived_select` gains an explicit wildcard projection and delegates to a new
  `wrap_query_as_derived_select`. It previously relied on every caller overwriting the projection
  with `SELECT 1`; a caller that wraps it in a further scope needs it to expose the body's columns,
  and an unset projection renders as `SELECT FROM`.

### Naming the scope

The scope has to keep answering to the name the correlation uses. That name comes from the join
keys, not from the build side's schema — a set operation's output carries no qualifier while the
keys naming it still do, so the schema would name the scope something nothing references.

Where no single name works, the plan is left alone rather than emitting references that cannot bind:

- the correlation names **more than one** of the build side's own inputs, so one scope cannot expose
  them all; or
- its only qualifier is one the **probe side also answers to**. Renaming that scope would rebind the
  reference to the probe and compare the outer row with itself — true for every row, which would
  make `EXISTS` fire whenever the bounded side is non-empty. That is strictly worse than the bug
  being fixed, so it declines.

Both declines keep today's output. That output is **known-incorrect** and the tests recording it say
so: the first still applies the bound after the correlation, and the second is already broken for an
unrelated reason -- the subquery's own `FROM "t"` shadows the outer `"t"`, so the correlation is lost
to shadowing whatever the bound does. Declining does not repair either; it only avoids trading one
wrong answer for a different one.

Closing both needs the correlation's column qualifiers rewritten to the scope the derived table
introduces. That is filed as spiceai/spiceai#12840, together with the related bare-name-alias
limitation under a `with_full_qualified_col(true)` dialect (spiceai/spiceai#12594), which this PR
inherits from the unparser's existing aliasing convention and widens the reach of.

## Test plan

Eight tests in `datafusion/sql/tests/cases/plan_to_sql.rs`:

- `..._left_semi_join_scopes_build_side_fetch` — the reported shape.
- `..._left_anti_join_scopes_build_side_fetch` — the mirror image.
- `..._left_mark_join_scopes_build_side_fetch` — the same body reached through a projected boolean.
- `..._left_semi_join_scopes_build_side_limit_node` — a `Limit` node rather than a scan `fetch`,
  carrying an `OFFSET` as well.
- `..._left_semi_join_scopes_bounded_set_operation_build_side` — a `UNION` build side, which is
  already wrapped once, and asserts the inner select projects something.
- `..._left_semi_join_declines_multi_relation_build_side` — pins the multi-relation decline.
- `..._left_semi_join_declines_probe_qualified_correlation` — pins the self-join decline and asserts
  the scope is not renamed.
- `..._left_semi_join_without_fetch_stays_flat` — an unbounded build side keeps the flat body, so
  the fix costs nothing when it is not needed.

The four bug-pinning tests were confirmed to fail with the fix disabled and pass with it.

`cargo test -p datafusion-sql`: **508 passed, 22 failed**. The same 22 fail on `spiceai-54` at
`edd8861e6` without this change (500 passed, 22 failed there) — they are pre-existing and unrelated.
`cargo clippy -p datafusion-sql --all-targets` is clean for the changed files.

## Note on formatting

`spiceai-54` is not `cargo fmt` clean at `edd8861e6` — `datafusion/expr/src/expr.rs`,
`datafusion/sql/src/unparser/{expr,utils}.rs`, `datafusion/core/tests/physical_optimizer/enforce_sorting.rs`
and `datafusion/sql/src/unparser/plan.rs` all have drift under the pinned rustfmt (1.95.0, matching
`rust-toolchain.toml`). This PR leaves that drift alone so the diff stays reviewable; the code it
adds is formatted.

## Review gate

Attests the two fixes pushed onto this branch in `0e6e61c7` (the orientation and fully-qualified-dialect corrections for Copilot's two threads) — not the original commits.

- **Adversarial review**: `codex`, scoped to `d383c8a3...0e6e61c7`. Run twice, because the first pass changed the approach.
  - Pass 1 returned **needs-attention**: the fully-qualified-dialect case originally *declined* the scope, which turns SQL that fails to bind into SQL that binds and silently answers from rows outside the bound. Accepted — that arm now refuses the plan (`not_impl_err!`), and the bound is tested for before the scope is named so an unbounded qualified join still unparses.
  - Pass 2 returned **needs-attention** on `RightMark` being absent from the input swap. Verified and real — a `RightMark` join unparses to `SELECT "t1"."c", "t1"."d" FROM "t1"` for a plan whose schema is `t2.c, t2.d, t1.mark`: wrong relation, no mark column, no `EXISTS`. But it is **pre-existing and out of scope**: the `matches!` list is byte-identical on `spiceai-54` and on this branch, and the reproduction gives the same output on both. Changing which join types swap alters the whole join arm for a join type this PR does not touch, and needs the mark-placeholder lookup moved too. Filed as spiceai/spiceai#13022 (issues are disabled on this fork).
- **Security review**: reasoned rather than tool-run — the session's cwd is another repository, so the tool would have collected the wrong diff. The diff adds a `const fn`, reorients two existing reads, and returns an error on one arm; the only externally visible change is which identifier is emitted as a derived-table alias, and it comes from a `TableReference` already in the plan through the same `new_table_alias` as before. No new input, sink, or surface.
- **Checks**: `cargo check` clean; `cargo fmt --check` and `cargo clippy` report nothing in the changed regions (the remaining complaints at `plan.rs:242/251/262/890/896/1102`, `expr.rs`, `utils.rs` are the fork's pre-existing drift). Full `datafusion-sql` suite: **512 passed / 22 failed**, and the 22 failing test names are byte-identical to this branch's own baseline before the change.
- **Tests neutered, not believed**: reverting the swap reproduces `... AS "t2" WHERE ("t1"."c" = "t2"."c")`; dropping the dialect guard emits `FROM (SELECT s.t2.c FROM s.t2 LIMIT 5) AS t2 WHERE (t1.c = s.t2.c)`; and restoring the original operand order makes the *unbounded* qualified plan fail to unparse — which is what the ordering exists to prevent.
