### PR TITLE
fix(unparser): refuse an EXISTS bound it cannot scope, rather than emit wrong rows

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2619,9 +2619,8 @@ impl Unparser<'_> {
         // `bounds_rows()` is tested first so the scope name is only demanded
         // when a bound actually has to be moved: naming it can refuse the plan
         // outright, and an unbounded build side has nothing to get wrong.
-        if query_builder.bounds_rows()
-            && let Some(scope_name) = self.exists_scope_name(join)?
-        {
+        if query_builder.bounds_rows() {
+            let scope_name = self.exists_scope_name(join)?;
             query_builder.body(Box::new(SetExpr::Select(select)));
             let bounded = query_builder.build()?;
             let alias = self.new_table_alias(scope_name, vec![]);
@@ -2724,21 +2723,25 @@ impl Unparser<'_> {
     /// answer to a name nothing references.
     ///
     /// * One relation — the scope takes its name and every reference resolves.
-    /// * None — the correlation is by unqualified columns, which resolve
-    ///   against the only relation in scope whatever it is called. It still
-    ///   needs *a* name, since most dialects reject an unaliased derived table.
-    /// * Several — the build side is itself a join and the correlation names
-    ///   more than one of its inputs. A single scope can expose only one of
-    ///   those names, so `None` is returned and the caller leaves the plan
-    ///   alone rather than emitting references that cannot bind.
+    /// * No qualifier at all — the correlation is by unqualified columns, which
+    ///   resolve against the only relation in scope whatever it is called. It
+    ///   still needs *a* name, since most dialects reject an unaliased derived
+    ///   table.
     ///
-    /// One shape is refused outright instead: a qualified name on a dialect
-    /// that spells columns in full. The scope cannot carry that name, and
-    /// unlike the `None` cases the unscoped form there *does* bind — so it
-    /// would run and quietly return the wrong rows rather than fail. Refusing
-    /// costs the pushdown, which is the trade `derive_row_limited_scope` makes
-    /// for the same reason.
-    fn exists_scope_name(&self, join: &Join) -> Result<Option<String>> {
+    /// Every other shape is refused, because a scope this function cannot name
+    /// is a bound this unparser cannot place — and leaving the bound beside the
+    /// correlation emits SQL that *binds and runs* while answering from rows
+    /// outside the bound. A wrong answer that executes is worse than one that
+    /// does not, so these cost the pushdown instead: the trade
+    /// `derive_row_limited_scope` makes for the limit it scopes, and the one the
+    /// fully-qualified-dialect arm below already made.
+    ///
+    /// Refusing is not the same as repairing. Each shape below is emitted
+    /// correctly only once the correlation's own qualifiers are rewritten to the
+    /// scope the derived table introduces, which is a pass over the correlation
+    /// expressions rather than a choice of name — tracked by spiceai/spiceai#12840.
+    /// Whoever implements it should expect these refusals to become scopes.
+    fn exists_scope_name(&self, join: &Join) -> Result<String> {
         // Which input is correlated against, and therefore which half of each
         // `on` pair names the side being scoped, follows the same swap the join
         // arm applies before it builds this subquery.
@@ -2777,26 +2780,24 @@ impl Unparser<'_> {
 
         match relations.as_slice() {
             // Nothing to preserve, so any name will do — but only once the
-            // correlation has been shown to name nothing. A qualifier the probe
-            // side also answers to can be a build-side reference on a self-join,
-            // where renaming the scope rebinds it to the probe. That shape is
-            // already mis-emitted for an unrelated reason (the body's own
-            // relation shadows the outer one), so declining does not repair it;
-            // it only avoids trading that wrong answer for a different one.
-            [] if !names_a_probe_relation => Ok(Some("derived_limit".to_string())),
+            // correlation has been shown to name nothing.
+            [] if !names_a_probe_relation => Ok("derived_limit".to_string()),
+            // A qualifier the probe side also answers to can be a build-side
+            // reference on a self-join, where naming the scope anything else
+            // rebinds it to the probe. Both readings are wrong: the body's own
+            // relation already shadows the outer one, so the correlation is lost
+            // whatever the bound does, and renaming would only swap that wrong
+            // answer for a different one.
+            [] => {
+                not_impl_err!(
+                    "Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation's only qualifier is one the probe side also answers to"
+                )
+            }
             // A derived table's alias is a single identifier, so only the last
             // component of a qualified name survives it, while a dialect that
             // spells columns in full still writes every component in the
             // correlated predicate — leaving it qualified by a relation that is
             // no longer in scope.
-            //
-            // Refused rather than declined, which the other arms here are. They
-            // fall back to output that is wrong in the way this PR describes
-            // but *fails to bind*, so a database rejects it; this one would
-            // bind and run, silently answering from rows outside the bound. A
-            // wrong answer that executes is worse than one that does not, so
-            // this arm costs the pushdown instead — the trade
-            // `derive_row_limited_scope` makes for the limit it scopes.
             [relation]
                 if self.dialect.full_qualified_col() && relation.to_vec().len() > 1 =>
             {
@@ -2804,8 +2805,16 @@ impl Unparser<'_> {
                     "Unparsing a row bound on an EXISTS-style join's build side is not supported for a qualified table name on a dialect that spells columns in full"
                 )
             }
-            [relation] => Ok(Some(relation.table().to_string())),
-            _ => Ok(None),
+            [relation] => Ok(relation.table().to_string()),
+            // The build side is itself a join and the correlation names more
+            // than one of its inputs. A single scope can expose only one of
+            // those names, so there is no name that keeps every reference
+            // bound to the relation it came from.
+            _ => {
+                not_impl_err!(
+                    "Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation names more than one of the build side's inputs"
+                )
+            }
         }
     }
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2732,9 +2732,8 @@ impl Unparser<'_> {
     /// is a bound this unparser cannot place — and leaving the bound beside the
     /// correlation emits SQL that *binds and runs* while answering from rows
     /// outside the bound. A wrong answer that executes is worse than one that
-    /// does not, so these cost the pushdown instead: the trade
-    /// `derive_row_limited_scope` makes for the limit it scopes, and the one the
-    /// fully-qualified-dialect arm below already made.
+    /// does not, so these cost the pushdown instead — the trade
+    /// `derive_row_limited_scope` makes for the limit it scopes.
     ///
     /// Refusing is not the same as repairing. Each shape below is emitted
     /// correctly only once the correlation's own qualifiers are rewritten to the

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3306,17 +3306,21 @@ fn test_unparse_left_semi_join_scopes_bounded_set_operation_build_side() -> Resu
 }
 
 /// A correlation naming more than one of the build side's own inputs cannot be
-/// scoped: one derived table can answer to only one of those names, so the
-/// alternative to leaving the bound where it is would be emitting `t2`/`t3`
-/// references that no longer bind.
+/// scoped: one derived table can answer to only one of those names, so no name
+/// keeps every reference bound to the relation it came from.
 ///
-/// The snapshot below is therefore **known-incorrect output**, recorded so the
-/// decline is visible rather than silent: the `LIMIT` still sits beside the
-/// correlation and still does nothing. Repairing it needs the correlation's
-/// qualifiers rewritten to the new scope, tracked by spiceai/spiceai#12840.
-/// Whoever implements that should expect this snapshot to change.
+/// Leaving the bound beside the correlation is not the safe fallback it looks
+/// like. That output is valid SQL — every qualifier still binds, `t1` to the
+/// outer query and `t2`/`t3` to the subquery's own inputs — so the database runs
+/// it and answers from rows outside the bound, which is the #12595 defect this
+/// shape was left holding. Refusing costs the pushdown instead of returning
+/// wrong rows.
+///
+/// Repairing it needs the correlation's qualifiers rewritten to the new scope,
+/// tracked by spiceai/spiceai#12840; whoever implements that should expect this
+/// refusal to become a scope.
 #[test]
-fn test_unparse_left_semi_join_declines_multi_relation_build_side() -> Result<()> {
+fn test_unparse_left_semi_join_refuses_multi_relation_build_side() -> Result<()> {
     let schema = exists_fetch_schema();
     let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
     let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
@@ -3338,9 +3342,12 @@ fn test_unparse_left_semi_join_declines_multi_relation_build_side() -> Result<()
         .build()?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("a correlation naming two build-side inputs must be refused");
     assert_snapshot!(
-        unparser.plan_to_sql(&plan)?,
-        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM "t2" INNER JOIN "t3" ON ("t2"."c" = "t3"."c") WHERE (("t1"."c" = "t2"."c") AND ("t1"."d" = "t3"."d")) LIMIT 5)"#
+        err,
+        @"This feature is not implemented: Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation names more than one of the build side's inputs"
     );
     Ok(())
 }
@@ -3350,16 +3357,18 @@ fn test_unparse_left_semi_join_declines_multi_relation_build_side() -> Result<()
 /// those references to the probe, turning the correlation into a comparison of
 /// the outer row with itself.
 ///
-/// The snapshot below is **known-incorrect output** and declining does not
-/// repair it — the subquery's own `FROM "t"` already shadows the outer `"t"`,
-/// so both sides of the predicate bind to the inner relation and the
-/// correlation is lost whatever the bound does. That shadowing is independent
-/// of this change and is tracked, with the rewrite that fixes it, by
-/// spiceai/spiceai#12840. What declining buys is only that the scope is not
-/// *also* renamed out from under the reference, which would swap one wrong
-/// answer for a different one.
+/// Nor is leaving it alone a fallback. The subquery's own `FROM "t"` shadows the
+/// outer `"t"`, so `"t"."c" = "t"."c"` binds entirely to the inner relation: the
+/// correlation is lost, the `EXISTS` reduces to "this table has a row", and the
+/// semi join keeps every probe row. That is valid SQL, so it runs — both
+/// readings are wrong, which is why this is refused rather than emitted.
+///
+/// The shadowing is independent of the bound and is tracked, with the rewrite
+/// that fixes it, by spiceai/spiceai#12840. This refusal only covers the bounded
+/// build side, which is where the scope is demanded; the unbounded shape is
+/// still emitted and still wrong.
 #[test]
-fn test_unparse_left_semi_join_declines_probe_qualified_correlation() -> Result<()> {
+fn test_unparse_left_semi_join_refuses_probe_qualified_correlation() -> Result<()> {
     let schema = exists_fetch_schema();
     let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
     let build = table_scan_with_filter_and_fetch(
@@ -3381,14 +3390,82 @@ fn test_unparse_left_semi_join_declines_probe_qualified_correlation() -> Result<
         .build()?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
-    let sql = unparser.plan_to_sql(&plan)?.to_string();
-    assert!(
-        !sql.contains("derived_limit"),
-        "must not rename a scope the correlation still names: {sql}"
-    );
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("a probe-qualified correlation must be refused, not shadowed");
     assert_snapshot!(
-        sql,
-        @r#"SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c") LIMIT 5)"#
+        err,
+        @"This feature is not implemented: Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation's only qualifier is one the probe side also answers to"
+    );
+    Ok(())
+}
+
+/// The same multi-relation correlation, unbounded: no scope is demanded, so the
+/// correlation stays in the body's own `WHERE` where it is correct, and both
+/// `t2` and `t3` are still in scope there.
+///
+/// Pins that the refusal above is gated on the bound rather than on the shape of
+/// the correlation. Widening it to every multi-relation correlation would cost
+/// the pushdown on queries that unparse correctly today.
+#[test]
+fn test_unparse_left_semi_join_without_fetch_keeps_multi_relation_correlation()
+-> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
+        .join_on(
+            table_scan(Some("t3"), &schema, Some(vec![0, 1]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            vec![col("t2.c").eq(col("t3.c"))],
+        )?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("t2.c")), col("t1.d").eq(col("t3.d"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d" FROM "t1" WHERE EXISTS (SELECT 1 FROM "t2" INNER JOIN "t3" ON ("t2"."c" = "t3"."c") WHERE (("t1"."c" = "t2"."c") AND ("t1"."d" = "t3"."d")))"#
+    );
+    Ok(())
+}
+
+/// The probe-qualified self-join, unbounded. Still emitted, and still wrong: the
+/// inner `FROM "t"` shadows the outer `"t"`, so the correlation is lost. That is
+/// the pre-existing defect spiceai/spiceai#12840 tracks, independent of any
+/// bound.
+///
+/// Recorded so the boundary of the refusal above is explicit — it covers the
+/// bounded build side, which is where a scope is demanded, and nothing else. Not
+/// an endorsement of this output; whoever lands the qualifier rewrite should
+/// expect this snapshot to change too.
+#[test]
+fn test_unparse_left_semi_join_without_fetch_still_shadows_probe_qualifier() -> Result<()>
+{
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t"), &schema, Some(vec![0]))?.build()?;
+
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t.c").eq(col("t.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c"))"#
     );
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3201,11 +3201,10 @@ fn qualified_build_side_semi_join(fetch: Option<usize>) -> Result<LogicalPlan> {
 /// name in the correlated predicate, but a derived table's alias is a single
 /// identifier and can only carry the last one, so the bound cannot be scoped.
 ///
-/// This one is refused rather than declined. The other declines in
-/// `exists_scope_name` fall back to SQL that does not bind, which a database
-/// rejects; leaving the bound unscoped *here* would bind and run, silently
-/// answering from rows outside the bound. Losing the pushdown is the cheaper
-/// failure, and it is the trade `derive_row_limited_scope` already makes.
+/// Every shape `exists_scope_name` cannot name is refused, this one included:
+/// leaving the bound unscoped binds and runs, silently answering from rows
+/// outside the bound. Losing the pushdown is the cheaper failure, and it is the
+/// trade `derive_row_limited_scope` already makes.
 #[test]
 fn test_unparse_semi_join_build_side_fetch_refuses_qualified_full_column_dialect()
 -> Result<()> {
@@ -3305,6 +3304,60 @@ fn test_unparse_left_semi_join_scopes_bounded_set_operation_build_side() -> Resu
     Ok(())
 }
 
+/// Builds `LeftSemi Join: t1.c = t2.c AND t1.d = t3.d` over a `t2 INNER JOIN t3`
+/// build side, optionally bounded, so the bounded and unbounded cases below
+/// differ only in the bound.
+fn multi_relation_build_side_semi_join(fetch: Option<usize>) -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?.join_on(
+        table_scan(Some("t3"), &schema, Some(vec![0, 1]))?.build()?,
+        datafusion_expr::JoinType::Inner,
+        vec![col("t2.c").eq(col("t3.c"))],
+    )?;
+    // Applied only when asked: `limit(0, None)` still inserts a `Limit` node,
+    // and the unbounded cases are about a build side that carries no bound.
+    let build = match fetch {
+        Some(fetch) => build.limit(0, Some(fetch))?,
+        None => build,
+    }
+    .build()?;
+
+    LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").eq(col("t2.c")), col("t1.d").eq(col("t3.d"))],
+        )?
+        .build()
+}
+
+/// Builds `LeftSemi Join: t.c = t.c` where the build side is the same relation as
+/// the probe, optionally bounded — the self-join whose correlation carries only a
+/// qualifier the probe also answers to.
+fn probe_qualified_self_join(fetch: Option<usize>) -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan_with_filter_and_fetch(
+        Some("t"),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        fetch,
+    )?
+    .build()?;
+
+    LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t.c").eq(col("t.c"))],
+        )?
+        .build()
+}
+
 /// A correlation naming more than one of the build side's own inputs cannot be
 /// scoped: one derived table can answer to only one of those names, so no name
 /// keeps every reference bound to the relation it came from.
@@ -3321,25 +3374,7 @@ fn test_unparse_left_semi_join_scopes_bounded_set_operation_build_side() -> Resu
 /// refusal to become a scope.
 #[test]
 fn test_unparse_left_semi_join_refuses_multi_relation_build_side() -> Result<()> {
-    let schema = exists_fetch_schema();
-    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
-    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
-        .join_on(
-            table_scan(Some("t3"), &schema, Some(vec![0, 1]))?.build()?,
-            datafusion_expr::JoinType::Inner,
-            vec![col("t2.c").eq(col("t3.c"))],
-        )?
-        .limit(0, Some(5))?
-        .build()?;
-
-    let plan = LogicalPlanBuilder::from(probe)
-        .project(vec![col("t1.d")])?
-        .join_on(
-            build,
-            datafusion_expr::JoinType::LeftSemi,
-            vec![col("t1.c").eq(col("t2.c")), col("t1.d").eq(col("t3.d"))],
-        )?
-        .build()?;
+    let plan = multi_relation_build_side_semi_join(Some(5))?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     let err = unparser
@@ -3369,25 +3404,7 @@ fn test_unparse_left_semi_join_refuses_multi_relation_build_side() -> Result<()>
 /// still emitted and still wrong.
 #[test]
 fn test_unparse_left_semi_join_refuses_probe_qualified_correlation() -> Result<()> {
-    let schema = exists_fetch_schema();
-    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
-    let build = table_scan_with_filter_and_fetch(
-        Some("t"),
-        &schema,
-        Some(vec![0]),
-        vec![],
-        Some(5),
-    )?
-    .build()?;
-
-    let plan = LogicalPlanBuilder::from(probe)
-        .project(vec![col("t.d")])?
-        .join_on(
-            build,
-            datafusion_expr::JoinType::LeftSemi,
-            vec![col("t.c").eq(col("t.c"))],
-        )?
-        .build()?;
+    let plan = probe_qualified_self_join(Some(5))?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     let err = unparser
@@ -3410,24 +3427,7 @@ fn test_unparse_left_semi_join_refuses_probe_qualified_correlation() -> Result<(
 #[test]
 fn test_unparse_left_semi_join_without_fetch_keeps_multi_relation_correlation()
 -> Result<()> {
-    let schema = exists_fetch_schema();
-    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
-    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
-        .join_on(
-            table_scan(Some("t3"), &schema, Some(vec![0, 1]))?.build()?,
-            datafusion_expr::JoinType::Inner,
-            vec![col("t2.c").eq(col("t3.c"))],
-        )?
-        .build()?;
-
-    let plan = LogicalPlanBuilder::from(probe)
-        .project(vec![col("t1.d")])?
-        .join_on(
-            build,
-            datafusion_expr::JoinType::LeftSemi,
-            vec![col("t1.c").eq(col("t2.c")), col("t1.d").eq(col("t3.d"))],
-        )?
-        .build()?;
+    let plan = multi_relation_build_side_semi_join(None)?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     assert_snapshot!(
@@ -3437,30 +3437,16 @@ fn test_unparse_left_semi_join_without_fetch_keeps_multi_relation_correlation()
     Ok(())
 }
 
-/// The probe-qualified self-join, unbounded. Still emitted, and still wrong: the
-/// inner `FROM "t"` shadows the outer `"t"`, so the correlation is lost. That is
-/// the pre-existing defect spiceai/spiceai#12840 tracks, independent of any
-/// bound.
-///
-/// Recorded so the boundary of the refusal above is explicit — it covers the
-/// bounded build side, which is where a scope is demanded, and nothing else. Not
-/// an endorsement of this output; whoever lands the qualifier rewrite should
-/// expect this snapshot to change too.
+/// Pins that the refusal above is gated on the bound: unbounded, the same
+/// correlation is still emitted. This output is **known-incorrect** — the inner
+/// `FROM "t"` shadows the outer `"t"`, so the correlation is lost — and it is not
+/// an endorsement. That shadowing is the pre-existing defect independent of any
+/// bound, so whoever lands the qualifier rewrite should expect this snapshot to
+/// change too.
 #[test]
 fn test_unparse_left_semi_join_without_fetch_still_shadows_probe_qualifier() -> Result<()>
 {
-    let schema = exists_fetch_schema();
-    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
-    let build = table_scan(Some("t"), &schema, Some(vec![0]))?.build()?;
-
-    let plan = LogicalPlanBuilder::from(probe)
-        .project(vec![col("t.d")])?
-        .join_on(
-            build,
-            datafusion_expr::JoinType::LeftSemi,
-            vec![col("t.c").eq(col("t.c"))],
-        )?
-        .build()?;
+    let plan = probe_qualified_self_join(None)?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     assert_snapshot!(


### PR DESCRIPTION
## Summary

`exists_scope_name` returned `None` for two shapes it could not name, and the caller then left the row bound beside the `EXISTS` correlation. Its doc comment justified that by saying such output *"fails to bind, so a database rejects it"* — and that is not true of either shape. Both are valid SQL, so the remote engine runs them and answers from rows outside the bound.

**Shape 1 — the correlation names more than one build-side input:**

```sql
SELECT "t1"."d" FROM "t1" WHERE EXISTS (
  SELECT 1 FROM "t2" INNER JOIN "t3" ON ("t2"."c" = "t3"."c")
  WHERE (("t1"."c" = "t2"."c") AND ("t1"."d" = "t3"."d")) LIMIT 5)
```

`t1` binds to the outer query and `t2`/`t3` to the subquery's own inputs, so nothing fails — the subquery searches the whole relation and reports a match among rows the `LIMIT` never kept. A semi or mark join then reports a match it does not have and an anti join drops a row it should return. That is the #12595 defect, left unfixed for this shape.

**Shape 2 — the correlation's only qualifier is one the probe side also answers to:**

```sql
SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c") LIMIT 5)
```

The inner `FROM "t"` shadows the outer `"t"`, so both sides of the predicate bind inside the subquery, the correlation is lost, the `EXISTS` degenerates to "this table has a row", and the semi join keeps every probe row.

Both shapes now return `not_impl_err!`, which is what the neighbouring fully-qualified-dialect arm already does for exactly this reason: **a wrong answer that executes is worse than one that does not.** This costs the pushdown for these shapes instead of returning wrong rows. In Spice the error surfaces from `VirtualExecutionPlan::final_sql()` at `execute()`, so the query fails rather than silently answering from the wrong rows.

### Scope — this refuses, it does not repair

Emitting these shapes *correctly* needs the correlated predicates' column qualifiers rewritten to the scope the derived table introduces, with explicit output-column aliases where inner names collide. That is a new pass over the correlation expressions, it is shared with #12594 and #12751, and it has hazards this PR deliberately does not take on — rewriting the derived table's projection interacts with `DISTINCT` and with an `ORDER BY` inside the bound, either of which changes which rows survive the bound. Doing it partially would trade one wrong answer for another, which is what #201 declined to do. So spiceai/spiceai#12840 stays open for the rewrite; the refusals, their tests, and the function doc all point at it, and whoever lands it should expect these refusals to become scopes.

The refusals are gated on the bound (`bounds_rows()`), so unbounded plans are untouched — including the unbounded multi-relation correlation, which is *correct* SQL today and would have lost its pushdown had the refusal keyed on the correlation's shape instead.

## Changes

- `datafusion/sql/src/unparser/plan.rs` — `exists_scope_name` returns `Result<String>` instead of `Result<Option<String>>`; the two shapes that returned `Ok(None)` return `not_impl_err!` with a message naming which shape. The caller loses its unscoped fall-through. Doc comments corrected — the "fails to bind" claim was load-bearing and false.
- `datafusion/sql/tests/cases/plan_to_sql.rs` — the two tests that snapshotted the known-incorrect SQL now assert the refusal; two tests added pinning that the refusal is gated on the bound. Bounded and unbounded cases share a `fetch`-parameterized fixture so "only the bound differs" is structural. Dropped the same false claim from the fully-qualified-dialect test's doc.

## Test plan

- `cargo test -p datafusion-sql --test sql_integration` — 548 pass. **22 tests fail identically on the unmodified base** (`upstream/spiceai-54` @ `b5cb7bb32`) and with this change, verified by re-running on a clean tree: `roundtrip_statement*`, the `snowflake_flatten*`/`snowflake_unnest*` group, `test_table_scan_pushdown`, `test_struct_expr`, `test_table_references_in_plan_to_sql_*`, `test_sort_with_scalar_fn_and_push_down_fetch`. Same 22 under `--all-features`, so it is not a feature-scoping artifact. Pre-existing branch breakage, unrelated to this PR — this repo runs no Rust test workflow, only Copilot review, so nothing catches it. Filed as spiceai/spiceai#13134.
- `cargo clippy -p datafusion-sql --tests --no-deps` — no new warnings; the warnings it does report are at `plan.rs:243/244/1123`, `rewrite.rs`, and `utils.rs`, all outside this diff.
- `cargo fmt -p datafusion-sql`.
- **Both refusal tests and both gating tests were neutered in each direction, and re-neutered after the cleanup commit** (0 compile errors in every neuter run, so each failure is behavioural rather than a build error):
  - restore the unscoped fall-through → the 2 refusal tests fail at `.expect_err`, i.e. the old wrong SQL comes back; the 2 gating tests still pass.
  - demand the scope name even when unbounded → the 2 gating tests fail; the 2 refusal tests still pass.
- A no-op bound was checked as a possible over-refusal and is unreachable: `Limit { skip: 0, fetch: None }` leaves `bounds_rows()` false, so no refusal fires and the SQL is emitted unchanged.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` is not installed in this environment (receipt: `engine=none exit=1 job=none`, base `upstream/spiceai-54`, head `4cb060c2f`). Its angles were hand-run instead; the one that paid was "does this over-refuse a bound that cannot truncate?", which produced the no-op-bound probe recorded in the test plan.
- `/security-review`: no findings. The harness collected an empty diff (it read the session's primary worktree, not this fork worktree), so the diff was reviewed directly rather than reporting a vacuous pass. No new input path or sink; both new messages are static literals that interpolate no identifier, so no schema detail reaches a client-visible error.
- `/simplify`: 4 agents (reuse, simplification, efficiency, altitude). Applied — the shared `fetch`-parameterized fixtures, and the stale "does not bind" claim on the fully-qualified-dialect test's doc, which two agents independently caught and which was the same false premise this PR exists to remove. Also trimmed a doc clause that singled out one arm as having "already made" the trade, now that every unnameable shape refuses. Skipped: folding the two `[]` match arms into one guarded arm (guard-order is idiomatic here and the sibling `full_qualified_col` arm is order-sensitive too); hoisting the shared 74-character message prefix into a helper (the tests match the full strings and the literals stay greppable from a user-reported error); two pre-existing micro-allocations in `exists_scope_name` (`column_refs()`'s `HashSet`, `to_vec().len() > 1`) — cold path, and the latter is the established spelling at two other sites. Efficiency confirmed the call count is unchanged and that the refusal now bails *before* building the subquery.
Relates to spiceai/spiceai#12840 — this refuses the two shapes rather than repairing them, so that issue stays open for the qualifier rewrite.
Relates to spiceai/spiceai#13134 — the pre-existing test failures noted in the test plan.
