### PR TITLE
fix(unparser): refuse an EXISTS correlation the subquery's own FROM would capture

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -45,8 +45,9 @@ use arrow::datatypes::{
 };
 use arrow::util::display::array_value_to_string;
 use datafusion_common::{
-    Column, Result, ScalarValue, assert_eq_or_internal_err, assert_or_internal_err,
-    internal_datafusion_err, internal_err, not_impl_err, plan_err,
+    Column, Result, ScalarValue, TableReference, assert_eq_or_internal_err,
+    assert_or_internal_err, internal_datafusion_err, internal_err, not_impl_err,
+    plan_err,
 };
 use datafusion_expr::{
     Between, BinaryExpr, Case, Cast, Expr, GroupingSet, Like, Operator, TryCast,
@@ -841,6 +842,22 @@ impl Unparser<'_> {
         }
     }
 
+    /// The identifier components this dialect spells a column's qualifier with.
+    ///
+    /// A dialect that does not spell columns in full writes only the relation's
+    /// last component, so two relations distinguished by schema or catalog are
+    /// emitted — and therefore bound — identically. Anything reasoning about how a
+    /// reference will resolve has to ask this rather than read the
+    /// [`TableReference`], or it will disagree with what
+    /// [`Self::col_to_sql`] actually writes.
+    pub(crate) fn emitted_qualifier(&self, table_ref: &TableReference) -> Vec<String> {
+        if self.dialect.full_qualified_col() {
+            table_ref.to_vec()
+        } else {
+            vec![table_ref.table().to_string()]
+        }
+    }
+
     pub fn col_to_sql(&self, col: &Column) -> Result<ast::Expr> {
         // Replace the column name if the dialect has an override
         let col_name =
@@ -851,11 +868,7 @@ impl Unparser<'_> {
             };
 
         if let Some(table_ref) = &col.relation {
-            let mut id = if self.dialect.full_qualified_col() {
-                table_ref.to_vec()
-            } else {
-                vec![table_ref.table().to_string()]
-            };
+            let mut id = self.emitted_qualifier(table_ref);
             id.push(col_name);
             return Ok(ast::Expr::CompoundIdentifier(
                 id.iter()

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2592,6 +2592,11 @@ impl Unparser<'_> {
         right_plan: &LogicalPlan,
         join: &Join,
     ) -> Result<ast::Query> {
+        // Checked before any of the body is built: this refusal is about the
+        // correlation's qualifiers alone, and holds whether or not a bound is
+        // found below.
+        Self::ensure_exists_correlation_not_shadowed(join)?;
+
         let mut query_builder = Some(QueryBuilder::default());
         let body = self.select_to_sql_expr(right_plan, &mut query_builder)?;
         let mut query_builder = query_builder.unwrap();
@@ -2714,6 +2719,102 @@ impl Unparser<'_> {
         matches!(join_type, JoinType::RightSemi | JoinType::RightAnti)
     }
 
+    /// Refuses a correlation that the `EXISTS` body's own `FROM` would capture.
+    ///
+    /// The correlated predicates are emitted inside the subquery, so every
+    /// reference in them binds to the innermost scope answering to its qualifier.
+    /// A reference meant for the outer query whose name the build side also
+    /// answers to therefore binds to the subquery's own relation instead: the
+    /// correlation becomes a comparison of an inner row with itself, `EXISTS`
+    /// degenerates to "this relation has a row", and a semi or mark join then
+    /// keeps every probe row while an anti join drops every one. That is valid
+    /// SQL, so a database runs it and returns those wrong rows.
+    ///
+    /// SQL's scoping rules decide it on their own, so the capture does not need a
+    /// row bound to happen and is checked before one is looked for. Refusing
+    /// costs the pushdown, which is the trade [`Self::exists_scope_name`] already
+    /// makes for output that binds and runs rather than failing.
+    ///
+    /// Two things this has to get right, both of which cost correctness in one
+    /// direction and pushdown in the other:
+    ///
+    /// * **Compare the name the SQL is spelled with, not the `TableReference`.**
+    ///   A qualified column renders as its relation's last component on the
+    ///   dialects that do not spell columns in full, so `s1.t` and `s2.t` are
+    ///   distinct references that both emit as `t` and both bind to whichever
+    ///   `t` the subquery's `FROM` introduces. Comparing the references whole
+    ///   reads them as disjoint and lets the capture through.
+    /// * **Attribute each `on` pair by side.** The pairs are already split into
+    ///   `(left, right)`, and only the probe half is the correlated reference; a
+    ///   build half naming a build relation is an ordinary local reference that
+    ///   binds inside on purpose. Testing both halves refuses every join whose
+    ///   build side shares a name with the probe, including the correct ones.
+    ///   `join.filter` carries no such split, so a reference in it cannot be
+    ///   attributed — there, only a name *both* sides answer to is refused,
+    ///   which no reference to a distinct relation can be.
+    ///
+    /// Left alone, and left to the qualifier rewrite tracked by
+    /// spiceai/spiceai#12840: an unqualified correlated reference, which names no
+    /// relation to collide with; and a shared relation whose columns one side
+    /// projects away entirely, which drops that side's name from the schema this
+    /// reads, so a filter-carried collision becomes invisible. Conversely this is
+    /// conservative under a dialect that spells columns in full, where the
+    /// distinct qualifiers would have kept the reference bound — that dialect is
+    /// already refused a scope by [`Self::exists_scope_name`] for the same
+    /// spelling reason.
+    fn ensure_exists_correlation_not_shadowed(join: &Join) -> Result<()> {
+        // Which input is correlated against, and therefore which half of each
+        // `on` pair is the correlated reference, follows the same swap the join
+        // arm applies before it builds this subquery.
+        let swapped = Self::swaps_join_inputs(join.join_type);
+        let (probe_plan, build_plan) = if swapped {
+            (&join.right, &join.left)
+        } else {
+            (&join.left, &join.right)
+        };
+
+        // The emitted name, which is what a reference in the subquery binds on.
+        let emitted_names = |plan: &LogicalPlan| -> Vec<String> {
+            let mut names: Vec<String> = Vec::new();
+            for (relation, _) in plan.schema().iter() {
+                if let Some(relation) = relation
+                    && !names.iter().any(|name| name == relation.table())
+                {
+                    names.push(relation.table().to_string());
+                }
+            }
+            names
+        };
+        let build_names = emitted_names(build_plan);
+        let names_any = |expr: &Expr, candidates: &[String]| {
+            expr.column_refs().into_iter().any(|column| {
+                column.relation.as_ref().is_some_and(|relation| {
+                    candidates.iter().any(|name| name == relation.table())
+                })
+            })
+        };
+
+        let captured = join
+            .on
+            .iter()
+            .map(|(left, right)| if swapped { right } else { left })
+            .any(|correlated| names_any(correlated, &build_names))
+            || join.filter.as_ref().is_some_and(|filter| {
+                let shared: Vec<String> = emitted_names(probe_plan)
+                    .into_iter()
+                    .filter(|name| build_names.contains(name))
+                    .collect();
+                names_any(filter, &shared)
+            });
+
+        if captured {
+            return not_impl_err!(
+                "Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
+            );
+        }
+        Ok(())
+    }
+
     /// The name a scope around the `EXISTS` build side has to answer to, so the
     /// correlated predicates still resolve against it.
     ///
@@ -2783,10 +2884,15 @@ impl Unparser<'_> {
             [] if !names_a_probe_relation => Ok("derived_limit".to_string()),
             // A qualifier the probe side also answers to can be a build-side
             // reference on a self-join, where naming the scope anything else
-            // rebinds it to the probe. Both readings are wrong: the body's own
-            // relation already shadows the outer one, so the correlation is lost
-            // whatever the bound does, and renaming would only swap that wrong
-            // answer for a different one.
+            // rebinds it to the probe.
+            //
+            // Where the build side answers to that qualifier too — the self-join
+            // proper — `ensure_exists_correlation_not_shadowed` has already
+            // refused the plan, bound or not. What reaches here is the residue:
+            // a correlation qualified only by a probe relation the build side
+            // does not share, so nothing is captured, but there is also no
+            // build-side name for the scope to keep bound. Renaming it would
+            // rebind the reference to the probe, so this refuses instead.
             [] => {
                 not_impl_err!(
                     "Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation's only qualifier is one the probe side also answers to"

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2719,36 +2719,56 @@ impl Unparser<'_> {
         matches!(join_type, JoinType::RightSemi | JoinType::RightAnti)
     }
 
+    /// Aliases the unparser may invent for a derived table it introduces.
+    ///
+    /// These reach the emitted `FROM` without appearing anywhere in the plan, so
+    /// [`Self::scope_qualifiers`] cannot find them by walking it. They are treated
+    /// as always in scope inside an `EXISTS` body: a correlated reference to a
+    /// relation a user happened to name one of these is refused rather than
+    /// emitted, since the invented alias would capture it.
+    const UNPARSER_DERIVED_ALIASES: [&'static str; 8] = [
+        "derived_aggregate",
+        "derived_distinct",
+        "derived_limit",
+        "derived_projection",
+        "derived_sort",
+        "derived_union",
+        "derived_unnest",
+        "derived_window_input",
+    ];
+
     /// The qualifiers the `EXISTS` body's `FROM` will answer to.
     ///
-    /// Not the same thing as the qualifiers on `plan`'s output schema. A
-    /// projection that prunes every column of a relation leaves that relation
-    /// with no qualified output field, yet it is still named in the emitted
-    /// `FROM` and still captures a reference using its name — so the schema
-    /// alone under-reports the scope, in the direction that emits wrong rows.
+    /// Read from the relations the `FROM` introduces rather than from `plan`'s
+    /// output schema, which is a proxy that is wrong in both directions:
     ///
-    /// So both halves are needed, and neither subsumes the other: the schema
-    /// reports a qualifier a node introduces without a scan beneath it — a
-    /// `SubqueryAlias`'s alias, say — while the walk reports a scanned relation
-    /// the schema has lost. The walk stops at a `SubqueryAlias` because a derived
-    /// table's inner relations are not addressable through its alias, so
-    /// collecting them would refuse references that bind perfectly well.
+    /// * A projection pruning every column of a relation leaves it with no
+    ///   qualified output field, while it is still named in the `FROM` and still
+    ///   captures a reference using its name.
+    /// * A `SubqueryAlias` puts its alias on the schema as the whole
+    ///   [`TableReference`] it was built from, but a derived table's alias is a
+    ///   single identifier, so only `table()` is emitted — and dialect-independently
+    ///   so, unlike a scanned relation. Keying an alias `s.a` off the schema would
+    ///   miss an outer `a.c` that `AS a` really does capture, and refuse an outer
+    ///   `s.a.c` that it does not.
+    ///
+    /// The walk stops at a `SubqueryAlias`: an alias replaces the name it is given
+    /// to, so the relations it encloses are not addressable through it and
+    /// collecting them would refuse references that bind correctly.
     fn scope_qualifiers(&self, plan: &LogicalPlan) -> Result<Vec<Vec<String>>> {
-        let mut qualifiers: Vec<Vec<String>> = plan
-            .schema()
+        let mut qualifiers: Vec<Vec<String>> = Self::UNPARSER_DERIVED_ALIASES
             .iter()
-            .filter_map(|(relation, _)| relation)
-            .map(|relation| self.emitted_qualifier(relation))
+            .map(|alias| vec![(*alias).to_string()])
             .collect();
         plan.apply(|node| match node {
             LogicalPlan::TableScan(scan) => {
                 qualifiers.push(self.emitted_qualifier(&scan.table_name));
                 Ok(TreeNodeRecursion::Continue)
             }
-            // The alias is already on this node's output schema, collected
-            // above; what the walk has to do here is stop, so the relations it
-            // encloses are not collected as if they were in scope.
-            LogicalPlan::SubqueryAlias(_) => Ok(TreeNodeRecursion::Jump),
+            LogicalPlan::SubqueryAlias(alias) => {
+                qualifiers.push(vec![alias.alias.table().to_string()]);
+                Ok(TreeNodeRecursion::Jump)
+            }
             _ => Ok(TreeNodeRecursion::Continue),
         })?;
         Ok(qualifiers)

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2719,6 +2719,41 @@ impl Unparser<'_> {
         matches!(join_type, JoinType::RightSemi | JoinType::RightAnti)
     }
 
+    /// The qualifiers the `EXISTS` body's `FROM` will answer to.
+    ///
+    /// Not the same thing as the qualifiers on `plan`'s output schema. A
+    /// projection that prunes every column of a relation leaves that relation
+    /// with no qualified output field, yet it is still named in the emitted
+    /// `FROM` and still captures a reference using its name — so the schema
+    /// alone under-reports the scope, in the direction that emits wrong rows.
+    ///
+    /// So both halves are needed, and neither subsumes the other: the schema
+    /// reports a qualifier a node introduces without a scan beneath it — a
+    /// `SubqueryAlias`'s alias, say — while the walk reports a scanned relation
+    /// the schema has lost. The walk stops at a `SubqueryAlias` because a derived
+    /// table's inner relations are not addressable through its alias, so
+    /// collecting them would refuse references that bind perfectly well.
+    fn scope_qualifiers(&self, plan: &LogicalPlan) -> Result<Vec<Vec<String>>> {
+        let mut qualifiers: Vec<Vec<String>> = plan
+            .schema()
+            .iter()
+            .filter_map(|(relation, _)| relation)
+            .map(|relation| self.emitted_qualifier(relation))
+            .collect();
+        plan.apply(|node| match node {
+            LogicalPlan::TableScan(scan) => {
+                qualifiers.push(self.emitted_qualifier(&scan.table_name));
+                Ok(TreeNodeRecursion::Continue)
+            }
+            // The alias is already on this node's output schema, collected
+            // above; what the walk has to do here is stop, so the relations it
+            // encloses are not collected as if they were in scope.
+            LogicalPlan::SubqueryAlias(_) => Ok(TreeNodeRecursion::Jump),
+            _ => Ok(TreeNodeRecursion::Continue),
+        })?;
+        Ok(qualifiers)
+    }
+
     /// Refuses a correlation that the `EXISTS` body's own `FROM` would capture.
     ///
     /// The correlated predicates are emitted inside the subquery, so every
@@ -2759,9 +2794,11 @@ impl Unparser<'_> {
     ///
     /// * An unqualified correlated reference, which names no relation to collide
     ///   with, so which scope it resolves against is that rewrite's question.
-    /// * A shared relation whose columns one side projects away entirely, which
-    ///   drops that side's qualifier from the schema read here, so a
-    ///   filter-carried collision becomes invisible.
+    /// * A relation reached through a `SubqueryAlias`, whose own name the emitted
+    ///   SQL replaces with the alias. The alias is what this compares, which is
+    ///   right for a reference written against it, but a correlated reference
+    ///   still qualified by the enclosed relation is a shape the rewrite has to
+    ///   requalify rather than refuse.
     fn ensure_exists_correlation_not_shadowed(&self, join: &Join) -> Result<()> {
         let swapped = Self::swaps_join_inputs(join.join_type);
         let (probe_plan, build_plan) = if swapped {
@@ -2770,14 +2807,6 @@ impl Unparser<'_> {
             (&join.left, &join.right)
         };
 
-        // Duplicates cannot change a membership test, so these are not deduped.
-        let emitted_qualifiers = |plan: &LogicalPlan| -> Vec<Vec<String>> {
-            plan.schema()
-                .iter()
-                .filter_map(|(relation, _)| relation)
-                .map(|relation| self.emitted_qualifier(relation))
-                .collect()
-        };
         let references_any = |expr: &Expr, candidates: &[Vec<String>]| {
             expr.column_refs().into_iter().any(|column| {
                 column.relation.as_ref().is_some_and(|relation| {
@@ -2786,20 +2815,24 @@ impl Unparser<'_> {
             })
         };
 
-        let build_qualifiers = emitted_qualifiers(build_plan);
+        let build_qualifiers = self.scope_qualifiers(build_plan)?;
         let on_captured = join
             .on
             .iter()
             .map(|(left, right)| if swapped { right } else { left })
             .any(|correlated| references_any(correlated, &build_qualifiers));
         // Computed only when there is a filter, which most joins do not have.
-        let filter_captured = join.filter.as_ref().is_some_and(|filter| {
-            let shared: Vec<Vec<String>> = emitted_qualifiers(probe_plan)
-                .into_iter()
-                .filter(|qualifier| build_qualifiers.contains(qualifier))
-                .collect();
-            references_any(filter, &shared)
-        });
+        let filter_captured = match &join.filter {
+            Some(filter) => {
+                let shared: Vec<Vec<String>> = self
+                    .scope_qualifiers(probe_plan)?
+                    .into_iter()
+                    .filter(|qualifier| build_qualifiers.contains(qualifier))
+                    .collect();
+                references_any(filter, &shared)
+            }
+            None => false,
+        };
 
         if on_captured || filter_captured {
             return not_impl_err!(

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -2595,7 +2595,7 @@ impl Unparser<'_> {
         // Checked before any of the body is built: this refusal is about the
         // correlation's qualifiers alone, and holds whether or not a bound is
         // found below.
-        Self::ensure_exists_correlation_not_shadowed(join)?;
+        self.ensure_exists_correlation_not_shadowed(join)?;
 
         let mut query_builder = Some(QueryBuilder::default());
         let body = self.select_to_sql_expr(right_plan, &mut query_builder)?;
@@ -2723,7 +2723,7 @@ impl Unparser<'_> {
     ///
     /// The correlated predicates are emitted inside the subquery, so every
     /// reference in them binds to the innermost scope answering to its qualifier.
-    /// A reference meant for the outer query whose name the build side also
+    /// A reference meant for the outer query whose qualifier the build side also
     /// answers to therefore binds to the subquery's own relation instead: the
     /// correlation becomes a comparison of an inner row with itself, `EXISTS`
     /// degenerates to "this relation has a row", and a semi or mark join then
@@ -2731,41 +2731,38 @@ impl Unparser<'_> {
     /// SQL, so a database runs it and returns those wrong rows.
     ///
     /// SQL's scoping rules decide it on their own, so the capture does not need a
-    /// row bound to happen and is checked before one is looked for. Refusing
-    /// costs the pushdown, which is the trade [`Self::exists_scope_name`] already
-    /// makes for output that binds and runs rather than failing.
+    /// row bound to happen. Refusing costs the pushdown, which is the trade
+    /// [`Self::exists_scope_name`] already makes for output that binds and runs
+    /// rather than failing.
     ///
-    /// Two things this has to get right, both of which cost correctness in one
-    /// direction and pushdown in the other:
+    /// Two things this has to get right, each of which costs correctness one way
+    /// and pushdown the other:
     ///
-    /// * **Compare the name the SQL is spelled with, not the `TableReference`.**
-    ///   A qualified column renders as its relation's last component on the
-    ///   dialects that do not spell columns in full, so `s1.t` and `s2.t` are
-    ///   distinct references that both emit as `t` and both bind to whichever
-    ///   `t` the subquery's `FROM` introduces. Comparing the references whole
-    ///   reads them as disjoint and lets the capture through.
+    /// * **Ask how the qualifier will be spelled**, via
+    ///   [`Self::emitted_qualifier`], rather than comparing the
+    ///   [`TableReference`]. A dialect that elides the prefix emits `s1.t` and
+    ///   `s2.t` alike as `t`, so distinct references collide; a dialect that
+    ///   spells columns in full keeps them apart, and refusing there would cost
+    ///   the pushdown on SQL that binds correctly. Neither is inferable from the
+    ///   reference alone.
     /// * **Attribute each `on` pair by side.** The pairs are already split into
     ///   `(left, right)`, and only the probe half is the correlated reference; a
     ///   build half naming a build relation is an ordinary local reference that
     ///   binds inside on purpose. Testing both halves refuses every join whose
-    ///   build side shares a name with the probe, including the correct ones.
-    ///   `join.filter` carries no such split, so a reference in it cannot be
-    ///   attributed — there, only a name *both* sides answer to is refused,
-    ///   which no reference to a distinct relation can be.
+    ///   build side shares a qualifier with the probe, including the correct
+    ///   ones. `join.filter` carries no such split, so a reference in it cannot
+    ///   be attributed — there, only a qualifier *both* sides answer to is
+    ///   refused, which no reference to a distinct relation can be.
     ///
-    /// Left alone, and left to the qualifier rewrite tracked by
-    /// spiceai/spiceai#12840: an unqualified correlated reference, which names no
-    /// relation to collide with; and a shared relation whose columns one side
-    /// projects away entirely, which drops that side's name from the schema this
-    /// reads, so a filter-carried collision becomes invisible. Conversely this is
-    /// conservative under a dialect that spells columns in full, where the
-    /// distinct qualifiers would have kept the reference bound — that dialect is
-    /// already refused a scope by [`Self::exists_scope_name`] for the same
-    /// spelling reason.
-    fn ensure_exists_correlation_not_shadowed(join: &Join) -> Result<()> {
-        // Which input is correlated against, and therefore which half of each
-        // `on` pair is the correlated reference, follows the same swap the join
-        // arm applies before it builds this subquery.
+    /// Two gaps are left to the qualifier rewrite tracked by
+    /// spiceai/spiceai#12840:
+    ///
+    /// * An unqualified correlated reference, which names no relation to collide
+    ///   with, so which scope it resolves against is that rewrite's question.
+    /// * A shared relation whose columns one side projects away entirely, which
+    ///   drops that side's qualifier from the schema read here, so a
+    ///   filter-carried collision becomes invisible.
+    fn ensure_exists_correlation_not_shadowed(&self, join: &Join) -> Result<()> {
         let swapped = Self::swaps_join_inputs(join.join_type);
         let (probe_plan, build_plan) = if swapped {
             (&join.right, &join.left)
@@ -2773,41 +2770,38 @@ impl Unparser<'_> {
             (&join.left, &join.right)
         };
 
-        // The emitted name, which is what a reference in the subquery binds on.
-        let emitted_names = |plan: &LogicalPlan| -> Vec<String> {
-            let mut names: Vec<String> = Vec::new();
-            for (relation, _) in plan.schema().iter() {
-                if let Some(relation) = relation
-                    && !names.iter().any(|name| name == relation.table())
-                {
-                    names.push(relation.table().to_string());
-                }
-            }
-            names
+        // Duplicates cannot change a membership test, so these are not deduped.
+        let emitted_qualifiers = |plan: &LogicalPlan| -> Vec<Vec<String>> {
+            plan.schema()
+                .iter()
+                .filter_map(|(relation, _)| relation)
+                .map(|relation| self.emitted_qualifier(relation))
+                .collect()
         };
-        let build_names = emitted_names(build_plan);
-        let names_any = |expr: &Expr, candidates: &[String]| {
+        let references_any = |expr: &Expr, candidates: &[Vec<String>]| {
             expr.column_refs().into_iter().any(|column| {
                 column.relation.as_ref().is_some_and(|relation| {
-                    candidates.iter().any(|name| name == relation.table())
+                    candidates.contains(&self.emitted_qualifier(relation))
                 })
             })
         };
 
-        let captured = join
+        let build_qualifiers = emitted_qualifiers(build_plan);
+        let on_captured = join
             .on
             .iter()
             .map(|(left, right)| if swapped { right } else { left })
-            .any(|correlated| names_any(correlated, &build_names))
-            || join.filter.as_ref().is_some_and(|filter| {
-                let shared: Vec<String> = emitted_names(probe_plan)
-                    .into_iter()
-                    .filter(|name| build_names.contains(name))
-                    .collect();
-                names_any(filter, &shared)
-            });
+            .any(|correlated| references_any(correlated, &build_qualifiers));
+        // Computed only when there is a filter, which most joins do not have.
+        let filter_captured = join.filter.as_ref().is_some_and(|filter| {
+            let shared: Vec<Vec<String>> = emitted_qualifiers(probe_plan)
+                .into_iter()
+                .filter(|qualifier| build_qualifiers.contains(qualifier))
+                .collect();
+            references_any(filter, &shared)
+        });
 
-        if captured {
+        if on_captured || filter_captured {
             return not_impl_err!(
                 "Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
             );

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3333,10 +3333,13 @@ fn multi_relation_build_side_semi_join(fetch: Option<usize>) -> Result<LogicalPl
         .build()
 }
 
-/// Builds `LeftSemi Join: t.c = t.c` where the build side is the same relation as
-/// the probe, optionally bounded — the self-join whose correlation carries only a
-/// qualifier the probe also answers to.
-fn probe_qualified_self_join(fetch: Option<usize>) -> Result<LogicalPlan> {
+/// Builds `<join_type> Join: t.c = t.c` where the build side is the same relation
+/// as the probe, optionally bounded — the self-join whose correlation carries
+/// only a qualifier the probe also answers to.
+fn probe_qualified_self_join(
+    fetch: Option<usize>,
+    join_type: datafusion_expr::JoinType,
+) -> Result<LogicalPlan> {
     let schema = exists_fetch_schema();
     let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
     let build = table_scan_with_filter_and_fetch(
@@ -3350,10 +3353,42 @@ fn probe_qualified_self_join(fetch: Option<usize>) -> Result<LogicalPlan> {
 
     LogicalPlanBuilder::from(probe)
         .project(vec![col("t.d")])?
+        .join_on(build, join_type, vec![col("t.c").eq(col("t.c"))])?
+        .build()
+}
+
+/// Builds `LeftSemi Join: t1.c = t3.c` where the probe is `t1 INNER JOIN t` and
+/// the build side is `t INNER JOIN t3`, so the two sides share the qualifier `t`
+/// while the correlation names neither of them.
+///
+/// The shared qualifier is what makes capture *possible*; this plan separates
+/// that from a correlation actually being captured.
+fn overlapping_but_unreferenced_qualifier_semi_join() -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?
+        .join_on(
+            table_scan(Some("t"), &schema, Some(vec![0]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            vec![col("t1.c").eq(col("t.c"))],
+        )?
+        .build()?;
+    let build = table_scan(Some("t"), &schema, Some(vec![0]))?
+        .join_on(
+            table_scan(Some("t3"), &schema, Some(vec![0]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            vec![col("t.c").eq(col("t3.c"))],
+        )?
+        .build()?;
+
+    // `t.c` is kept in the projection deliberately: projecting every column of
+    // `t` away would leave the probe's schema carrying no `t` qualifier at all,
+    // and the overlap this plan exists to exercise would not be there.
+    LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d"), col("t.c")])?
         .join_on(
             build,
             datafusion_expr::JoinType::LeftSemi,
-            vec![col("t.c").eq(col("t.c"))],
+            vec![col("t1.c").eq(col("t3.c"))],
         )?
         .build()
 }
@@ -3387,24 +3422,22 @@ fn test_unparse_left_semi_join_refuses_multi_relation_build_side() -> Result<()>
     Ok(())
 }
 
-/// A correlation whose only qualifier is one the probe side also answers to
-/// cannot be scoped under an invented name: renaming the scope would rebind
-/// those references to the probe, turning the correlation into a comparison of
-/// the outer row with itself.
+/// A correlation whose only qualifier is one the probe side also answers to is
+/// captured by the subquery's own `FROM "t"`: `"t"."c" = "t"."c"` binds entirely
+/// to the inner relation, so the correlation is lost, the `EXISTS` reduces to
+/// "this table has a row", and the semi join keeps every probe row. That is
+/// valid SQL, so a database runs it and returns those wrong rows.
 ///
-/// Nor is leaving it alone a fallback. The subquery's own `FROM "t"` shadows the
-/// outer `"t"`, so `"t"."c" = "t"."c"` binds entirely to the inner relation: the
-/// correlation is lost, the `EXISTS` reduces to "this table has a row", and the
-/// semi join keeps every probe row. That is valid SQL, so it runs — both
-/// readings are wrong, which is why this is refused rather than emitted.
+/// Scoping the bound under an invented name does not repair it either — that
+/// would rebind the references to the probe, trading one wrong answer for
+/// another — so the shape is refused.
 ///
-/// The shadowing is independent of the bound and is tracked, with the rewrite
-/// that fixes it, by spiceai/spiceai#12840. This refusal only covers the bounded
-/// build side, which is where the scope is demanded; the unbounded shape is
-/// still emitted and still wrong.
+/// The bounded case is refused by the same bound-independent check as
+/// [`test_unparse_left_semi_join_without_fetch_refuses_shadowed_correlation`],
+/// which is why both report capture rather than a bound that cannot be scoped.
 #[test]
 fn test_unparse_left_semi_join_refuses_probe_qualified_correlation() -> Result<()> {
-    let plan = probe_qualified_self_join(Some(5))?;
+    let plan = probe_qualified_self_join(Some(5), datafusion_expr::JoinType::LeftSemi)?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     let err = unparser
@@ -3412,7 +3445,7 @@ fn test_unparse_left_semi_join_refuses_probe_qualified_correlation() -> Result<(
         .expect_err("a probe-qualified correlation must be refused, not shadowed");
     assert_snapshot!(
         err,
-        @"This feature is not implemented: Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation's only qualifier is one the probe side also answers to"
+        @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
     );
     Ok(())
 }
@@ -3437,21 +3470,199 @@ fn test_unparse_left_semi_join_without_fetch_keeps_multi_relation_correlation()
     Ok(())
 }
 
-/// Pins that the refusal above is gated on the bound: unbounded, the same
-/// correlation is still emitted. This output is **known-incorrect** — the inner
-/// `FROM "t"` shadows the outer `"t"`, so the correlation is lost — and it is not
-/// an endorsement. That shadowing is the pre-existing defect independent of any
-/// bound, so whoever lands the qualifier rewrite should expect this snapshot to
-/// change too.
+/// The capture does not need a bound to bite. With no bound at all the same
+/// plan used to unparse to
+/// `... WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c"))`, whose inner
+/// `FROM "t"` shadows the outer `"t"` — valid SQL that runs and answers from an
+/// inner tautology, so a semi or mark join keeps every probe row and an anti
+/// join drops every one.
+///
+/// Nothing about that depends on a row bound, so the refusal is decided by the
+/// correlation's qualifiers rather than by the bound, and the unbounded shape is
+/// refused on the same terms as the bounded one above.
+///
+/// Repairing it rather than refusing it needs the correlated qualifiers
+/// rewritten to the scope the derived table introduces, tracked by
+/// spiceai/spiceai#12840.
 #[test]
-fn test_unparse_left_semi_join_without_fetch_still_shadows_probe_qualifier() -> Result<()>
+fn test_unparse_left_semi_join_without_fetch_refuses_shadowed_correlation() -> Result<()>
 {
-    let plan = probe_qualified_self_join(None)?;
+    let plan = probe_qualified_self_join(None, datafusion_expr::JoinType::LeftSemi)?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("an unbounded shadowed correlation must be refused, not emitted");
+    assert_snapshot!(
+        err,
+        @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
+    );
+    Ok(())
+}
+
+/// The anti join's harm runs the other way and is covered by the same refusal.
+///
+/// Captured, the correlation is an inner tautology, so `NOT EXISTS` is false for
+/// every probe row and the join returns nothing — where a semi join keeps rows it
+/// should not, an anti join drops rows it should return. Both are wrong rows, so
+/// neither may be emitted.
+#[test]
+fn test_unparse_left_anti_join_without_fetch_refuses_shadowed_correlation() -> Result<()>
+{
+    let plan = probe_qualified_self_join(None, datafusion_expr::JoinType::LeftAnti)?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("an unbounded shadowed anti-join correlation must be refused");
+    assert_snapshot!(err, @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query");
+    Ok(())
+}
+
+/// The right semi join reaches the same refusal, covering the join types that
+/// swap which input is correlated against.
+///
+/// The check does not consult that swap — a shared qualifier is shared whichever
+/// side is read first — so this covers the join type rather than pinning an
+/// orientation. It is here because the swap is easy to reintroduce while
+/// reworking this code, and reaching the refusal from both orientations is what
+/// says it is not needed.
+#[test]
+fn test_unparse_right_semi_join_without_fetch_refuses_shadowed_correlation() -> Result<()>
+{
+    let plan = probe_qualified_self_join(None, datafusion_expr::JoinType::RightSemi)?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("a swapped shadowed correlation must be refused too");
+    assert_snapshot!(err, @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query");
+    Ok(())
+}
+
+/// Two relations in different schemas that share a table name collide in the
+/// emitted SQL even though their `TableReference`s differ.
+///
+/// On a dialect that does not spell columns in full, a qualified column renders
+/// as its relation's last component, so both `s1.t.c` and `s2.t.c` emit as
+/// `"t"."c"` — and inside `FROM "s2"."t"` both bind to the inner relation, which
+/// is the same tautology as the bare self-join. Comparing the references whole
+/// would read these as disjoint and let it through; before this was caught, the
+/// plan unparsed to
+/// `SELECT "d" FROM "public"."t" WHERE EXISTS (SELECT 1 FROM "other"."t" WHERE ("t"."c" = "t"."c"))`.
+#[test]
+fn test_unparse_left_semi_join_refuses_cross_schema_name_collision() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("public.t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("other.t"), &schema, Some(vec![0]))?.build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("public.t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("public.t.c").eq(col("other.t.c"))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("relations sharing an emitted name must be refused");
+    assert_snapshot!(err, @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query");
+    Ok(())
+}
+
+/// A build-side join key naming the shared relation is not a capture, and must
+/// keep its pushdown.
+///
+/// The probe is `t1 INNER JOIN t` and the build side is `t`, so the two share the
+/// name `t`, but the key is `(t1.c, t.c)`: only `t1.c` is correlated, and the
+/// build half `t.c` is meant to bind to the subquery's own `t` — which is exactly
+/// what it does. Refusing here would cost the pushdown on correct SQL, and
+/// testing both halves of each pair rather than the correlated one does refuse
+/// it, which is what this pins.
+#[test]
+fn test_unparse_left_semi_join_keeps_build_side_key_on_shared_relation() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?
+        .join_on(
+            table_scan(Some("t"), &schema, Some(vec![0]))?.build()?,
+            datafusion_expr::JoinType::Inner,
+            vec![col("t1.d").eq(col("t.c"))],
+        )?
+        .build()?;
+    let build = table_scan(Some("t"), &schema, Some(vec![0]))?.build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d"), col("t.c")])?
+        .join(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            (vec!["t1.c"], vec!["t.c"]),
+            None,
+        )?
+        .build()?;
 
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     assert_snapshot!(
         unparser.plan_to_sql(&plan)?,
-        @r#"SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c"))"#
+        @r#"SELECT "t1"."d", "t"."c" FROM "t1" INNER JOIN "t" ON ("t1"."d" = "t"."c") WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t1"."c" = "t"."c"))"#
+    );
+    Ok(())
+}
+
+/// The same capture through `join.on` rather than `join.filter`.
+///
+/// A shared-qualifier equality cannot be attributed to two sides, so
+/// [`LogicalPlanBuilder::join_on`] puts it in the filter and the other refusals
+/// here reach it there. Naming the join keys directly puts the identical
+/// predicate in `on` instead, which is a plan the unparser can be handed even
+/// though the higher-level builder will not produce it — and the emitted SQL,
+/// and so the capture, is the same either way.
+#[test]
+fn test_unparse_left_semi_join_refuses_shadowed_correlation_in_join_keys() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t"), &schema, Some(vec![0]))?.build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            (vec!["t.c"], vec!["t.c"]),
+            None,
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    let err = unparser
+        .plan_to_sql(&plan)
+        .expect_err("a shadowed correlation in the join keys must be refused too");
+    assert_snapshot!(
+        err,
+        @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
+    );
+    Ok(())
+}
+
+/// Sharing a qualifier is not on its own a reason to refuse. Both sides here
+/// answer to `t`, but the correlated half of the `on` pair names `t1`, which the
+/// build side does not answer to, so nothing is captured and the plan unparses.
+///
+/// This is the boundary the refusal is drawn on: the correlated reference's own
+/// qualifier, not an overlap between the two sides' relations. Refusing on
+/// overlap alone would cost the pushdown on federated self-joins that unparse
+/// correctly today — the same trade
+/// [`test_unparse_left_semi_join_without_fetch_keeps_multi_relation_correlation`]
+/// guards from the other direction.
+#[test]
+fn test_unparse_left_semi_join_keeps_overlapping_but_unreferenced_qualifier() -> Result<()>
+{
+    let plan = overlapping_but_unreferenced_qualifier_semi_join()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t1"."d", "t"."c" FROM "t1" INNER JOIN "t" ON ("t1"."c" = "t"."c") WHERE EXISTS (SELECT 1 FROM "t" INNER JOIN "t3" ON ("t"."c" = "t3"."c") WHERE ("t1"."c" = "t3"."c"))"#
     );
     Ok(())
 }

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3546,6 +3546,110 @@ fn test_unparse_right_semi_join_without_fetch_refuses_shadowed_correlation() -> 
     Ok(())
 }
 
+/// A relation the build side renames is not in the emitted scope under its own
+/// name, so a correlation naming it is not captured and must keep its pushdown.
+///
+/// The build side scans `t` — the probe's own relation — but emits it as
+/// `FROM "t" AS "derived"`. An alias *replaces* the name it is given to, so `"t"`
+/// is not addressable inside the subquery and `"t"."c" > 0` binds outward,
+/// exactly as intended.
+///
+/// This is why the scope walk stops at a `SubqueryAlias` rather than descending:
+/// collecting the renamed `t` would read this as a collision and refuse working
+/// SQL.
+#[test]
+fn test_unparse_left_semi_join_keeps_relation_enclosed_by_build_side_alias() -> Result<()>
+{
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t"), &schema, Some(vec![0]))?
+        .alias("derived")?
+        .build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t.c").gt(lit(0))],
+        )?
+        .build()?;
+
+    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan)?,
+        @r#"SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" AS "derived" WHERE ("t"."c" > 0))"#
+    );
+    Ok(())
+}
+
+/// A build side aliased to the probe's own name captures through the alias.
+///
+/// The enclosed relation is `t2`, which shares nothing with the probe — what
+/// collides is the alias the derived table is given. `EXISTS (SELECT 1 FROM
+/// (...) AS "t" WHERE ...)` puts `"t"` in the inner scope, so a correlated
+/// reference qualified by `t` binds there.
+///
+/// This is the half of the scope the `FROM` walk cannot see: it stops at the
+/// alias, so the alias has to come from the output schema, which is what carries
+/// it.
+#[test]
+fn test_unparse_left_semi_join_refuses_capture_by_build_side_alias() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
+        .alias("t")?
+        .build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t.c").gt(lit(0))],
+        )?
+        .build()?;
+
+    assert_captured_correlation_refused(
+        &plan,
+        "a build side aliased to the probe's name must be seen to capture",
+    );
+    Ok(())
+}
+
+/// A build side that projects away every column still names its relation in the
+/// emitted `FROM`, so it still captures.
+///
+/// `TableScan t` with `projection=[]` has no qualified output field at all, so
+/// reading the scope off the output schema reports it as sharing nothing. The SQL
+/// says otherwise: `FROM "t"` is emitted, and a probe-only filter `"t"."c" > 0`
+/// binds to that inner `t`. The `EXISTS` then asks whether *any* inner row is
+/// positive rather than testing each probe row — one answer for the whole join,
+/// so a semi join keeps every probe row or none.
+///
+/// Before the scope was read from the relations the `FROM` introduces, this
+/// unparsed to
+/// `SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" > 0))`.
+#[test]
+fn test_unparse_left_semi_join_refuses_capture_by_unprojected_build_relation()
+-> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t"), &schema, Some(vec![]))?.build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t.c").gt(lit(0))],
+        )?
+        .build()?;
+
+    assert_captured_correlation_refused(
+        &plan,
+        "a build relation with no projected columns must still be seen to capture",
+    );
+    Ok(())
+}
+
 /// A dialect that spells columns in full keeps those two relations apart, so
 /// there is no capture and the pushdown must survive.
 ///

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3546,6 +3546,97 @@ fn test_unparse_right_semi_join_without_fetch_refuses_shadowed_correlation() -> 
     Ok(())
 }
 
+/// Builds `LeftSemi Join` correlating `<probe>.c > 0` against a build side aliased
+/// `s.a`, which the unparser emits as the single identifier `AS "a"`.
+fn qualified_alias_build_side_semi_join(probe_name: &str) -> Result<LogicalPlan> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some(probe_name), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?
+        .alias("s.a")?
+        .build()?;
+
+    LogicalPlanBuilder::from(probe)
+        .project(vec![col(format!("{probe_name}.d"))])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col(format!("{probe_name}.c")).gt(lit(0))],
+        )?
+        .build()
+}
+
+/// A derived table's alias is a single identifier however the dialect spells
+/// columns, so a *qualified* alias captures under only its last component.
+///
+/// The build side is aliased `s.a` and emitted `AS "a"`, so an outer relation
+/// named `a` is shadowed. Keying the alias off the output schema — which carries
+/// the whole `s.a` reference — misses this, because on a fully-qualifying dialect
+/// it looks for `s.a` while the SQL only ever says `a`.
+#[test]
+fn test_unparse_left_semi_join_refuses_capture_by_qualified_alias_last_component()
+-> Result<()> {
+    let plan = qualified_alias_build_side_semi_join("a")?;
+
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .build();
+    let err = Unparser::new(&dialect)
+        .plan_to_sql(&plan)
+        .expect_err("an alias emitted as `AS a` must be seen to shadow the outer `a`");
+    assert_eq!(err.to_string(), CAPTURED_CORRELATION_REFUSAL);
+    Ok(())
+}
+
+/// The other direction: `AS "a"` does not shadow an outer `s.a`, so that keeps its
+/// pushdown.
+///
+/// `s.a.c` names schema `s`, table `a`; the alias is an unqualified `a` and does
+/// not answer to it, so the reference binds outward. Keying the alias off the
+/// schema would have matched `s.a` here and refused correct SQL — the same
+/// mismatch as the test above, costing pushdown instead of correctness.
+#[test]
+fn test_unparse_left_semi_join_keeps_qualified_reference_past_bare_alias() -> Result<()> {
+    let plan = qualified_alias_build_side_semi_join("s.a")?;
+
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .build();
+    assert_snapshot!(
+        Unparser::new(&dialect).plan_to_sql(&plan)?,
+        @"SELECT s.a.d FROM s.a WHERE EXISTS (SELECT 1 FROM t2 AS a WHERE (s.a.c > 0))"
+    );
+    Ok(())
+}
+
+/// An alias the unparser invents for a derived table is in the emitted scope even
+/// though it appears nowhere in the plan.
+///
+/// A relation a user named `derived_limit` cannot be distinguished from the alias
+/// `exists_scope_name` hands a bounded build side, so a correlation naming it is
+/// refused rather than risk the invented alias capturing it. Refusing costs the
+/// pushdown on a pathological table name; emitting risks wrong rows.
+#[test]
+fn test_unparse_left_semi_join_refuses_correlation_naming_an_invented_alias() -> Result<()>
+{
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("derived_limit"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("t2"), &schema, Some(vec![0]))?.build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("derived_limit.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("derived_limit.c").gt(lit(0))],
+        )?
+        .build()?;
+
+    assert_captured_correlation_refused(
+        &plan,
+        "a correlation naming an alias the unparser can invent must be refused",
+    );
+    Ok(())
+}
+
 /// A relation the build side renames is not in the emitted scope under its own
 /// name, so a correlation naming it is not captured and must keep its pushdown.
 ///

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -3439,13 +3439,9 @@ fn test_unparse_left_semi_join_refuses_multi_relation_build_side() -> Result<()>
 fn test_unparse_left_semi_join_refuses_probe_qualified_correlation() -> Result<()> {
     let plan = probe_qualified_self_join(Some(5), datafusion_expr::JoinType::LeftSemi)?;
 
-    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
-    let err = unparser
-        .plan_to_sql(&plan)
-        .expect_err("a probe-qualified correlation must be refused, not shadowed");
-    assert_snapshot!(
-        err,
-        @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
+    assert_captured_correlation_refused(
+        &plan,
+        "a probe-qualified correlation must be refused, not shadowed",
     );
     Ok(())
 }
@@ -3470,6 +3466,22 @@ fn test_unparse_left_semi_join_without_fetch_keeps_multi_relation_correlation()
     Ok(())
 }
 
+/// The refusal every captured-correlation shape must produce, spelled once.
+///
+/// Asserted rather than snapshotted: an inline snapshot is keyed by the location
+/// of its macro, so one shared by several tests collides between them. Every
+/// caller has to produce this identical string, which is what makes sharing it
+/// the point — a reword stays a one-place edit.
+const CAPTURED_CORRELATION_REFUSAL: &str = "This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query";
+
+#[track_caller]
+fn assert_captured_correlation_refused(plan: &LogicalPlan, context: &str) {
+    let err = Unparser::new(&UnparserPostgreSqlDialect {})
+        .plan_to_sql(plan)
+        .expect_err(context);
+    assert_eq!(err.to_string(), CAPTURED_CORRELATION_REFUSAL);
+}
+
 /// The capture does not need a bound to bite. With no bound at all the same
 /// plan used to unparse to
 /// `... WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c"))`, whose inner
@@ -3489,13 +3501,9 @@ fn test_unparse_left_semi_join_without_fetch_refuses_shadowed_correlation() -> R
 {
     let plan = probe_qualified_self_join(None, datafusion_expr::JoinType::LeftSemi)?;
 
-    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
-    let err = unparser
-        .plan_to_sql(&plan)
-        .expect_err("an unbounded shadowed correlation must be refused, not emitted");
-    assert_snapshot!(
-        err,
-        @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
+    assert_captured_correlation_refused(
+        &plan,
+        "an unbounded shadowed correlation must be refused, not emitted",
     );
     Ok(())
 }
@@ -3511,11 +3519,10 @@ fn test_unparse_left_anti_join_without_fetch_refuses_shadowed_correlation() -> R
 {
     let plan = probe_qualified_self_join(None, datafusion_expr::JoinType::LeftAnti)?;
 
-    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
-    let err = unparser
-        .plan_to_sql(&plan)
-        .expect_err("an unbounded shadowed anti-join correlation must be refused");
-    assert_snapshot!(err, @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query");
+    assert_captured_correlation_refused(
+        &plan,
+        "an unbounded shadowed anti-join correlation must be refused",
+    );
     Ok(())
 }
 
@@ -3532,11 +3539,88 @@ fn test_unparse_right_semi_join_without_fetch_refuses_shadowed_correlation() -> 
 {
     let plan = probe_qualified_self_join(None, datafusion_expr::JoinType::RightSemi)?;
 
+    assert_captured_correlation_refused(
+        &plan,
+        "a swapped shadowed correlation must be refused too",
+    );
+    Ok(())
+}
+
+/// A dialect that spells columns in full keeps those two relations apart, so
+/// there is no capture and the pushdown must survive.
+///
+/// This is the other half of the finding above: keying the refusal on the bare
+/// table name unconditionally refuses this plan, whose SQL binds correctly —
+/// `public.t.c` names the outer relation and nothing shadows it. The refusal has
+/// to ask the dialect how the qualifier will be spelled, which is why it goes
+/// through `emitted_qualifier` rather than reading the `TableReference`.
+///
+/// The bound is absent deliberately: `exists_scope_name` is consulted only when
+/// one is present, so nothing else in this file would refuse this shape, and a
+/// guard keyed on the bare name would be the only thing standing between a
+/// working pushdown and a query failure.
+#[test]
+fn test_unparse_left_semi_join_keeps_cross_schema_on_full_column_dialect() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("public.t"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan(Some("other.t"), &schema, Some(vec![0]))?.build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("public.t.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("public.t.c").eq(col("other.t.c"))],
+        )?
+        .build()?;
+
+    let dialect = CustomDialectBuilder::default()
+        .with_full_qualified_col(true)
+        .build();
+    assert_snapshot!(
+        Unparser::new(&dialect).plan_to_sql(&plan)?,
+        @"SELECT public.t.d FROM public.t WHERE EXISTS (SELECT 1 FROM other.t WHERE (public.t.c = other.t.c))"
+    );
+    Ok(())
+}
+
+/// `exists_scope_name`'s probe-qualified arm still has a shape that reaches it,
+/// and this pins that it does.
+///
+/// The correlation is carried entirely by a filter naming only probe relations,
+/// and the two sides share no qualifier — so the capture guard returns without
+/// refusing, and the bound then demands a scope name that has no build-side
+/// relation to take. Without this, that arm has no coverage: the test that used
+/// to reach it now stops at the capture guard instead, which is a refusal moving
+/// rather than a shape disappearing.
+#[test]
+fn test_unparse_left_semi_join_refuses_probe_only_filter_with_bound() -> Result<()> {
+    let schema = exists_fetch_schema();
+    let probe = table_scan(Some("t1"), &schema, Some(vec![0, 1]))?.build()?;
+    let build = table_scan_with_filter_and_fetch(
+        Some("t2"),
+        &schema,
+        Some(vec![0]),
+        vec![],
+        Some(5),
+    )?
+    .build()?;
+    let plan = LogicalPlanBuilder::from(probe)
+        .project(vec![col("t1.d")])?
+        .join_on(
+            build,
+            datafusion_expr::JoinType::LeftSemi,
+            vec![col("t1.c").gt(col("t1.d"))],
+        )?
+        .build()?;
+
     let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
     let err = unparser
         .plan_to_sql(&plan)
-        .expect_err("a swapped shadowed correlation must be refused too");
-    assert_snapshot!(err, @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query");
+        .expect_err("a bound with no build-side qualifier to scope must be refused");
+    assert_snapshot!(
+        err,
+        @"This feature is not implemented: Unparsing a row bound on an EXISTS-style join's build side is not supported when the correlation's only qualifier is one the probe side also answers to"
+    );
     Ok(())
 }
 
@@ -3544,8 +3628,8 @@ fn test_unparse_right_semi_join_without_fetch_refuses_shadowed_correlation() -> 
 /// emitted SQL even though their `TableReference`s differ.
 ///
 /// On a dialect that does not spell columns in full, a qualified column renders
-/// as its relation's last component, so both `s1.t.c` and `s2.t.c` emit as
-/// `"t"."c"` — and inside `FROM "s2"."t"` both bind to the inner relation, which
+/// as its relation's last component, so both `public.t.c` and `other.t.c` emit as
+/// `"t"."c"` — and inside `FROM "other"."t"` both bind to the inner relation, which
 /// is the same tautology as the bare self-join. Comparing the references whole
 /// would read these as disjoint and let it through; before this was caught, the
 /// plan unparsed to
@@ -3564,11 +3648,10 @@ fn test_unparse_left_semi_join_refuses_cross_schema_name_collision() -> Result<(
         )?
         .build()?;
 
-    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
-    let err = unparser
-        .plan_to_sql(&plan)
-        .expect_err("relations sharing an emitted name must be refused");
-    assert_snapshot!(err, @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query");
+    assert_captured_correlation_refused(
+        &plan,
+        "relations sharing an emitted name must be refused",
+    );
     Ok(())
 }
 
@@ -3633,13 +3716,9 @@ fn test_unparse_left_semi_join_refuses_shadowed_correlation_in_join_keys() -> Re
         )?
         .build()?;
 
-    let unparser = Unparser::new(&UnparserPostgreSqlDialect {});
-    let err = unparser
-        .plan_to_sql(&plan)
-        .expect_err("a shadowed correlation in the join keys must be refused too");
-    assert_snapshot!(
-        err,
-        @"This feature is not implemented: Unparsing an EXISTS-style join is not supported when the correlation is qualified by a relation the build side also answers to: the subquery's own FROM would capture that reference instead of the outer query"
+    assert_captured_correlation_refused(
+        &plan,
+        "a shadowed correlation in the join keys must be refused too",
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

A semi/anti/mark join whose two sides emit the same relation qualifier unparsed to a correlated predicate that binds *inside* the `EXISTS` body instead of to the outer query:

```sql
SELECT "t"."d" FROM "t" WHERE EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" = "t"."c"))
```

The inner `FROM "t"` shadows the outer `"t"`, so the predicate is an inner tautology. `EXISTS` degenerates to "this relation has a row", and for a nonempty relation a semi or mark join keeps **every** probe row while an anti join drops **every** one. That is valid SQL, so the remote engine runs it and answers from the wrong rows.

spiceai/datafusion#205 refused this shape, but only when the build side carried a row bound, because the refusal lived in `exists_scope_name` — which the caller consults only when a bound has to be moved. The capture is decided by SQL's name scoping and never needed a bound, so the unbounded plan kept emitting the SQL above. #205's own suite recorded that: `test_unparse_left_semi_join_without_fetch_still_shadows_probe_qualifier` snapshotted the wrong SQL under a doc comment calling it "known-incorrect" and "not an endorsement".

This moves the decision to the correlation's qualifiers, checked before a bound is looked for, so the bounded and unbounded shapes are refused on the same terms.

### It is a query failure, not a fallback

Worth stating plainly, because "costs the pushdown" understates it. `datafusion-federation` wraps a plan in `FederatedPlanNode` **before** attempting to unparse it (`SQLFederationAnalyzerRule::analyze`), then propagates this error out of `VirtualExecutionPlan::final_sql()` at `execute()`. So an affected query now fails with `not_impl_err` rather than falling back to local execution. A structured error in place of silently wrong rows is the intended trade, but it is a failure, not a graceful degrade.

### Scope — this refuses, it does not repair

Emitting these shapes *correctly* needs the correlated qualifiers rewritten to the scope a derived table introduces, with generated aliases where inner names collide. That is the pass spiceai/spiceai#12840 tracks and #205 declined for stated reasons (interaction with `DISTINCT` and with an `ORDER BY` inside a bound, either of which changes which rows survive). This does not attempt it, so that issue stays open.

One pointer for whoever does: `requalify_column_onto_derived_table` (`unparser/rewrite.rs:603`) already re-points a qualifier onto a derived table's alias, and its doc states the obstacle from the other side — *"neither distinguishes a correlated reference to an enclosing query — that qualifier can name the very same relation. A caller must not offer one"*. So the rewrite is an extension of that machinery to the case it currently refuses to be handed, not a greenfield pass.

## Changes

- `datafusion/sql/src/unparser/expr.rs` — `emitted_qualifier` extracted from `col_to_sql`'s qualifier branch and called by it, so there is one answer to "what components will this qualifier be spelled with".
- `datafusion/sql/src/unparser/plan.rs` — new `ensure_exists_correlation_not_shadowed`, called at the top of `build_exists_subquery` before the body is built. Two things it has to get right, each costing correctness one way and pushdown the other:
  - **It asks the dialect how the qualifier will be spelled** rather than comparing the `TableReference`. A dialect that elides the prefix emits `s1.t` and `s2.t` alike as `t`, so distinct references collide and the capture happens; a dialect with `full_qualified_col()` keeps them apart, and refusing there would cost the pushdown on SQL that binds correctly. Neither is inferable from the reference — and `TableReference::resolved_eq` is the wrong tool, since it compares schemas when both sides carry one and so reports exactly this collision as *unequal*.
  - **It attributes each `on` pair by side.** Only the probe half is the correlated reference; a build half naming a build relation binds inside on purpose. Testing both halves refuses every join whose build side shares a qualifier with its probe, including correct ones. `join.filter` carries no such split, so there only a qualifier *both* sides answer to is refused — which no reference to a distinct relation can be.
- The pre-existing `[]` arm of `exists_scope_name` keeps its refusal, with its comment corrected: the self-join it described is refused upstream of it now, bound or not, and what reaches it is the residue (a correlation qualified only by a probe relation the build side does not share).
- `datafusion/sql/tests/cases/plan_to_sql.rs` — the snapshot of the known-incorrect unbounded SQL becomes a refusal assertion. Added: the anti-join direction, the `RightSemi` orientation, the capture arriving through `on` rather than `filter`, the cross-schema collision, **both** answers to the dialect question, and three cases that must **keep** their pushdown (a shared qualifier nothing references, a build-side join key on the shared relation, and the cross-schema plan under a fully-qualifying dialect). `probe_qualified_self_join` is parameterized over join type so those arms differ only in that, and the shared refusal message is asserted through one helper so a reword is a one-place edit.

## Test plan

- `cargo test -p datafusion-sql --test sql_integration` — 562 pass. **22 fail identically on the unmodified base** (`upstream/spiceai-54` @ `8e881090e`) and with this change; the failing sets were diffed with `comm` rather than compared by count, and are identical. Pre-existing branch breakage tracked by spiceai/spiceai#13134 — this repo runs no Rust CI, which is how it landed.
- `cargo clippy -p datafusion-sql --all-targets` — no new warnings. The ones it reports (`plan.rs:243`, `plan.rs:1123`, `rewrite.rs:630`, `utils.rs:432/622/634`) are all outside this diff and present on the base.
- `cargo fmt -p datafusion-sql`.
- **Neuter matrix — 18 neuters against the whole suite, every one caught, none vacuous.** Each keeps the real error message, so a failure is behavioural rather than text-matching:

  | Neuter | Fails |
  |---|---|
  | drop the check | all 8 refusal tests |
  | gate it on a bound (the pre-fix reach) | all 8 refusal tests |
  | key both sides on the bare table name | the fully-qualifying-dialect test |
  | key both sides on the full path | the cross-schema refusal |
  | `col_to_sql` stops using `emitted_qualifier` (drift) | 4 tests, 2 of them pre-existing |
  | test both halves of each `on` pair | build-side-key test + ordinary right semi/anti |
  | ignore the `RightSemi` swap | ordinary right semi/anti |
  | skip the `on` arm | the join-keys test only |
  | skip the filter arm | the filter-route refusals, not the join-keys one |
  | filter: drop the both-sides restriction | 17 tests — broad over-refusal |
  | drop the schema half of the scope | the build-side-alias refusal |
  | drop the `FROM` walk | the unprojected-build-relation refusal |
  | descend past a `SubqueryAlias` | the enclosed-relation pushdown test |
  | key a `SubqueryAlias` off the schema qualifier | both qualified-alias tests |
  | drop the invented-alias reservations | the invented-alias refusal |
  | drop the `TableScan` arm | 9 refusal tests |

  The `TableScan` row is large because the walk is now the whole scope, for the probe side as well as the build side. The `col_to_sql` row is why `emitted_qualifier` is *called* by the emitter rather than copied from it: the extraction is pinned faithful by tests that predate this diff. The last three are why the scope is a union — each half carries a case the other loses, and the alias boundary is what keeps a legitimate rename pushed down.

- **Five claims did not survive their own neuter and were corrected rather than kept.** The matrix is what caught them:
  - a `RightSemi` test whose doc claimed to pin the input swap — it cannot, since a self-join answers to the same name either orientation; the ordinary right semi/anti tests are what pin it, by over-refusing.
  - an "overlapping qualifier" test whose probe projected the shared relation away entirely, so it had no overlap left to exercise.
  - an `on`-pair arm no test could reach, because a shared-qualifier equality is unsplittable and `join_on` routes it to `join.filter`; naming the join keys directly is what reaches it.
  - a `SubqueryAlias` arm that pushed the alias the output schema already carried — dropped as redundant, keeping only the boundary stop.
  - a predicted snapshot for an aliased build side that assumed a derived table; it renders as `FROM "t" AS "derived"`. The claim survived (an alias replaces the name, so the reference still binds outward) but the expected SQL was wrong and was corrected to what is emitted.

## Review gate

- Adversarial review: `codex` — job `review-mt09k4js-3lbiem` (base `upstream/spiceai-54`, head `e3a7cd9d9`, `exit=0`, `verdict=needs-attention`). A first pass ran on the original diff as job `review-mt08tia7-7krp6b` (head `fba0c5b50`, `exit=0`, `verdict=needs-attention`).
  - *[high, first pass]* comparing whole `TableReference`s let `s1.t`/`s2.t` read as disjoint although both emit as `"t"."c"`. **Valid — fixed**, and confirmed by probe before the fix: the plan emitted `SELECT "d" FROM "public"."t" WHERE EXISTS (SELECT 1 FROM "other"."t" WHERE ("t"."c" = "t"."c"))`.
  - *[medium, first pass]* testing both halves of each `on` pair rejected valid joins whose build-side key names the shared relation. **Valid — fixed** by attributing pairs by side, with a test that must keep its pushdown.
  - *[high, second pass]* a build relation whose columns are all projected away is still in the emitted `FROM`, so the schema-derived scope missed it. **Valid — fixed**; reproduced first (`... EXISTS (SELECT 1 FROM "t" WHERE ("t"."c" > 0))`, correlating nothing), then closed by reading the scope from the `FROM`. This was a gap the previous revision *documented* rather than closed, which was the wrong call for a wrong-rows guard.
- `/security-review`: **not run — declared skip.** The harness collects its diff from the session's working directory, which is a different repository than this fork, so it reports an empty diff and would mint a vacuous pass. Hand-audited instead: no new input path, sink, deserialization, route, or authz surface; the one new message is a static literal interpolating no identifier, so no schema detail reaches a client-visible error; no `unwrap`/`expect`/indexing/arithmetic added in `src/` (0 by grep), so no new panic path. The behavioural risk is availability, not disclosure — a refusal turns a wrong-rows query into a failing one, which is stated above and is the intended trade.
- `/simplify`: 4 agents (reuse, simplification, efficiency, altitude). **Applied**: the dialect-aware key and the `col_to_sql` extraction (altitude — this was a shipped pushdown regression *and* a doc comment whose stated justification was false); a test for `exists_scope_name`'s residue arm, which lost its only coverage when the capture guard took over its previous test; the shared refusal-message helper; dropping a redundant dedup; deleting a comment that restated `swaps_join_inputs`'s own doc; and aligning a doc's example names with its test's.
  - **Skipped**: a cross-file `relation_qualifiers` helper in `utils.rs` for three sites whose collection steps differ (reuse) — the concept was already unified where it matters, in `emitted_qualifier`. An `exists_sides` helper (both reuse and altitude called it optional). `Vec<&str>` in place of `Vec<String>` (efficiency verified it compiles, then measured it a wash) — superseded anyway, since the dialect-aware key is an owned `Vec<String>`. A `HashSet` container: efficiency showed the dedup loop is O(columns × relations), not quadratic, so a set would be a pessimization at this relation count; both it and simplification recommended against.
  - **Two agents reported a concurrent session editing this worktree with `zzprobe_*` scaffolding. That was false** — `git status` clean, `wc -l` unchanged, `grep -c 'zz_probe|eprintln!'` = 0. They were running against the same worktree and misread each other's transient experiments. Recorded because an unchallenged "another session is live here" would have stopped this pass.
- Copilot review: **one active comment, plus one it suppressed — both valid, both fixed** in `e7466c7`, and both about the same mistake: reading the emitted scope off the output schema.
  - *[active]* a `SubqueryAlias`'s alias is a whole `TableReference` on the schema, but only `alias.table()` is emitted (`plan.rs:1650`), dialect-independently. So keying it off the schema missed an outer `a.c` that `AS "a"` does capture and refused an outer `s.a.c` that it does not. **Fixed** by dropping the schema from the computation entirely — it was a wrong proxy for the `FROM` in both covered cases — and keying an alias on its last component. Both directions have tests on a fully-qualifying dialect, where the two keys differ.
  - *[suppressed]* aliases the unparser *invents* (`derived_limit` and seven siblings) reach the emitted `FROM` without appearing in the plan, so no walk can find them. **Fixed** by reserving those eight names inside an `EXISTS` body. Suppressed by Copilot, but constructible, and a constructible bypass of a wrong-rows guard is the bug rather than a caveat.
  - Not taken: deriving the scope from the emitted AST after `select_to_sql_expr`. More faithful, but the guard runs before the body is built so a refusal does not pay to unparse it, and reserving eight known constants closes the same gap. Noted on spiceai/spiceai#12840, where the rewrite stops inferring the scope at all.
- Merging the guard into `exists_scope_name` was considered and rejected: they read opposite halves of each `on` pair and answer different questions (is this emittable at all, versus what may the alias be called), and only the second needs a bound.

Relates to spiceai/spiceai#12840 — this refuses these shapes rather than repairing them, so that issue stays open for the qualifier rewrite.
Relates to spiceai/spiceai#13134 — the pre-existing test failures noted in the test plan.
Relates to spiceai/spiceai#13277 — the pin bump that carries spiceai/datafusion#205; this needs a further bump to reach the runtime.