### PR TITLE
fix(unparser): name a derived table's unnamed outputs (fixes spiceai/spiceai#12751)

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -730,11 +730,11 @@ impl RelationBuilder {
     /// The alias is attached once the relation has been built, so a derived table
     /// built in the meantime cannot see it and would otherwise name its own
     /// outputs redundantly.
-    pub fn columns_named_by_alias(&mut self, value: bool) -> &mut Self {
+    pub(super) fn columns_named_by_alias(&mut self, value: bool) -> &mut Self {
         self.columns_named_by_alias = value;
         self
     }
-    pub fn has_columns_named_by_alias(&self) -> bool {
+    pub(super) fn has_columns_named_by_alias(&self) -> bool {
         self.columns_named_by_alias
     }
     fn create_empty() -> Self {

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -632,6 +632,9 @@ impl Default for TableWithJoinsBuilder {
 #[derive(Clone)]
 pub struct RelationBuilder {
     relation: Option<TableFactorBuilder>,
+    /// Whether the enclosing scope names this relation's output columns itself,
+    /// through a column list on the alias it attaches once the relation is built.
+    columns_named_by_alias: bool,
 }
 
 #[derive(Clone)]
@@ -722,9 +725,22 @@ impl RelationBuilder {
             None => return Err(Into::into(UninitializedFieldError::from("relation"))),
         })
     }
+    /// Declares that the alias this relation is given will carry a column list.
+    ///
+    /// The alias is attached once the relation has been built, so a derived table
+    /// built in the meantime cannot see it and would otherwise name its own
+    /// outputs redundantly.
+    pub fn columns_named_by_alias(&mut self, value: bool) -> &mut Self {
+        self.columns_named_by_alias = value;
+        self
+    }
+    pub fn has_columns_named_by_alias(&self) -> bool {
+        self.columns_named_by_alias
+    }
     fn create_empty() -> Self {
         Self {
             relation: Default::default(),
+            columns_named_by_alias: false,
         }
     }
 }

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -30,8 +30,8 @@ use super::{
     utils::{
         find_agg_node_within_select, find_projection_node_within_select,
         find_unnest_node_within_select, find_window_nodes_within_select,
-        try_transform_to_simple_table_scan_with_filters, unproject_sort_expr,
-        unproject_unnamed_projection_exprs, unproject_unnest_expr,
+        name_derived_scope_outputs, try_transform_to_simple_table_scan_with_filters,
+        unproject_sort_expr, unproject_unnamed_projection_exprs, unproject_unnest_expr,
         unproject_unnest_expr_as_flatten_value, unproject_window_exprs,
     },
 };
@@ -417,6 +417,21 @@ impl Unparser<'_> {
         alias: Option<ast::TableAlias>,
         lateral: bool,
     ) -> Result<()> {
+        // A derived table is referred to by the names its schema reports, so any
+        // output the projection below leaves for the engine to name has to be
+        // aliased before the enclosing scope can bind it. A table alias that
+        // carries a column list already names every output, so it needs nothing.
+        let columns_named_by_alias = relation.has_columns_named_by_alias()
+            || alias
+                .as_ref()
+                .is_some_and(|alias| !alias.columns.is_empty());
+        let named = if columns_named_by_alias {
+            None
+        } else {
+            name_derived_scope_outputs(plan)?
+        };
+        let plan = named.as_ref().unwrap_or(plan);
+
         let mut derived_builder = DerivedRelationBuilder::default();
         derived_builder.lateral(lateral).alias(alias).subquery({
             let inner_statement = self.plan_to_sql(plan)?;
@@ -1643,7 +1658,17 @@ impl Unparser<'_> {
                         relation,
                     )?;
                 } else {
+                    // The alias attached below carries these names, so a derived
+                    // table built during the walk does not have to name its own
+                    // outputs to be addressable. An alias an enclosing scope has
+                    // already declared covers this relation too, since it is
+                    // attached last and is the one the outermost scope reads.
+                    let named_by_enclosing_alias = relation.has_columns_named_by_alias();
+                    relation.columns_named_by_alias(
+                        named_by_enclosing_alias || !columns.is_empty(),
+                    );
                     self.select_to_sql_recursively(&plan, query, select, relation)?;
+                    relation.columns_named_by_alias(named_by_enclosing_alias);
                 }
 
                 relation.alias(Some(

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1660,15 +1660,13 @@ impl Unparser<'_> {
                 } else {
                     // The alias attached below carries these names, so a derived
                     // table built during the walk does not have to name its own
-                    // outputs to be addressable. An alias an enclosing scope has
-                    // already declared covers this relation too, since it is
-                    // attached last and is the one the outermost scope reads.
-                    let named_by_enclosing_alias = relation.has_columns_named_by_alias();
-                    relation.columns_named_by_alias(
-                        named_by_enclosing_alias || !columns.is_empty(),
-                    );
+                    // outputs to be addressable. Restored afterwards because this
+                    // builder outlives the walk — a join derives its other side
+                    // through the same one.
+                    let outer = relation.has_columns_named_by_alias();
+                    relation.columns_named_by_alias(outer || !columns.is_empty());
                     self.select_to_sql_recursively(&plan, query, select, relation)?;
-                    relation.columns_named_by_alias(named_by_enclosing_alias);
+                    relation.columns_named_by_alias(outer);
                 }
 
                 relation.alias(Some(

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -315,16 +315,27 @@ pub(crate) fn name_derived_scope_outputs(
         return Ok(None);
     };
     // Naming an output must not rename it: the alias is the name the schema
-    // already reports, so the enclosing scope's references still resolve. Decline
-    // the rewrite rather than emit a derived table with different columns.
-    if named.schema().field_names() != plan.schema().field_names() {
-        return Ok(None);
-    }
+    // already reports, so the enclosing scope's references still resolve. That
+    // holds by construction — the alias is taken from the schema itself — and a
+    // node added to the walk below that renames its outputs would break it.
+    debug_assert!(
+        named
+            .schema()
+            .logically_equivalent_names_and_types(plan.schema()),
+        "naming a derived table's outputs renamed them: {} became {}",
+        plan.schema(),
+        named.schema()
+    );
     Ok(Some(named))
 }
 
 /// Aliases the unnamed outputs of the [Projection] that becomes this scope's `SELECT`
 /// list, rebuilding the nodes walked through on the way down to it.
+///
+/// The nodes walked through are the ones that carry the projection's output names
+/// out to the derived table unchanged. [`find_projection_node_within_select`] walks
+/// the same way for a different purpose and stops at a narrower set, because a
+/// predicate can only reach a projection that stays in its own `SELECT`.
 fn name_scope_projection_outputs(plan: &LogicalPlan) -> Result<Option<LogicalPlan>> {
     match plan {
         LogicalPlan::Projection(projection) => name_projection_outputs(projection),
@@ -357,9 +368,12 @@ fn name_projection_outputs(projection: &Projection) -> Result<Option<LogicalPlan
     let named = projection
         .expr
         .iter()
-        .map(|expr| {
+        .zip(projection.schema.fields())
+        .map(|(expr, field)| {
             if output_is_unnamed(expr) {
-                expr.clone().alias(expr.schema_name().to_string())
+                // The schema's name for the output, rather than a second derivation
+                // of it: this is the name the enclosing scope refers to it by.
+                expr.clone().alias(field.name().clone())
             } else {
                 expr.clone()
             }
@@ -416,18 +430,16 @@ pub(crate) fn unproject_unnamed_projection_exprs(
 /// time, in a clause that may see a different value than the `SELECT` list did,
 /// which would answer the query with silently wrong rows. The unbindable
 /// reference this repairs is at least a loud failure, so it is the safer of the
-/// two to leave in place.
+/// two to leave in place. Volatility is a fact about whether inlining is safe, not
+/// about whether the output is named, so it is checked separately from
+/// [`output_is_unnamed`].
 fn find_unnamed_projection_expr<'a>(
     projection: &'a Projection,
     column: &Column,
 ) -> Option<&'a Expr> {
     let index = projection.schema.index_of_column(column).ok()?;
     let expr = projection.expr.get(index)?;
-    if matches!(expr, Expr::Alias(_) | Expr::Column(_)) || expr.is_volatile() {
-        None
-    } else {
-        Some(expr)
-    }
+    (output_is_unnamed(expr) && !expr.is_volatile()).then_some(expr)
 }
 
 fn find_agg_expr<'a>(agg: &'a Aggregate, column: &Column) -> Result<Option<&'a Expr>> {

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -296,6 +296,93 @@ pub(crate) fn find_projection_node_within_select(
     }
 }
 
+/// Names the outputs a derived table exposes, where the [Projection] that supplies
+/// them leaves them unnamed.
+///
+/// A derived table is addressed from the scope that encloses it, and the unparser
+/// spells such a reference with the output's logical name — `t.a + t.b` for
+/// `Projection: t.a + t.b`. That name describes the expression; it is not an
+/// identifier the derived table carries, since an engine names an unaliased
+/// expression itself (`?column?` on PostgreSQL). Aliasing each unnamed output to
+/// the logical name the enclosing scope uses makes the reference bind, and — unlike
+/// repeating the expression at the point of use — evaluates it exactly once.
+///
+/// Returns `None` when nothing needs naming, so the plan is unparsed as it stands.
+pub(crate) fn name_derived_scope_outputs(
+    plan: &LogicalPlan,
+) -> Result<Option<LogicalPlan>> {
+    let Some(named) = name_scope_projection_outputs(plan)? else {
+        return Ok(None);
+    };
+    // Naming an output must not rename it: the alias is the name the schema
+    // already reports, so the enclosing scope's references still resolve. Decline
+    // the rewrite rather than emit a derived table with different columns.
+    if named.schema().field_names() != plan.schema().field_names() {
+        return Ok(None);
+    }
+    Ok(Some(named))
+}
+
+/// Aliases the unnamed outputs of the [Projection] that becomes this scope's `SELECT`
+/// list, rebuilding the nodes walked through on the way down to it.
+fn name_scope_projection_outputs(plan: &LogicalPlan) -> Result<Option<LogicalPlan>> {
+    match plan {
+        LogicalPlan::Projection(projection) => name_projection_outputs(projection),
+        // These carry the projection's output names through to the derived table
+        // unchanged, so the projection below is still the one exposing its columns.
+        LogicalPlan::Filter(_)
+        | LogicalPlan::Sort(_)
+        | LogicalPlan::Limit(_)
+        | LogicalPlan::Distinct(_)
+        | LogicalPlan::SubqueryAlias(_) => {
+            let inputs = plan.inputs();
+            let [input] = inputs.as_slice() else {
+                return Ok(None);
+            };
+            let Some(named_input) = name_scope_projection_outputs(input)? else {
+                return Ok(None);
+            };
+            plan.with_new_exprs(plan.expressions(), vec![named_input])
+                .map(Some)
+        }
+        _ => Ok(None),
+    }
+}
+
+/// The projection with each unnamed output aliased to the name its schema reports.
+fn name_projection_outputs(projection: &Projection) -> Result<Option<LogicalPlan>> {
+    if !projection.expr.iter().any(output_is_unnamed) {
+        return Ok(None);
+    }
+    let named = projection
+        .expr
+        .iter()
+        .map(|expr| {
+            if output_is_unnamed(expr) {
+                expr.clone().alias(expr.schema_name().to_string())
+            } else {
+                expr.clone()
+            }
+        })
+        .collect();
+    Projection::try_new(named, Arc::clone(&projection.input))
+        .map(|projection| Some(LogicalPlan::Projection(projection)))
+}
+
+/// Whether the emitted `SELECT` leaves this output for the engine to name.
+///
+/// An alias names it explicitly and a bare column keeps the name it already had,
+/// so in both cases the emitted name is the one the schema reports. A wildcard
+/// stands for a list of columns that each keep their own name, and cannot take an
+/// alias at all. Every other expression is emitted unnamed.
+fn output_is_unnamed(expr: &Expr) -> bool {
+    #[expect(deprecated)]
+    !matches!(
+        expr,
+        Expr::Alias(_) | Expr::Column(_) | Expr::Wildcard { .. }
+    )
+}
+
 /// Replaces a reference to a [Projection] output that the projection does not name
 /// with the expression that produces it.
 ///

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -27,8 +27,8 @@ use datafusion_common::{
     tree_node::{Transformed, TransformedResult, TreeNode},
 };
 use datafusion_expr::{
-    Aggregate, Expr, LogicalPlan, LogicalPlanBuilder, Projection, SortExpr, Unnest,
-    Window, expr, utils::grouping_set_to_exprlist,
+    Aggregate, Distinct, Expr, LogicalPlan, LogicalPlanBuilder, Projection, SortExpr,
+    Unnest, Window, expr, utils::grouping_set_to_exprlist,
 };
 
 use indexmap::IndexSet;
@@ -337,27 +337,58 @@ pub(crate) fn name_derived_scope_outputs(
 /// the same way for a different purpose and stops at a narrower set, because a
 /// predicate can only reach a projection that stays in its own `SELECT`.
 fn name_scope_projection_outputs(plan: &LogicalPlan) -> Result<Option<LogicalPlan>> {
+    // Each node is rebuilt by replacing its input and leaving every other field as
+    // it stands. `LogicalPlan::with_new_exprs` is the shorter spelling and the
+    // wrong one: it reconstructs a node from the expressions a plan reports, and
+    // that round trip does not carry a `DISTINCT ON`'s sort expressions — it
+    // panics on a plan that has them.
     match plan {
         LogicalPlan::Projection(projection) => name_projection_outputs(projection),
-        // These carry the projection's output names through to the derived table
-        // unchanged, so the projection below is still the one exposing its columns.
-        LogicalPlan::Filter(_)
-        | LogicalPlan::Sort(_)
-        | LogicalPlan::Limit(_)
-        | LogicalPlan::Distinct(_)
-        | LogicalPlan::SubqueryAlias(_) => {
-            let inputs = plan.inputs();
-            let [input] = inputs.as_slice() else {
-                return Ok(None);
-            };
-            let Some(named_input) = name_scope_projection_outputs(input)? else {
-                return Ok(None);
-            };
-            plan.with_new_exprs(plan.expressions(), vec![named_input])
-                .map(Some)
+        // The nodes below carry the projection's output names out to the derived
+        // table unchanged, so the projection under them is still the one exposing
+        // its columns.
+        LogicalPlan::Filter(filter) => with_named_input(&filter.input, |input| {
+            let mut filter = filter.clone();
+            filter.input = input;
+            LogicalPlan::Filter(filter)
+        }),
+        LogicalPlan::Sort(sort) => with_named_input(&sort.input, |input| {
+            let mut sort = sort.clone();
+            sort.input = input;
+            LogicalPlan::Sort(sort)
+        }),
+        LogicalPlan::Limit(limit) => with_named_input(&limit.input, |input| {
+            let mut limit = limit.clone();
+            limit.input = input;
+            LogicalPlan::Limit(limit)
+        }),
+        LogicalPlan::Distinct(Distinct::All(input)) => {
+            with_named_input(input, |input| LogicalPlan::Distinct(Distinct::All(input)))
+        }
+        LogicalPlan::Distinct(Distinct::On(distinct_on)) => {
+            with_named_input(&distinct_on.input, |input| {
+                let mut distinct_on = distinct_on.clone();
+                distinct_on.input = input;
+                LogicalPlan::Distinct(Distinct::On(distinct_on))
+            })
+        }
+        LogicalPlan::SubqueryAlias(subquery_alias) => {
+            with_named_input(&subquery_alias.input, |input| {
+                let mut subquery_alias = subquery_alias.clone();
+                subquery_alias.input = input;
+                LogicalPlan::SubqueryAlias(subquery_alias)
+            })
         }
         _ => Ok(None),
     }
+}
+
+/// Rebuilds a node around a named input, or `None` where the input needs no naming.
+fn with_named_input(
+    input: &Arc<LogicalPlan>,
+    rebuild: impl FnOnce(Arc<LogicalPlan>) -> LogicalPlan,
+) -> Result<Option<LogicalPlan>> {
+    Ok(name_scope_projection_outputs(input)?.map(|named| rebuild(Arc::new(named))))
 }
 
 /// The projection with each unnamed output aliased to the name its schema reports.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -6144,6 +6144,140 @@ fn test_filter_on_unnamed_volatile_projection_output_is_not_inlined() -> Result<
 }
 
 #[test]
+fn test_derived_projection_output_is_named() -> Result<()> {
+    // The `Filter` sits above the projection rather than beside it, so the
+    // projection becomes a derived table and the predicate keeps the reference
+    // instead of inlining what produces it. The reference is the output's logical
+    // name, which the derived table only carries once the projection names it.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b"))])?
+        .filter(col("t.a + t.b").gt(lit(1)))?
+        .project(vec![col("t.a + t.b")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "t.a + t.b" FROM (SELECT (t.a + t.b) AS "t.a + t.b" FROM t) WHERE ("t.a + t.b" > 1)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_derived_limit_output_is_named() -> Result<()> {
+    // A row limit puts the projection in a scope of its own for a reason of its
+    // own, and the outer reference is unbindable there for the same reason.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b"))])?
+        .limit(0, Some(5))?
+        .project(vec![col("t.a + t.b")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "t.a + t.b" FROM (SELECT (t.a + t.b) AS "t.a + t.b" FROM t LIMIT 5)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_derived_literal_output_is_named() -> Result<()> {
+    // A literal is named by the engine too, so a reference to one from the
+    // enclosing scope needs the same repair.
+    let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0]))?
+        .project(vec![lit(1)])?
+        .filter(col("Int32(1)").gt(lit(0)))?
+        .project(vec![col("Int32(1)")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "Int32(1)" FROM (SELECT 1 AS "Int32(1)" FROM t) WHERE ("Int32(1)" > 0)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_derived_volatile_output_is_named_and_evaluated_once() -> Result<()> {
+    // A volatile output is left in place rather than inlined, since inlining
+    // evaluates it a second time and answers the query with rows the `SELECT`
+    // list never saw. Naming the output binds the reference *and* keeps the
+    // single evaluation, so the scope the derived table provides repairs the
+    // case that inlining cannot.
+    let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0]))?
+        .project(vec![datafusion_functions::math::random().call(vec![])])?
+        .filter(col("random()").gt(lit(0.5)))?
+        .project(vec![col("random()")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "random()" FROM (SELECT random() AS "random()" FROM t) WHERE ("random()" > 0.5)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_named_derived_projection_outputs_are_unchanged() -> Result<()> {
+    // An alias and a bare column already carry the name the enclosing scope
+    // uses, so neither is renamed and neither picks up a redundant alias.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b")).alias("s"), col("t.b")])?
+        .filter(col("s").gt(lit(1)))?
+        .project(vec![col("s"), col("t.b")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT s, b FROM (SELECT (t.a + t.b) AS s, t.b FROM t) WHERE (s > 1)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_subquery_alias_over_pushed_down_scan_still_unbindable() -> Result<()> {
+    // The scan pushdown requalifies the projection onto the subquery alias before
+    // the derived table is built, so the name the derived table can report for the
+    // output — `s.a + s.b` — is not the one the enclosing scope uses for it,
+    // `t.a + t.b`. Naming the output cannot close that gap: the repair is for the
+    // enclosing scope to name the relation's columns on the alias it attaches.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = LogicalPlanBuilder::from(
+        table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+            .project(vec![col("t.a").add(col("t.b"))])?
+            .alias("s")?
+            .build()?,
+    )
+    .project(vec![Expr::Column(Column::new(
+        Some(TableReference::bare("s")),
+        "t.a + t.b",
+    ))])?
+    .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT s."t.a + t.b" FROM (SELECT (s.a + s.b) AS "s.a + s.b" FROM t AS s) AS s"#
+    );
+    Ok(())
+}
+
+#[test]
 fn test_qualified_join_input_fetch_refused_on_full_qualified_col_dialect() -> Result<()> {
     let schema = Schema::new(vec![
         Field::new("id", DataType::Utf8, false),

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -6227,6 +6227,61 @@ fn test_derived_volatile_output_is_named_and_evaluated_once() -> Result<()> {
 }
 
 #[test]
+fn test_derived_output_under_sort_and_distinct_is_named() -> Result<()> {
+    // The nodes between the derived table and the projection carry the output's
+    // name out unchanged, so the projection below is still the one that has to
+    // name it — including for the `ORDER BY` inside the derived table, which
+    // refers to the output by the same name the enclosing scope does.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b"))])?
+        .distinct()?
+        .sort(vec![col("t.a + t.b").sort(true, false)])?
+        .limit(0, Some(5))?
+        .project(vec![col("t.a + t.b")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "t.a + t.b" FROM (SELECT DISTINCT (t.a + t.b) AS "t.a + t.b" FROM t ORDER BY "t.a + t.b" ASC NULLS LAST LIMIT 5)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_derived_output_under_subquery_alias_is_named() -> Result<()> {
+    // The subquery alias renames the relation, not the output, so the name the
+    // enclosing scope uses is still the one the projection reports — and the
+    // requalification of the expression onto the alias happens after the output
+    // has been named, so the two do not have to agree on the expression's spelling.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = LogicalPlanBuilder::from(
+        table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+            .project(vec![col("t.a").add(col("t.b"))])?
+            .alias("s")?
+            .build()?,
+    )
+    .limit(0, Some(5))?
+    .project(vec![Expr::Column(Column::new(
+        Some(TableReference::bare("s")),
+        "t.a + t.b",
+    ))])?
+    .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "t.a + t.b" FROM (SELECT (s.a + s.b) AS "t.a + t.b" FROM (SELECT s.a, s.b FROM t AS s) AS s LIMIT 5)"#
+    );
+    Ok(())
+}
+
+#[test]
 fn test_named_derived_projection_outputs_are_unchanged() -> Result<()> {
     // An alias and a bare column already carry the name the enclosing scope
     // uses, so neither is renamed and neither picks up a redundant alias.
@@ -6243,6 +6298,27 @@ fn test_named_derived_projection_outputs_are_unchanged() -> Result<()> {
     assert_snapshot!(
         plan_to_sql(&plan)?,
         @r#"SELECT s, b FROM (SELECT (t.a + t.b) AS s, t.b FROM t) WHERE (s > 1)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_derived_output_name_carrying_a_quote_is_escaped() -> Result<()> {
+    // The name comes from the plan, so it can carry any character a literal or a
+    // column name can — including the quote that delimits the identifier it is
+    // emitted as. Both the alias and the reference to it escape it, so neither
+    // closes the identifier early and injects into the statement.
+    let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
+    let hostile = r#"Utf8("x" OR 1=1 --")"#;
+    let plan = table_scan(Some("t"), &schema, Some(vec![0]))?
+        .project(vec![lit("x\" OR 1=1 --")])?
+        .filter(col(hostile).is_not_null())?
+        .project(vec![col(hostile)])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "Utf8(""x"" OR 1=1 --"")" FROM (SELECT 'x" OR 1=1 --' AS "Utf8(""x"" OR 1=1 --"")" FROM t) WHERE "Utf8(""x"" OR 1=1 --"")" IS NOT NULL"#
     );
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -6282,6 +6282,34 @@ fn test_derived_output_under_subquery_alias_is_named() -> Result<()> {
 }
 
 #[test]
+fn test_derived_output_under_distinct_on_with_sort_is_named() -> Result<()> {
+    // `DISTINCT ON` carries its own `ORDER BY`, and rebuilding the node from the
+    // expressions a plan reports drops it — `LogicalPlan::with_new_exprs` asserts
+    // it was not asked to. Replacing only the input keeps every other field, so a
+    // plan with sort expressions is named rather than panicked on.
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]);
+    let plan = table_scan(Some("t"), &schema, Some(vec![0, 1]))?
+        .project(vec![col("t.a").add(col("t.b")), col("t.a")])?
+        .distinct_on(
+            vec![col("t.a")],
+            vec![col("t.a + t.b"), col("t.a")],
+            Some(vec![col("t.a").sort(true, false)]),
+        )?
+        .limit(0, Some(5))?
+        .project(vec![col("t.a + t.b")])?
+        .build()?;
+
+    assert_snapshot!(
+        plan_to_sql(&plan)?,
+        @r#"SELECT "t.a + t.b" FROM (SELECT DISTINCT ON (t.a) "t.a + t.b", a FROM (SELECT (t.a + t.b) AS "t.a + t.b", t.a FROM t) ORDER BY a ASC NULLS LAST LIMIT 5)"#
+    );
+    Ok(())
+}
+
+#[test]
 fn test_named_derived_projection_outputs_are_unchanged() -> Result<()> {
     // An alias and a bare column already carry the name the enclosing scope
     // uses, so neither is renamed and neither picks up a redundant alias.


### PR DESCRIPTION
## Summary

A `Projection` that becomes a derived table leaves an output the projection does not name for the engine to name — `?column?` on PostgreSQL — while the scope that encloses the derived table refers to that output by its *logical* name, `t.a + t.b`. The emitted statement then carries a reference no engine can bind:

```sql
SELECT "t.a + t.b" FROM (SELECT (t.a + t.b) FROM t) WHERE ("t.a + t.b" > 1)
--     ^^^^^^^^^^^ names nothing the derived table exposes
```

spiceai/spiceai#12599 repaired the case where the projection is flattened into the *same* `SELECT`, by inlining the producing expression at the point of use. That repair deliberately stops at the scope boundary: once the `SELECT` list is taken, the projection becomes a derived table and the producing expression is no longer available where the reference is. Nothing then named the derived table's columns, so the reference stayed unbindable — which is what a remote engine rejects on a federated pushdown.

The gap is not specific to the reported shape. Every derived table the unparser builds goes through `Unparser::derive`, and all of them exposed the same unnamed outputs — a `Filter` above the projection, a row limit, a literal output:

```sql
SELECT "t.a + t.b" FROM (SELECT (t.a + t.b) FROM t LIMIT 5)
SELECT "Int32(1)"  FROM (SELECT 1 FROM t) WHERE ("Int32(1)" > 0)
```

## Changes

Alias each unnamed output to the name its schema reports, in `derive`, so every derived table the unparser builds is addressable by the names the enclosing scope uses. An output is "unnamed" exactly where spiceai/spiceai#12599's repair says it is: an alias names it explicitly, a bare column keeps the name it already had, and a wildcard cannot take an alias at all — everything else is emitted for the engine to name.

Two properties fall out of doing it here rather than at the point of use:

- **It repairs the volatile case, which inlining cannot.** Inlining a volatile expression evaluates it a second time in a clause that can observe a different value than the `SELECT` list did, answering the query with rows the `SELECT` list never saw; spiceai/spiceai#12599 declines it for that reason and leaves the reference unbindable. A name is not an evaluation, so the derived scope binds the reference *and* keeps the single evaluation.
- **No existing output changes.** A table alias that carries a column list already names every output, so the rewrite is skipped there. That includes the case where an enclosing `SubqueryAlias` attaches the list *after* the derived table has been built, which the relation builder now carries as an explicit declaration (`RelationBuilder::columns_named_by_alias`). Without it, `roundtrip_statement_with_dialect_18` picks up a redundant alias — that test is the guard on this half.

The rewrite is declined outright if it would ever rename an output rather than name it, so a derived table cannot come back with different columns than the plan says it has.

### Scope

`test_subquery_alias_over_pushed_down_scan_still_unbindable` pins one shape this does **not** repair: when the scan pushdown requalifies the projection onto a subquery alias, the name the derived table can report is not the name the enclosing scope uses, and no naming of the output can close that gap. The repair there belongs to the enclosing scope's column list. Filed as spiceai/spiceai#13140.

## Test plan

- `cargo test -p datafusion-sql` — 556 pass. The 22 failures on this branch are **pre-existing on `spiceai-54`** (identical set on a clean tree; tracked in spiceai/spiceai#13134) and none are new: the failing-test set is byte-identical before and after this change.
- `cargo test -p datafusion --test core_integration -- sql::unparser sql::joins` — 9 pass, including the TPC-H and ClickBench unparser roundtrips, which re-plan the emitted SQL and compare results.
- New tests in `datafusion/sql/tests/cases/plan_to_sql.rs`:
  - `test_derived_projection_output_is_named` — the reported shape.
  - `test_derived_limit_output_is_named` — the same defect reached through a row limit rather than a filter.
  - `test_derived_output_under_sort_and_distinct_is_named` — the nodes walked through on the way to the projection, including the derived table's own `ORDER BY`, which refers to the output by the same name.
  - `test_derived_output_under_subquery_alias_is_named` — a subquery alias renames the relation, not the output, so the name still binds even though the expression is requalified afterwards.
  - `test_derived_output_under_distinct_on_with_sort_is_named` — a `DISTINCT ON` keeps its own `ORDER BY` through the rebuild; this panicked before the walk stopped reconstructing nodes from their reported expressions.
  - `test_derived_literal_output_is_named` — a literal output is engine-named too.
  - `test_derived_volatile_output_is_named_and_evaluated_once` — binds without a second evaluation.
  - `test_named_derived_projection_outputs_are_unchanged` — an alias or bare column picks up nothing.
  - `test_derived_output_name_carrying_a_quote_is_escaped` — the name comes from the plan, so it can carry the quote character that delimits the identifier it is emitted as; both the alias and the reference double it.
  - `test_subquery_alias_over_pushed_down_scan_still_unbindable` — pins the shape left open, above.
- Neutered each half to prove the tests are not vacuous: disabling the rewrite fails 8 of the 9 naming tests and leaves `test_named_derived_projection_outputs_are_unchanged` passing; removing the `columns_named_by_alias` declaration fails `roundtrip_statement_with_dialect_18` only; restoring the `with_new_exprs` rebuild panics `test_derived_output_under_distinct_on_with_sort_is_named` at `plan.rs:1068`.

**This repository runs no Rust CI** — `spiceai/datafusion` has only a Copilot review workflow on every branch, `main` included (spiceai/spiceai#13134), so a fork PR inherits no sign-off or `Attestation` gate. The results above are from local runs.

## Performance impact

`derive` runs once per derived table at unparsing time, not per row. Where nothing needs naming it scans the projection's expressions and returns without allocating; where something does, it clones that projection's expressions and rebuilds the nodes above it. Both are bounded by plan size.

## Review gate

- Adversarial review: **skipped** — re-run on the current head (`a5da81b`) and again on the first push; both receipts record `engine=none exit=1`, because `codex` exited 1 with `Codex error: Your workspace is out of credits. Ask your workspace owner to refill in order to continue.`, and `grok` is not installed on this machine, so the receipt records `engine=none exit=1`. Its angles were run by hand instead, and two changed the diff: tracing where a rewritten plan's names come from (the alias now reads the projection's schema rather than re-deriving the name from the expression, so the name and the reference cannot drift), and asking what the rewrite costs where nothing needs naming (the scan over the projection's expressions returns without allocating, and nothing is rebuilt). Two angles were checked and left the diff alone: the rewritten plan is consumed by `plan_to_sql` and discarded, so it cannot leak a changed schema downstream; and an identifier longer than an engine's limit fails identically at the alias and at the reference, so no query that binds today stops binding.
- `/security-review`: run, but the harness scoped it to the session's working directory rather than this repository, so it audited an empty diff — treated as a skip and the audit run by hand over the same diff. One class applies: the alias is a plan-derived string emitted in identifier position, so a name carrying the identifier's own quote character could close it early. It does not — `Ident`'s rendering doubles the quote in both the alias and the reference — and `test_derived_output_name_carrying_a_quote_is_escaped` pins that. No credential, token, or internal detail reaches a log line, error, or this body.
- Copilot review: one finding, and it was a real defect — `LogicalPlan::with_new_exprs` asserts it was not handed a `DISTINCT ON`'s sort expressions, so naming the outputs under a `DISTINCT ON ... ORDER BY` **panicked**. Reproduced, then fixed more broadly than reported: the walk now replaces only each node's input and leaves every other field as it stands, since reconstructing a node from the expressions it reports can only carry what those expressions carry. Thread resolved with the reproduction.
- `/simplify`: 4 agents (reuse / simplification / efficiency / altitude). Applied: one definition of "the projection leaves this output unnamed", shared with the inlining repair that had spelled it separately; the alias taken from the schema rather than re-derived; an allocation-free schema comparison, then demoted to a `debug_assert!` once it was shown unreachable by construction; the builder accessors narrowed from `pub` to `pub(super)`; a cross-reference between this walk and the narrower one beside it; and the three untested arms of the walk covered by two new tests. Skipped with reasons: replacing the walk with `transform_down` (the explicit arms name the load-bearing fact — which nodes carry a name through — that control-flow markers would hide); reusing `inject_column_aliases` (it aliases unconditionally, which is what its other caller needs and the opposite of what this one needs); collapsing the setter/getter into a public field (the file's builders are uniformly setter-based); and dropping the two tests called redundant (each pins a user-visible shape the others do not name). The suggestion to consolidate the crate's four hand-rolled projection walks is real but outside this diff — filed as spiceai/spiceai#13141.

Fixes spiceai/spiceai#12751
