### PR TITLE
fix(physical-plan): dedup a repeated predicate in `FilterExec::handle_child_pushdown_result`

### DIFF
--- a/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
@@ -643,6 +643,87 @@ fn test_filter_with_fetch_not_pushed_to_unsupportive_scan() {
     );
 }
 
+/// A `FilterExec` sitting directly above a source that does not support
+/// pushdown may already carry the same predicate its own ancestor is trying
+/// to push down into it (a node in between can legitimately pre-attach its
+/// own copy of a predicate so this exact absorption lets a redundant
+/// ancestor `FilterExec` be dropped via `if_all`). `handle_child_pushdown_result`
+/// must not conjoin that pushed-down duplicate onto its own predicate
+/// verbatim -- doing so would apply the same condition twice on every row.
+#[test]
+fn test_filter_with_fetch_not_pushed_to_unsupportive_scan_dedups_repeated_ancestor_predicate()
+ {
+    let scan = TestScanBuilder::new(schema()).with_support(false).build();
+    let predicate = col_lit_predicate("a", "foo", &schema());
+    let inner_filter =
+        Arc::new(FilterExec::try_new(Arc::clone(&predicate), scan).unwrap());
+    // The outer FilterExec pushes the *same* predicate down into inner_filter.
+    let plan = Arc::new(FilterExec::try_new(predicate, inner_filter).unwrap());
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, FilterPushdown::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - FilterExec: a@0 = foo
+        -   FilterExec: a@0 = foo
+        -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=false
+      output:
+        Ok:
+          - FilterExec: a@0 = foo
+          -   DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=false
+    "
+    );
+}
+
+/// Companion to the test above: two independently-built calls to the same
+/// volatile function must never be merged into a single duplicated
+/// predicate, even when they are structurally identical. The generic
+/// `FilterPushdown` driver already declines to push a volatile expression
+/// at all (see its own `is_volatile` gate), so the two `FilterExec`s here
+/// never combine in the first place and each keeps its own single
+/// evaluation -- exactly the safety property `dedup_deterministic_exprs`'s
+/// volatility check exists to preserve if a filter ever *did* reach it.
+#[test]
+fn test_filter_with_fetch_not_pushed_to_unsupportive_scan_keeps_repeated_volatile_predicate()
+ {
+    let scan = TestScanBuilder::new(schema()).with_support(false).build();
+    let cfg = Arc::new(ConfigOptions::default());
+    let random_call = || {
+        Arc::new(BinaryExpr::new(
+            Arc::new(Column::new_with_schema("a", &schema()).unwrap()),
+            Operator::Eq,
+            Arc::new(
+                ScalarFunctionExpr::try_new(
+                    Arc::new(ScalarUDF::from(RandomFunc::new())),
+                    vec![],
+                    &schema(),
+                    Arc::clone(&cfg),
+                )
+                .unwrap(),
+            ),
+        )) as Arc<dyn PhysicalExpr>
+    };
+    let inner_filter = Arc::new(FilterExec::try_new(random_call(), scan).unwrap());
+    let plan = Arc::new(FilterExec::try_new(random_call(), inner_filter).unwrap());
+
+    insta::assert_snapshot!(
+        OptimizationTest::new(plan, FilterPushdown::new(), true),
+        @r"
+    OptimizationTest:
+      input:
+        - FilterExec: a@0 = random()
+        -   FilterExec: a@0 = random()
+        -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=false
+      output:
+        Ok:
+          - FilterExec: a@0 = random()
+          -   FilterExec: a@0 = random()
+          -     DataSourceExec: file_groups={1 group: [[test.parquet]]}, projection=[a, b, c], file_type=test, pushdown_supported=false
+    "
+    );
+}
+
 #[test]
 fn test_push_down_through_transparent_nodes() {
     // expect the predicate to be pushed down into the DataSource

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -68,7 +68,7 @@ use datafusion_physical_expr::{
     conjunction, split_conjunction,
 };
 
-use datafusion_physical_expr_common::physical_expr::fmt_sql;
+use datafusion_physical_expr_common::physical_expr::{fmt_sql, is_volatile};
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
@@ -714,6 +714,12 @@ impl ExecutionPlan for FilterExec {
             .chain(unsupported_self_filters)
             .collect_vec();
 
+        // `unsupported_parent_filters` and `unsupported_self_filters` can
+        // legitimately overlap: a parent may push filter `p` down into a
+        // `FilterExec` that already carries `p` itself as part of its own
+        // predicate. Drop the duplicate before building the combined predicate.
+        let unhandled_filters = dedup_deterministic_exprs(unhandled_filters);
+
         // If we have unhandled filters, we need to create a new FilterExec
         let filter_input = Arc::clone(self.input());
         let new_predicate = conjunction(unhandled_filters);
@@ -878,6 +884,30 @@ fn collect_equality_columns(predicate: &Arc<dyn PhysicalExpr>) -> (HashSet<usize
     }
 
     (eq_values.into_keys().collect(), infeasible)
+}
+
+/// Removes exact duplicates from `exprs`, keeping the first occurrence of
+/// each and preserving order.
+///
+/// A volatile expression (e.g. a call to a `Volatility::Volatile` UDF) is
+/// never treated as a duplicate, even against a structurally-identical
+/// sibling: two evaluations of a volatile expression can return different
+/// values or carry side effects, so removing one changes the predicate's
+/// meaning, not just its cost.
+fn dedup_deterministic_exprs(
+    exprs: Vec<Arc<dyn PhysicalExpr>>,
+) -> Vec<Arc<dyn PhysicalExpr>> {
+    let mut deduped: Vec<Arc<dyn PhysicalExpr>> = Vec::with_capacity(exprs.len());
+    for expr in exprs {
+        let is_duplicate = !is_volatile(&expr)
+            && deduped
+                .iter()
+                .any(|kept| !is_volatile(kept) && kept.as_ref() == expr.as_ref());
+        if !is_duplicate {
+            deduped.push(expr);
+        }
+    }
+    deduped
 }
 
 /// Converts an interval bound to a [`Precision`] value. NULL bounds (which


### PR DESCRIPTION
## Summary
A `FilterExec` sitting above a source that doesn't support filter pushdown can already carry a predicate that its own ancestor independently pushes down into it. `handle_child_pushdown_result` combined the two without deduping and conjoined them verbatim, so the predicate ended up applied twice (`p AND p`) instead of once.

This adds `dedup_deterministic_exprs` to drop the exact duplicate before building the combined predicate, while never deduping a volatile expression (mirrors the `is_volatile` guard the generic `FilterPushdown` driver already uses elsewhere).

## Test plan
- New regression tests in `filter_pushdown.rs` and `filter.rs`'s own unit tests, covering both the deterministic-dedup case and the volatile-no-dedup case.
- `cargo test -p datafusion --test core_integration -- physical_optimizer::filter_pushdown::` and `cargo test -p datafusion-physical-plan --lib filter::` — passing.
- `cargo clippy -p datafusion-physical-plan --lib --no-deps` — clean.